### PR TITLE
feat-lobbies

### DIFF
--- a/game-service-model/src/main/scala/com/andy327/model/core/GameType.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/core/GameType.scala
@@ -1,6 +1,12 @@
 package com.andy327.model.core
 
-sealed trait GameType
+sealed trait GameType {
+  def minPlayers: Int
+  def maxPlayers: Int
+}
+
 object GameType {
-  case object TicTacToe extends GameType
+  case object TicTacToe extends GameType {
+    val (minPlayers, maxPlayers) = (2, 2)
+  }
 }

--- a/game-service-model/src/main/scala/com/andy327/model/core/package.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/core/package.scala
@@ -1,0 +1,7 @@
+package com.andy327.model
+
+import java.util.UUID
+
+package object core {
+  type PlayerId = UUID
+}

--- a/game-service-model/src/main/scala/com/andy327/model/tictactoe/GameError.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/tictactoe/GameError.scala
@@ -1,11 +1,13 @@
 package com.andy327.model.tictactoe
 
+import com.andy327.model.core.PlayerId
+
 sealed trait GameError {
   def message: String
 }
 object GameError {
-  case class InvalidPlayer(player: String) extends GameError {
-    val message: String = s"Unknown player: $player"
+  case class InvalidPlayer(playerId: PlayerId) extends GameError {
+    val message: String = s"Unknown player: $playerId"
   }
   case object InvalidTurn extends GameError {
     val message = "It's not your turn."

--- a/game-service-model/src/main/scala/com/andy327/model/tictactoe/TicTacToe.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/tictactoe/TicTacToe.scala
@@ -1,11 +1,11 @@
 package com.andy327.model.tictactoe
 
-import com.andy327.model.core.{Game, Renderable}
+import com.andy327.model.core.{Game, PlayerId, Renderable}
 
 import GameError._
 
 object TicTacToe {
-  def empty(playerX: String, playerO: String): TicTacToe = TicTacToe(
+  def empty(playerX: PlayerId, playerO: PlayerId): TicTacToe = TicTacToe(
     playerX = playerX,
     playerO = playerO,
     board = Vector.fill(3, 3)(Option.empty[Mark]),
@@ -30,8 +30,8 @@ object TicTacToe {
 }
 
 final case class TicTacToe(
-    playerX: String,
-    playerO: String,
+    playerX: PlayerId,
+    playerO: PlayerId,
     board: Board,
     currentPlayer: Mark,
     winner: Option[Mark],

--- a/game-service-model/src/test/scala/com/andy327/model/tictactoe/TicTacToeSpec.scala
+++ b/game-service-model/src/test/scala/com/andy327/model/tictactoe/TicTacToeSpec.scala
@@ -1,19 +1,26 @@
 package com.andy327.model.tictactoe
 
+import java.util.UUID
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import com.andy327.model.core.PlayerId
+
 class TicTacToeSpec extends AnyWordSpec with Matchers {
+  val alice: PlayerId = UUID.randomUUID()
+  val bob: PlayerId = UUID.randomUUID()
+
   "A TicTacToe game" should {
     "start with an empty board" in {
-      val game = TicTacToe.empty("alice", "bob")
+      val game = TicTacToe.empty(alice, bob)
       game.board.flatten.flatten shouldBe empty
       game.currentPlayer shouldBe X
       game.gameStatus shouldBe InProgress
     }
 
     "allow a player to make a move" in {
-      val game = TicTacToe.empty("alice", "bob")
+      val game = TicTacToe.empty(alice, bob)
       val result = game.play(X, Location(0, 0))
       result.isRight shouldBe true
       val newState = result.toOption.get
@@ -23,25 +30,25 @@ class TicTacToeSpec extends AnyWordSpec with Matchers {
     }
 
     "not allow the wrong player to make a move" in {
-      val game = TicTacToe.empty("alice", "bob").play(X, Location(0, 0)).toOption.get
+      val game = TicTacToe.empty(alice, bob).play(X, Location(0, 0)).toOption.get
       val result = game.play(X, Location(0, 1))
       result shouldBe Left(GameError.InvalidTurn)
     }
 
     "not allow a move on an occupied space" in {
-      val game = TicTacToe.empty("alice", "bob").play(X, Location(0, 0)).toOption.get
+      val game = TicTacToe.empty(alice, bob).play(X, Location(0, 0)).toOption.get
       val result = game.play(O, Location(0, 0))
       result shouldBe Left(GameError.CellOccupied)
     }
 
     "not allow a move on an invalid cell" in {
-      val game = TicTacToe.empty("alice", "bob")
+      val game = TicTacToe.empty(alice, bob)
       val result = game.play(X, Location(0, 4))
       result shouldBe Left(GameError.OutOfBounds)
     }
 
     "detect a winning condition" in {
-      val game = TicTacToe.empty("alice", "bob")
+      val game = TicTacToe.empty(alice, bob)
         .play(X, Location(0, 0)).toOption.get
         .play(O, Location(1, 0)).toOption.get
         .play(X, Location(0, 1)).toOption.get
@@ -52,7 +59,7 @@ class TicTacToeSpec extends AnyWordSpec with Matchers {
     }
 
     "detect a draw" in {
-      val game = TicTacToe.empty("alice", "bob")
+      val game = TicTacToe.empty(alice, bob)
         .play(X, Location(1, 1)).toOption.get
         .play(O, Location(0, 0)).toOption.get
         .play(X, Location(1, 0)).toOption.get
@@ -67,7 +74,7 @@ class TicTacToeSpec extends AnyWordSpec with Matchers {
     }
 
     "not allow a move after the game is won" in {
-      val game = TicTacToe.empty("alice", "bob")
+      val game = TicTacToe.empty(alice, bob)
         .play(X, Location(0, 0)).toOption.get
         .play(O, Location(1, 0)).toOption.get
         .play(X, Location(0, 1)).toOption.get
@@ -80,7 +87,7 @@ class TicTacToeSpec extends AnyWordSpec with Matchers {
     }
 
     "properly render a game board" in {
-      val game = TicTacToe.empty("alice", "bob")
+      val game = TicTacToe.empty(alice, bob)
         .play(X, Location(0, 0)).toOption.get
         .play(O, Location(1, 0)).toOption.get
         .play(X, Location(0, 1)).toOption.get

--- a/game-service-persistence/src/test/scala/com/andy327/persistence/db/postgres/PostgresGameRepositorySpec.scala
+++ b/game-service-persistence/src/test/scala/com/andy327/persistence/db/postgres/PostgresGameRepositorySpec.scala
@@ -1,5 +1,7 @@
 package com.andy327.persistence.db.postgres
 
+import java.util.UUID
+
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.implicits._
@@ -10,7 +12,7 @@ import doobie.implicits._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import com.andy327.model.core.GameType
+import com.andy327.model.core.{GameType, PlayerId}
 import com.andy327.model.tictactoe.TicTacToe
 import com.andy327.persistence.db.schema.GameTypeCodecs
 
@@ -40,7 +42,9 @@ class PostgresGameRepositorySpec extends AnyWordSpec with Matchers with ForAllTe
   "PostgresGameRepository" should {
     "save then load a TicTacToe game" in {
       val gameId = "g1"
-      val game = TicTacToe.empty("alice", "bob")
+      val alice: PlayerId = UUID.randomUUID()
+      val bob: PlayerId = UUID.randomUUID()
+      val game = TicTacToe.empty(alice, bob)
 
       gameRepo.saveGame(gameId, GameType.TicTacToe, game).unsafeRunSync()
       gameRepo.loadGame(gameId, GameType.TicTacToe).unsafeRunSync() shouldBe Some(game)
@@ -64,7 +68,9 @@ class PostgresGameRepositorySpec extends AnyWordSpec with Matchers with ForAllTe
     }
 
     "list all saved games" in {
-      gameRepo.saveGame("g2", GameType.TicTacToe, TicTacToe.empty("carl", "david")).unsafeRunSync()
+      val carl: PlayerId = UUID.randomUUID()
+      val david: PlayerId = UUID.randomUUID()
+      gameRepo.saveGame("g2", GameType.TicTacToe, TicTacToe.empty(carl, david)).unsafeRunSync()
 
       val all = gameRepo.loadAllGames().unsafeRunSync()
       all.keySet should contain theSameElementsAs Set("g1", "g2")
@@ -74,7 +80,9 @@ class PostgresGameRepositorySpec extends AnyWordSpec with Matchers with ForAllTe
       val badTypeGameId = "bad-type"
       val corruptedGameId = "bad-json-2"
       val validGameId = "g3"
-      val validGame = TicTacToe.empty("x", "y")
+      val x: PlayerId = UUID.randomUUID()
+      val y: PlayerId = UUID.randomUUID()
+      val validGame = TicTacToe.empty(x, y)
 
       // Insert valid, corrupted, and unknown-type rows
       val insertAll = List(

--- a/game-service-persistence/src/test/scala/com/andy327/persistence/db/schema/GameTypeCodecsSpec.scala
+++ b/game-service-persistence/src/test/scala/com/andy327/persistence/db/schema/GameTypeCodecsSpec.scala
@@ -1,15 +1,20 @@
 package com.andy327.persistence.db.schema
 
+import java.util.UUID
+
 import io.circe.parser._
 import io.circe.syntax._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import com.andy327.model.core.GameType
+import com.andy327.model.core.{GameType, PlayerId}
 import com.andy327.model.tictactoe.{Location, TicTacToe, X}
 
 class GameTypeCodecsSpec extends AnyWordSpec with Matchers {
   import GameTypeCodecs._
+
+  val alice: PlayerId = UUID.randomUUID()
+  val bob: PlayerId = UUID.randomUUID()
 
   "GameTypeCodecs" should {
     "correctly encode and decode GameType.TicTacToe" in {
@@ -29,7 +34,7 @@ class GameTypeCodecsSpec extends AnyWordSpec with Matchers {
     }
 
     "deserialize a valid TicTacToe game from JSON" in {
-      val game = TicTacToe.empty("alice", "bob").play(X, Location(0, 0)).toOption.get
+      val game = TicTacToe.empty(alice, bob).play(X, Location(0, 0)).toOption.get
       val json = game.asJson.noSpaces
       println(json)
 

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/GameActor.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/GameActor.scala
@@ -2,7 +2,7 @@ package com.andy327.server.actors.core
 
 import org.apache.pekko.actor.typed.{ActorRef, Behavior}
 
-import com.andy327.model.core.{Game, GameType, GameTypeTag}
+import com.andy327.model.core.{Game, GameType, GameTypeTag, PlayerId}
 import com.andy327.server.actors.persistence.PersistenceProtocol
 import com.andy327.server.http.json.GameState
 
@@ -28,7 +28,7 @@ trait GameActor[G <: Game[_, _, _, _, _], S <: GameState] {
   /** Spawn a fresh game actor given players, ids, etc. */
   def create(
       gameId: String,
-      players: Seq[String],
+      players: Seq[PlayerId],
       persist: ActorRef[PersistenceProtocol.Command],
       gameManager: ActorRef[GameManager.Command]
   ): (G, Behavior[_])

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/GameActor.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/GameActor.scala
@@ -26,12 +26,18 @@ trait GameActor[G <: Game[_, _, _, _, _], S <: GameState] {
   def gameType(implicit tag: GameTypeTag[G]): GameType = tag.value
 
   /** Spawn a fresh game actor given players, ids, etc. */
-  def create(gameId: String, players: Seq[String], persist: ActorRef[PersistenceProtocol.Command]): (G, Behavior[_])
+  def create(
+      gameId: String,
+      players: Seq[String],
+      persist: ActorRef[PersistenceProtocol.Command],
+      gameManager: ActorRef[GameManager.Command]
+  ): (G, Behavior[_])
 
   /** Re-hydrate an actor from a snapshot already loaded from the database. */
   def fromSnapshot(
       gameId: String,
       snap: Game[_, _, _, _, _],
-      persist: ActorRef[PersistenceProtocol.Command]
+      persist: ActorRef[PersistenceProtocol.Command],
+      gameManager: ActorRef[GameManager.Command]
   ): Behavior[_]
 }

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/GameManager.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/GameManager.scala
@@ -16,6 +16,7 @@ import com.andy327.persistence.db.GameRepository
 import com.andy327.server.actors.persistence.PersistenceProtocol
 import com.andy327.server.actors.tictactoe.TicTacToeActor
 import com.andy327.server.http.json.GameState
+import com.andy327.server.lobby.{GameLifecycleStatus, GameMetadata, Player}
 
 /**
  * A supervisor actor that handles creating and monitoring one child actor per game, provides an API for creating games
@@ -26,7 +27,17 @@ import com.andy327.server.http.json.GameState
  */
 object GameManager {
   sealed trait Command
-  final case class CreateGame(gameType: GameType, players: Seq[String], replyTo: ActorRef[GameResponse]) extends Command
+
+  final case class CreateLobby(gameType: GameType, host: Player, replyTo: ActorRef[GameResponse]) extends Command
+  final case class JoinLobby(gameId: String, player: Player, replyTo: ActorRef[GameResponse]) extends Command
+  final case class LeaveLobby(gameId: String, playerId: UUID, replyTo: ActorRef[GameResponse]) extends Command
+  final case class StartGame(gameId: String, playerId: UUID, replyTo: ActorRef[GameResponse]) extends Command
+  final case class ListLobbies(replyTo: ActorRef[GameResponse]) extends Command
+  final case class GetLobbyMetadata(gameId: String, replyTo: ActorRef[GameResponse]) extends Command
+  final case class GameCompleted(gameId: String, result: GameLifecycleStatus.GameEnded) extends Command
+
+  final case class CreateGame(gameType: GameType, players: Seq[String], replyTo: ActorRef[GameResponse])
+      extends Command // TODO: Remove
   final case class ForwardToGame[T](gameId: String, message: T, replyTo: Option[ActorRef[GameResponse]]) extends Command
   final protected[core] case class RestoreGames(games: Map[String, (GameType, Game[_, _, _, _, _])]) extends Command
   final private case class WrappedGameResponse(response: Either[GameError, GameState], replyTo: ActorRef[GameResponse])
@@ -34,6 +45,11 @@ object GameManager {
 
   sealed trait GameResponse
   final case class GameCreated(gameId: String) extends GameResponse
+  final case class LobbyJoined(gameId: String, metadata: GameMetadata) extends GameResponse
+  final case class LobbyLeft(gameId: String, message: String) extends GameResponse
+  final case class GameStarted(gameId: String) extends GameResponse
+  final case class LobbiesListed(lobbies: List[GameMetadata]) extends GameResponse
+  final case class LobbyMetadata(metadata: GameMetadata) extends GameResponse
   final case class GameStatus(state: GameState) extends GameResponse
   final case class ErrorResponse(message: String) extends GameResponse
 
@@ -81,7 +97,7 @@ object GameManager {
           val gameActor = gameType match {
             case GameType.TicTacToe =>
               context.spawn(
-                TicTacToeActor.fromSnapshot(gameId, game.asInstanceOf[TicTacToe], persistActor),
+                TicTacToeActor.fromSnapshot(gameId, game.asInstanceOf[TicTacToe], persistActor, context.self),
                 s"game-$gameId"
               ).unsafeUpcast[GameActor.GameCommand]
           }
@@ -92,8 +108,8 @@ object GameManager {
         // tell the listener we are ready
         onReady.foreach(_ ! Ready)
 
-        // unstash everything and switch to running behavior
-        stash.unstashAll(running(restoredActors, persistActor))
+        // unstash everything and switch to running behavior (lobbies start fresh)
+        stash.unstashAll(running(Map.empty, restoredActors, persistActor))
 
       case other =>
         stash.stash(other)
@@ -106,20 +122,147 @@ object GameManager {
     * Accepts new game creation and forwards commands to existing game actors.
     */
   private def running(
+      lobbies: Map[String, GameMetadata],
       games: Map[String, ActorRef[GameActor.GameCommand]],
       persistActor: ActorRef[PersistenceProtocol.Command]
   ): Behavior[Command] =
     Behaviors.setup { implicit context =>
       Behaviors.receiveMessage {
+        case CreateLobby(gameType, host, replyTo) =>
+          context.log.info(s"Creating new lobby for game type $gameType with host ${host.name}")
+          val lobby = GameMetadata.newLobby(gameType, host)
+          replyTo ! GameCreated(lobby.gameId)
+          running(lobbies + (lobby.gameId -> lobby), games, persistActor)
+
+        case JoinLobby(gameId, player, replyTo) =>
+          lobbies.get(gameId) match {
+            case Some(metadata)
+                if metadata.status == GameLifecycleStatus.WaitingForPlayers || metadata.status == GameLifecycleStatus.ReadyToStart =>
+              if (metadata.players.contains(player.id)) {
+                replyTo ! ErrorResponse("Player already in game")
+                Behaviors.same
+              } else if (metadata.players.size >= metadata.gameType.maxPlayers) {
+                replyTo ! ErrorResponse("Cannot join - lobby is full")
+                Behaviors.same
+              } else {
+                val updatedPlayers = metadata.players + (player.id -> player)
+                val updatedStatus =
+                  if (updatedPlayers.size >= metadata.gameType.minPlayers) GameLifecycleStatus.ReadyToStart
+                  else GameLifecycleStatus.WaitingForPlayers
+
+                val updatedMetadata = metadata.copy(players = updatedPlayers, status = updatedStatus)
+                replyTo ! LobbyJoined(gameId, updatedMetadata)
+                running(lobbies + (gameId -> updatedMetadata), games, persistActor)
+              }
+
+            case Some(_) =>
+              replyTo ! ErrorResponse("Cannot join — game already started or ended")
+              Behaviors.same
+
+            case None =>
+              replyTo ! ErrorResponse("No such lobby")
+              Behaviors.same
+          }
+
+        case LeaveLobby(gameId, playerId, replyTo) =>
+          lobbies.get(gameId) match {
+            case Some(metadata) =>
+              val updatedPlayers = metadata.players - playerId
+              val updatedStatus =
+                if (updatedPlayers.size >= metadata.gameType.minPlayers) GameLifecycleStatus.ReadyToStart
+                else GameLifecycleStatus.WaitingForPlayers
+
+              val newMetadata = metadata.copy(players = updatedPlayers, status = updatedStatus)
+
+              if (playerId == metadata.hostId) {
+                val cancelled = newMetadata.copy(status = GameLifecycleStatus.Cancelled)
+                context.log.info(s"Host ($playerId) left lobby $gameId. Cancelling game...")
+                replyTo ! LobbyLeft(gameId, s"Lobby $gameId ended - host left")
+                running(lobbies + (gameId -> cancelled), games, persistActor)
+              } else {
+                context.log.info(s"Player $playerId left lobby $gameId")
+                replyTo ! LobbyLeft(gameId, s"$playerId left lobby $gameId")
+                running(lobbies + (gameId -> newMetadata), games, persistActor)
+              }
+
+            case None =>
+              replyTo ! ErrorResponse("No such lobby")
+              Behaviors.same
+          }
+
+        case StartGame(gameId, playerId, replyTo) =>
+          lobbies.get(gameId) match {
+            case Some(metadata) if metadata.hostId == playerId && metadata.status == GameLifecycleStatus.ReadyToStart =>
+              val (game, behavior) = metadata.gameType match {
+                case GameType.TicTacToe =>
+                  val playerNames = metadata.players.values.map(_.name).toSeq
+                  TicTacToeActor.create(gameId, playerNames, persistActor, context.self)
+              }
+              val actor = context.spawn(behavior, s"game-$gameId").unsafeUpcast[GameActor.GameCommand]
+
+              // Persist immediately after creation; no need to wait for acknowledgement
+              persistActor ! PersistenceProtocol.SaveSnapshot(
+                gameId,
+                metadata.gameType,
+                game,
+                replyTo = context.system.ignoreRef
+              )
+
+              context.log.info(s"Created and persisted new game with gameId: $gameId")
+              replyTo ! GameStarted(gameId)
+
+              running(
+                lobbies + (gameId -> metadata.copy(status = GameLifecycleStatus.InProgress)),
+                games + (gameId -> actor),
+                persistActor
+              )
+
+            case Some(_) =>
+              replyTo ! ErrorResponse("Only host can start, and game must be ready to start")
+              Behaviors.same
+
+            case None =>
+              replyTo ! ErrorResponse("No such game")
+              Behaviors.same
+          }
+
+        case ListLobbies(replyTo) =>
+          context.log.info("Listing available lobbies")
+          val activeLobbies = lobbies.values.filter { m =>
+            m.status == GameLifecycleStatus.WaitingForPlayers || m.status == GameLifecycleStatus.ReadyToStart
+          }.toList
+          replyTo ! LobbiesListed(activeLobbies)
+          Behaviors.same
+
+        case GetLobbyMetadata(gameId, replyTo) =>
+          context.log.info(s"Getting lobby metadata for game $gameId")
+          lobbies.get(gameId) match {
+            case Some(metadata) => replyTo ! LobbyMetadata(metadata)
+            case None           => replyTo ! ErrorResponse(s"No game with gameId: $gameId")
+          }
+          Behaviors.same
+
+        case GameCompleted(gameId, result) =>
+          lobbies.get(gameId) match {
+            case Some(metadata) =>
+              val updated = metadata.copy(status = result)
+              context.log.info(s"Marking game $gameId as completed with result $result")
+              running(lobbies + (gameId -> updated), games, persistActor)
+            case None =>
+              context.log.warn(s"Tried to complete unknown game: $gameId")
+              Behaviors.same
+          }
+
+        // TODO: CreateLobby + StartGame renders CreateGame redundant; remove
         case CreateGame(gameType, players, replyTo) =>
-          if (players.size != 2) {
-            replyTo ! ErrorResponse(s"Expected 2 players, got ${players.size}")
+          if (players.size < gameType.minPlayers || players.size > gameType.maxPlayers) {
+            replyTo ! ErrorResponse(s"Invalid number of players, got ${players.size}")
             Behaviors.same
           } else {
             val gameId = UUID.randomUUID().toString
             val (game, actor) = gameType match {
               case GameType.TicTacToe =>
-                val (game, behavior) = TicTacToeActor.create(gameId, players, persistActor)
+                val (game, behavior) = TicTacToeActor.create(gameId, players, persistActor, context.self)
                 val actor = context.spawn(behavior, s"game-$gameId").unsafeUpcast[GameActor.GameCommand]
                 (game, actor)
             }
@@ -130,7 +273,7 @@ object GameManager {
             context.log.info(s"Created and persisted new game with gameId: $gameId")
             replyTo ! GameCreated(gameId)
 
-            running(games + (gameId -> actor), persistActor)
+            running(lobbies, games + (gameId -> actor), persistActor)
           }
 
         case ForwardToGame(gameId, msg, replyToOpt) =>

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/GameManager.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/GameManager.scala
@@ -40,8 +40,8 @@ object GameManager {
       extends Command
 
   sealed trait GameResponse
-  final case class LobbyCreated(gameId: String) extends GameResponse
-  final case class LobbyJoined(gameId: String, metadata: GameMetadata) extends GameResponse
+  final case class LobbyCreated(gameId: String, host: Player) extends GameResponse
+  final case class LobbyJoined(gameId: String, metadata: GameMetadata, joinedPlayer: Player) extends GameResponse
   final case class LobbyLeft(gameId: String, message: String) extends GameResponse
   final case class GameStarted(gameId: String) extends GameResponse
   final case class LobbiesListed(lobbies: List[GameMetadata]) extends GameResponse
@@ -127,7 +127,7 @@ object GameManager {
         case CreateLobby(gameType, host, replyTo) =>
           context.log.info(s"Creating new lobby for game type $gameType with host ${host.name}")
           val lobby = GameMetadata.newLobby(gameType, host)
-          replyTo ! LobbyCreated(lobby.gameId)
+          replyTo ! LobbyCreated(lobby.gameId, host)
           running(lobbies + (lobby.gameId -> lobby), games, persistActor)
 
         case JoinLobby(gameId, player, replyTo) =>
@@ -147,7 +147,7 @@ object GameManager {
                   else GameLifecycleStatus.WaitingForPlayers
 
                 val updatedMetadata = metadata.copy(players = updatedPlayers, status = updatedStatus)
-                replyTo ! LobbyJoined(gameId, updatedMetadata)
+                replyTo ! LobbyJoined(gameId, updatedMetadata, player)
                 running(lobbies + (gameId -> updatedMetadata), games, persistActor)
               }
 

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -1,15 +1,39 @@
 package com.andy327.server.http.json
 
+import java.util.UUID
+
 import org.apache.pekko.http.scaladsl.marshalling.{Marshaller, ToResponseMarshaller}
 import org.apache.pekko.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse, MediaTypes}
 import spray.json._
+
+import com.andy327.server.lobby.Player
 
 /**
  * Spray-Json protocol + Pekko marshalling helpers.
  */
 object JsonProtocol extends DefaultJsonProtocol {
   implicit val moveFormat: RootJsonFormat[TicTacToeMove] = jsonFormat3(TicTacToeMove)
+
   implicit val statusFormat: RootJsonFormat[TicTacToeState] = jsonFormat4(TicTacToeState.apply)
+
+  implicit val uuidFormat: RootJsonFormat[UUID] = new RootJsonFormat[UUID] {
+    def write(uuid: UUID): JsValue = JsString(uuid.toString)
+    def read(value: JsValue): UUID = value match {
+      case JsString(str) =>
+        try UUID.fromString(str)
+        catch {
+          case _: IllegalArgumentException =>
+            deserializationError(s"Invalid UUID string: $str")
+        }
+      case other => deserializationError(s"Expected UUID string, got: $other")
+    }
+  }
+
+  implicit val playerFormat: RootJsonFormat[Player] = jsonFormat2(Player.apply)
+
+  implicit val createLobbyRequestFormat: RootJsonFormat[CreateLobbyRequest] = jsonFormat1(CreateLobbyRequest)
+
+  implicit val joinLobbyRequestFormat: RootJsonFormat[JoinLobbyRequest] = jsonFormat1(JoinLobbyRequest)
 
   /** Polymorphic marshaller that knows how to serialise any GameState into an HttpResponse. */
   implicit val gameStateMarshaller: ToResponseMarshaller[GameState] =

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -7,8 +7,8 @@ import org.apache.pekko.http.scaladsl.model.{ContentTypes, HttpEntity, HttpRespo
 import spray.json._
 
 import com.andy327.model.core.GameType
-import com.andy327.server.actors.core.GameManager.ErrorResponse
-import com.andy327.server.lobby.{GameLifecycleStatus, GameMetadata, Player}
+import com.andy327.server.actors.core.GameManager.{ErrorResponse, LobbyCreated, LobbyJoined}
+import com.andy327.server.lobby.{GameLifecycleStatus, GameMetadata, IncomingPlayer, Player}
 
 /**
  * Spray-Json protocol + Pekko marshalling helpers.
@@ -26,6 +26,8 @@ object JsonProtocol extends DefaultJsonProtocol {
       case other => deserializationError(s"Expected UUID string, got: $other")
     }
   }
+
+  implicit val incomingPlayerFormat: RootJsonFormat[IncomingPlayer] = jsonFormat2(IncomingPlayer.apply)
 
   implicit val playerFormat: RootJsonFormat[Player] = jsonFormat2(Player.apply)
 
@@ -54,11 +56,15 @@ object JsonProtocol extends DefaultJsonProtocol {
 
   implicit val gameMetadataFormat: RootJsonFormat[GameMetadata] = jsonFormat5(GameMetadata.apply)
 
-  implicit val moveFormat: RootJsonFormat[TicTacToeMove] = jsonFormat3(TicTacToeMove)
+  implicit val lobbyCreatedFormat: RootJsonFormat[LobbyCreated] = jsonFormat2(LobbyCreated.apply)
+
+  implicit val lobbyJoinedFormat: RootJsonFormat[LobbyJoined] = jsonFormat3(LobbyJoined.apply)
+
+  implicit val moveFormat: RootJsonFormat[TicTacToeMove] = jsonFormat3(TicTacToeMove.apply)
 
   implicit val statusFormat: RootJsonFormat[TicTacToeState] = jsonFormat4(TicTacToeState.apply)
 
-  implicit val errorResponseFormat: RootJsonFormat[ErrorResponse] = jsonFormat1(ErrorResponse)
+  implicit val errorResponseFormat: RootJsonFormat[ErrorResponse] = jsonFormat1(ErrorResponse.apply)
 
   /** Polymorphic marshaller that knows how to serialise any GameState into an HttpResponse. */
   implicit val gameStateMarshaller: ToResponseMarshaller[GameState] =

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -49,6 +49,7 @@ object JsonProtocol extends DefaultJsonProtocol {
         case JsString("ReadyToStart")      => GameLifecycleStatus.ReadyToStart
         case JsString("InProgress")        => GameLifecycleStatus.InProgress
         case JsString("Completed")         => GameLifecycleStatus.Completed
+        case JsString("Cancelled")         => GameLifecycleStatus.Cancelled
         case JsString(other)               => deserializationError(s"Unknown GameLifecycleStatus: $other")
         case _                             => deserializationError("Expected GameLifecycleStatus as string")
       }
@@ -60,18 +61,18 @@ object JsonProtocol extends DefaultJsonProtocol {
 
   implicit val lobbyJoinedFormat: RootJsonFormat[LobbyJoined] = jsonFormat3(LobbyJoined.apply)
 
-  implicit val moveFormat: RootJsonFormat[TicTacToeMove] = jsonFormat3(TicTacToeMove.apply)
-
-  implicit val statusFormat: RootJsonFormat[TicTacToeState] = jsonFormat4(TicTacToeState.apply)
-
   implicit val errorResponseFormat: RootJsonFormat[ErrorResponse] = jsonFormat1(ErrorResponse.apply)
+
+  implicit val ticTacToeMoveFormat: RootJsonFormat[TicTacToeMove] = jsonFormat3(TicTacToeMove.apply)
+
+  implicit val ticTacToeStateFormat: RootJsonFormat[TicTacToeState] = jsonFormat4(TicTacToeState.apply)
 
   /** Polymorphic marshaller that knows how to serialise any GameState into an HttpResponse. */
   implicit val gameStateMarshaller: ToResponseMarshaller[GameState] =
     Marshaller.withFixedContentType(MediaTypes.`application/json`) { gameState =>
       gameState match {
         case s: TicTacToeState =>
-          val json = statusFormat.write(s).compactPrint
+          val json = ticTacToeStateFormat.write(s).compactPrint
           HttpResponse(entity = HttpEntity(ContentTypes.`application/json`, json))
       }
     }

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/LobbyRequests.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/LobbyRequests.scala
@@ -1,6 +1,0 @@
-package com.andy327.server.http.json
-
-import com.andy327.server.lobby.Player
-
-final case class CreateLobbyRequest(player: Player)
-final case class JoinLobbyRequest(player: Player)

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/LobbyRequests.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/LobbyRequests.scala
@@ -1,0 +1,6 @@
+package com.andy327.server.http.json
+
+import com.andy327.server.lobby.Player
+
+final case class CreateLobbyRequest(player: Player)
+final case class JoinLobbyRequest(player: Player)

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/Move.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/Move.scala
@@ -1,6 +1,8 @@
 package com.andy327.server.http.json
 
+import com.andy327.model.core.PlayerId
+
 /**
  * A move made by a player in a Tic-Tac-Toe game.
  */
-case class TicTacToeMove(playerId: String, row: Int, col: Int)
+case class TicTacToeMove(player: PlayerId, row: Int, col: Int)

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/Move.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/Move.scala
@@ -5,4 +5,4 @@ import com.andy327.model.core.PlayerId
 /**
  * A move made by a player in a Tic-Tac-Toe game.
  */
-case class TicTacToeMove(player: PlayerId, row: Int, col: Int)
+case class TicTacToeMove(playerId: PlayerId, row: Int, col: Int)

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/TicTacToeRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/TicTacToeRoutes.scala
@@ -13,15 +13,24 @@ import org.apache.pekko.util.Timeout
 import com.andy327.model.core.GameType
 import com.andy327.model.tictactoe.{GameError, Location}
 import com.andy327.server.actors.core.GameManager
-import com.andy327.server.actors.core.GameManager.{ErrorResponse, GameCreated, GameResponse, GameStatus}
+import com.andy327.server.actors.core.GameManager.{
+  ErrorResponse,
+  GameResponse,
+  GameStarted,
+  GameStatus,
+  LobbiesListed,
+  LobbyCreated,
+  LobbyJoined
+}
 import com.andy327.server.actors.tictactoe.TicTacToeActor
 import com.andy327.server.http.json.JsonProtocol._
 import com.andy327.server.http.json.{GameState, TicTacToeMove}
+import com.andy327.server.lobby.Player
 
 /**
  * HTTP routes for managing Tic-Tac-Toe games.
  *
- * This class defines endpoints for creating games, making moves, and querying game status.
+ * This class defines endpoints for creating/joining/listing lobbies, making moves, and querying game status.
  * Requests are forwarded to the GameManager actor, which handles routing to individual game actors.
  */
 class TicTacToeRoutes(system: ActorSystem[GameManager.Command]) {
@@ -31,41 +40,97 @@ class TicTacToeRoutes(system: ActorSystem[GameManager.Command]) {
   val routes: Route = pathPrefix("tictactoe") {
 
     /**
-     * @route POST /tictactoe
-     * @queryParam playerX Player ID for player X
-     * @queryParam playerO Player ID for player O
-     * @response 200 gameId as plain text
+     * @route POST /tictactoe/lobby
+     * @bodyParam Player JSON { "id": "UUID", "name": "alice" }
+     * @response 200 The ID of the created lobby as plain text
+     * @response 500 Unexpected response from GameManager
      *
-     * Create a new Tic-Tac-Toe game with the specified player IDs.
+     * Create a new game lobby.
      */
-    pathEndOrSingleSlash {
+    path("lobby") {
       post {
-        parameters("playerX", "playerO") { (p1, p2) =>
-          val players = Seq(p1, p2)
-          onSuccess(system.ask[GameResponse](replyTo => GameManager.CreateGame(GameType.TicTacToe, players, replyTo))) {
-            case GameCreated(gameId)    => complete(gameId)
-            case ErrorResponse(message) => complete(StatusCodes.BadRequest, message)
-            case unknown                => complete(StatusCodes.InternalServerError, s"Unexpected response: $unknown")
+        entity(as[Player]) { player =>
+          onSuccess(system.ask[GameResponse](replyTo => GameManager.CreateLobby(GameType.TicTacToe, player, replyTo))) {
+            case LobbyCreated(gameId) => complete(gameId)
+            case other                => complete(StatusCodes.InternalServerError -> s"Unexpected: $other")
           }
         }
       }
     } ~
     /**
+     * @route POST /tictactoe/lobby/{gameId}/join
+     * @pathParam gameId The ID of the lobby to join
+     * @bodyParam Player JSON { "id": "UUID", "name": "bob" }
+     * @response 200 GameMetadata of the joined lobby
+     * @response 400 If the join request is invalid
+     * @response 500 Unexpected response from GameManager
+     *
+     * Join an existing game lobby.
+     */
+    path("lobby" / Segment / "join") { gameId =>
+      post {
+        entity(as[Player]) { player =>
+          onSuccess(system.ask[GameResponse](replyTo => GameManager.JoinLobby(gameId, player, replyTo))) {
+            case LobbyJoined(_, metadata) => complete(metadata)
+            case ErrorResponse(msg)       => complete(StatusCodes.BadRequest -> msg)
+            case other                    => complete(StatusCodes.InternalServerError -> s"Unexpected: $other")
+          }
+        }
+      }
+    } ~
+    /**
+     * @route POST /tictactoe/lobby/{gameId}/start
+     * @pathParam gameId The ID of the lobby to start
+     * @bodyParam Player JSON { "id": "UUID", "name": "alice" }
+     * @response 200 The ID of the started game as plain text
+     * @response 400 If the game cannot be started
+     * @response 500 Unexpected response from GameManager
+     *
+     * Start a game from a lobby as the host player.
+     */
+    path("lobby" / Segment / "start") { gameId =>
+      post {
+        entity(as[Player]) { player =>
+          onSuccess(system.ask[GameResponse](replyTo => GameManager.StartGame(gameId, player, replyTo))) {
+            case GameStarted(id)        => complete(id)
+            case ErrorResponse(message) => complete(StatusCodes.BadRequest -> message)
+            case other                  => complete(StatusCodes.InternalServerError -> s"Unexpected response: $other")
+          }
+        }
+      }
+    } ~
+    /**
+     * @route GET /tictactoe/lobbies
+     * @response 200 List of GameMetadata objects representing all open lobbies
+     * @response 500 Unexpected response from GameManager
+     *
+     * List all open lobbies.
+     */
+    path("lobbies") {
+      get {
+        onSuccess(system.ask[GameResponse](GameManager.ListLobbies)) {
+          case LobbiesListed(lobbies) => complete(lobbies)
+          case other                  => complete(StatusCodes.InternalServerError -> s"Unexpected response: $other")
+        }
+      }
+    } ~
+    /**
      * @route POST /tictactoe/{id}/move
-     * @pathParam id The ID of the game
-     * @bodyParam Move JSON { "playerId": "X", "row": 0, "col": 1 }
-     * @response 200 TicTacToeStatus
-     * @response 404 if the game is not found or move is invalid
+     * @pathParam id The ID of the game to make a move in
+     * @bodyParam TicTacToeMove JSON { "player": { "id": "UUID", "name": "alice" }, "row": 0, "col": 1 }
+     * @response 200 Updated game state
+     * @response 404 If the game is not found or move is invalid
+     * @response 500 Unexpected response from GameManager
      *
      * Submit a move for a player in a given game.
      */
     path(Segment / "move") { gameId =>
       post {
-        entity(as[TicTacToeMove]) { case TicTacToeMove(playerId, row, col) =>
+        entity(as[TicTacToeMove]) { case TicTacToeMove(player, row, col) =>
           onSuccess(
             system.ask[GameResponse] { replyTo =>
               val dummyRef = system.ignoreRef[Either[GameError, GameState]]
-              val gameCmd = TicTacToeActor.MakeMove(playerId, Location(row, col), dummyRef)
+              val gameCmd = TicTacToeActor.MakeMove(player, Location(row, col), dummyRef)
               GameManager.ForwardToGame(gameId, gameCmd, Some(replyTo))
             }
           ) {
@@ -78,9 +143,10 @@ class TicTacToeRoutes(system: ActorSystem[GameManager.Command]) {
     } ~
     /**
      * @route GET /tictactoe/{id}/status
-     * @pathParam id The ID of the game
-     * @response 200 TicTacToeStatus
-     * @response 404 if the game is not found
+     * @pathParam id The ID of the game to check status
+     * @response 200 Current game state
+     * @response 404 If the game is not found
+     * @response 500 Unexpected response from GameManager
      *
      * Fetch the current state of the specified game.
      */

--- a/game-service-server/src/main/scala/com/andy327/server/lobby/GameLifecycleStatus.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/lobby/GameLifecycleStatus.scala
@@ -1,0 +1,13 @@
+package com.andy327.server.lobby
+
+sealed trait GameLifecycleStatus
+
+object GameLifecycleStatus {
+  case object WaitingForPlayers extends GameLifecycleStatus
+  case object ReadyToStart extends GameLifecycleStatus
+  case object InProgress extends GameLifecycleStatus
+
+  sealed trait GameEnded extends GameLifecycleStatus
+  case object Completed extends GameEnded // game ended normally (win/draw)
+  case object Cancelled extends GameEnded // abandoned or invalidated
+}

--- a/game-service-server/src/main/scala/com/andy327/server/lobby/GameMetadata.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/lobby/GameMetadata.scala
@@ -1,0 +1,21 @@
+package com.andy327.server.lobby
+
+import java.util.UUID
+
+import com.andy327.model.core.GameType
+
+object GameMetadata {
+  def newLobby(gameType: GameType, host: Player): GameMetadata = {
+    val gameId = UUID.randomUUID().toString
+    val players = Map(host.id -> host)
+    GameMetadata(gameId, gameType, players, host.id, GameLifecycleStatus.WaitingForPlayers)
+  }
+}
+
+case class GameMetadata(
+    gameId: String,
+    gameType: GameType,
+    players: Map[UUID, Player], // includes the host
+    hostId: UUID,
+    status: GameLifecycleStatus
+)

--- a/game-service-server/src/main/scala/com/andy327/server/lobby/Player.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/lobby/Player.scala
@@ -1,0 +1,9 @@
+package com.andy327.server.lobby
+
+import java.util.UUID
+
+object Player {
+  def apply(name: String): Player = Player(UUID.randomUUID(), name)
+}
+
+case class Player(id: UUID, name: String)

--- a/game-service-server/src/main/scala/com/andy327/server/lobby/Player.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/lobby/Player.scala
@@ -2,8 +2,19 @@ package com.andy327.server.lobby
 
 import java.util.UUID
 
+import com.andy327.model.core.PlayerId
+
 object Player {
   def apply(name: String): Player = Player(UUID.randomUUID(), name)
 }
 
-case class Player(id: UUID, name: String)
+case class Player(id: PlayerId, name: String)
+
+/** Handles PlayerId generation if none is supplied by the user. */
+case class IncomingPlayer(id: Option[PlayerId], name: String)
+
+object IncomingPlayerOps {
+  implicit class RichIncomingPlayer(val inc: IncomingPlayer) extends AnyVal {
+    def toPlayer: Player = Player(inc.id.getOrElse(UUID.randomUUID()), inc.name)
+  }
+}

--- a/game-service-server/src/test/scala/com/andy327/server/GameServerSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/GameServerSpec.scala
@@ -43,6 +43,7 @@ class GameServerSpec extends AnyWordSpec with Matchers {
       val player2 = Player("bob")
       val player1Entity = HttpEntity(ContentTypes.`application/json`, player1.toJson.compactPrint)
       val player2Entity = HttpEntity(ContentTypes.`application/json`, player2.toJson.compactPrint)
+      val hostIdEntity = HttpEntity(ContentTypes.`application/json`, player1.id.toJson.compactPrint)
 
       try {
         // Create lobby with player 1
@@ -68,7 +69,7 @@ class GameServerSpec extends AnyWordSpec with Matchers {
         val startGameReq = HttpRequest(
           method = HttpMethods.POST,
           uri = s"http://localhost:${actualPort}/tictactoe/lobby/${gameId}/start",
-          entity = player1Entity
+          entity = hostIdEntity
         )
         val startResp = Await.result(Http()(classicSystem).singleRequest(startGameReq), 2.seconds)
         startResp.status shouldBe StatusCodes.OK

--- a/game-service-server/src/test/scala/com/andy327/server/GameServerSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/GameServerSpec.scala
@@ -1,7 +1,7 @@
 package com.andy327.server
 
+import scala.concurrent.Await
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
 
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
@@ -9,12 +9,16 @@ import cats.effect.unsafe.IORuntime
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.Http
 import org.apache.pekko.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshal
 import org.apache.pekko.util.Timeout
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import spray.json._
 
 import com.andy327.model.core.{Game, GameType}
 import com.andy327.persistence.db.GameRepository
+import com.andy327.server.http.json.JsonProtocol._
+import com.andy327.server.lobby.Player
 
 class GameServerSpec extends AnyWordSpec with Matchers {
   implicit val timeout: Timeout = Timeout(5.seconds)
@@ -33,15 +37,42 @@ class GameServerSpec extends AnyWordSpec with Matchers {
       val actualPort = binding.localAddress.getPort
       implicit val classicSystem: ActorSystem = system.classicSystem
 
-      try {
-        val request = HttpRequest(
-          method = HttpMethods.POST,
-          uri = s"http://localhost:${actualPort}/tictactoe?playerX=alice&playerO=bob"
-        )
-        val responseFuture: Future[HttpResponse] = Http()(classicSystem).singleRequest(request)
-        val response = Await.result(responseFuture, 5.seconds)
+      val player1 = Player("alice")
+      val player2 = Player("bob")
+      val player1Entity = HttpEntity(ContentTypes.`application/json`, player1.toJson.compactPrint)
+      val player2Entity = HttpEntity(ContentTypes.`application/json`, player2.toJson.compactPrint)
 
-        response.status shouldBe StatusCodes.OK
+      try {
+        // Create lobby with player 1
+        val createLobbyReq = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"http://localhost:${actualPort}/tictactoe/lobby",
+          entity = player1Entity
+        )
+        val createLobbyResp = Await.result(Http()(classicSystem).singleRequest(createLobbyReq), 2.seconds)
+        val gameId = Await.result(Unmarshal(createLobbyResp.entity).to[String], 2.seconds)
+        createLobbyResp.status shouldBe StatusCodes.OK
+
+        // Join lobby with player 2
+        val joinLobbyReq = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"http://localhost:${actualPort}/tictactoe/lobby/${gameId}/join",
+          entity = player2Entity
+        )
+        val joinLobbyResp = Await.result(Http()(classicSystem).singleRequest(joinLobbyReq), 2.seconds)
+        joinLobbyResp.status shouldBe StatusCodes.OK
+
+        // Start the game from the lobby (initiated by the host)
+        val startGameReq = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"http://localhost:${actualPort}/tictactoe/lobby/${gameId}/start",
+          entity = player1Entity
+        )
+        val startResp = Await.result(Http()(classicSystem).singleRequest(startGameReq), 2.seconds)
+        startResp.status shouldBe StatusCodes.OK
+
+        val startedGameId = Await.result(Unmarshal(startResp.entity).to[String], 2.seconds)
+        startedGameId shouldBe gameId
       } finally {
         Await.result(binding.unbind(), 5.seconds)
         system.terminate()

--- a/game-service-server/src/test/scala/com/andy327/server/GameServerSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/GameServerSpec.scala
@@ -8,6 +8,7 @@ import cats.effect.unsafe.IORuntime
 
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import org.apache.pekko.http.scaladsl.model._
 import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshal
 import org.apache.pekko.util.Timeout
@@ -17,6 +18,7 @@ import spray.json._
 
 import com.andy327.model.core.{Game, GameType}
 import com.andy327.persistence.db.GameRepository
+import com.andy327.server.actors.core.GameManager
 import com.andy327.server.http.json.JsonProtocol._
 import com.andy327.server.lobby.Player
 
@@ -50,7 +52,7 @@ class GameServerSpec extends AnyWordSpec with Matchers {
           entity = player1Entity
         )
         val createLobbyResp = Await.result(Http()(classicSystem).singleRequest(createLobbyReq), 2.seconds)
-        val gameId = Await.result(Unmarshal(createLobbyResp.entity).to[String], 2.seconds)
+        val gameId = Await.result(Unmarshal(createLobbyResp.entity).to[GameManager.LobbyCreated], 2.seconds).gameId
         createLobbyResp.status shouldBe StatusCodes.OK
 
         // Join lobby with player 2

--- a/game-service-server/src/test/scala/com/andy327/server/actors/core/GameManagerSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/core/GameManagerSpec.scala
@@ -16,6 +16,7 @@ import com.andy327.server.actors.persistence.PersistenceProtocol
 import com.andy327.server.actors.tictactoe.TicTacToeActor
 import com.andy327.server.http.json.TicTacToeState.TicTacToeView
 import com.andy327.server.http.json.{GameState, GameStateConverters}
+import com.andy327.server.lobby.{GameLifecycleStatus, Player}
 
 /** In-memory GameRepository for unit tests */
 class InMemRepo(initialGames: Map[String, (GameType, Game[_, _, _, _, _])] = Map.empty) extends GameRepository {
@@ -41,15 +42,13 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
     "spawn a game actor and persist an empty snapshot" in {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
       val gameRepo = new InMemRepo
-      val readyProbe = TestProbe[GameManager.Ready.type]()
 
-      val gm = spawn(GameManager(persistProbe.ref, gameRepo, Some(readyProbe.ref)))
-      readyProbe.expectMessage(GameManager.Ready) // wait for initialization
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
 
-      val replyProbe = TestProbe[GameManager.GameResponse]()
-      gm ! GameManager.CreateGame(GameType.TicTacToe, Seq("alice", "bob"), replyProbe.ref)
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+      gm ! GameManager.CreateGame(GameType.TicTacToe, Seq("alice", "bob"), responseProbe.ref)
 
-      val GameManager.GameCreated(gameId) = replyProbe.receiveMessage()
+      val GameManager.GameCreated(gameId) = responseProbe.receiveMessage()
       gameId.length should be > 0
 
       val save = persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
@@ -58,32 +57,29 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
       save.game shouldBe TicTacToe.empty("alice", "bob")
     }
 
-    "return error when not specifying the correct number of players" in {
+    "return an error when not specifying the correct number of players" in {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
       val gameRepo = new InMemRepo
-      val readyProbe = TestProbe[GameManager.Ready.type]()
 
-      val gm = spawn(GameManager(persistProbe.ref, gameRepo, Some(readyProbe.ref)))
-      readyProbe.expectMessage(GameManager.Ready) // wait for initialization
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
 
-      val replyProbe = TestProbe[GameManager.GameResponse]()
-      gm ! GameManager.CreateGame(GameType.TicTacToe, Seq("alice", "bob", "carl"), replyProbe.ref)
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+      gm ! GameManager.CreateGame(GameType.TicTacToe, Seq("alice", "bob", "carl"), responseProbe.ref)
 
-      val response = replyProbe.expectMessageType[GameManager.ErrorResponse]
-      response.message should include("Expected 2 players")
+      val response = responseProbe.expectMessageType[GameManager.ErrorResponse]
+      response.message should include("Invalid number of players")
     }
 
-    "return error when forwarding to unknown game" in {
+    "return an error when forwarding to a nonexistent game" in {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
       val gameRepo = new InMemRepo
-      val readyProbe = TestProbe[GameManager.Ready.type]()
-      val gm = spawn(GameManager(persistProbe.ref, gameRepo, Some(readyProbe.ref)))
-      readyProbe.expectMessage(GameManager.Ready) // wait for initialization
 
-      val replyProbe = TestProbe[GameManager.GameResponse]()
-      gm ! GameManager.ForwardToGame("no-such-id", "noop-msg", Some(replyProbe.ref))
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
 
-      val error = replyProbe.expectMessageType[GameManager.ErrorResponse]
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+      gm ! GameManager.ForwardToGame("nonexistent", "noop-msg", Some(responseProbe.ref))
+
+      val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
       error.message should include("No game found with gameId")
     }
 
@@ -104,13 +100,11 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
 
     "restore saved games from the game repository on startup" in {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
-      val readyProbe = TestProbe[GameManager.Ready.type]()
       val gameId = "restored-game"
       val restoredGame = TicTacToe.empty("alice", "bob")
-
       val gameRepo = new InMemRepo(Map(gameId -> (GameType.TicTacToe, restoredGame)))
-      val gm = spawn(GameManager(persistProbe.ref, gameRepo, Some(readyProbe.ref)))
-      readyProbe.expectMessage(GameManager.Ready)
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
 
       val gameStateProbe = TestProbe[Either[GameError, GameState]]()
       val gameResponseProbe = TestProbe[GameManager.GameResponse]()
@@ -146,10 +140,8 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
     "ignore RestoreGames messages in running state" in {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
       val gameRepo = new InMemRepo
-      val readyProbe = TestProbe[GameManager.Ready.type]()
 
-      val gm = spawn(GameManager(persistProbe.ref, gameRepo, Some(readyProbe.ref)))
-      readyProbe.expectMessage(GameManager.Ready)
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
 
       // Now send an unexpected RestoreGames message while in `running` state
       gm ! GameManager.RestoreGames(Map.empty)
@@ -160,6 +152,323 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
 
       val response = responseProbe.expectMessageType[GameManager.GameCreated]
       assert(response.gameId.nonEmpty)
+    }
+
+    "create a new lobby and return its metadata" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+      val alice = Player("alice")
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
+
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+
+      val response = responseProbe.expectMessageType[GameManager.GameCreated]
+      assert(response.gameId.nonEmpty)
+
+      gm ! GameManager.GetLobbyMetadata(response.gameId, responseProbe.ref)
+      val GameManager.LobbyMetadata(metadata) = responseProbe.expectMessageType[GameManager.LobbyMetadata]
+
+      metadata.status shouldBe GameLifecycleStatus.WaitingForPlayers
+    }
+
+    "return an error when retrieving metadata for a nonexistent lobby" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
+
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+
+      gm ! GameManager.GetLobbyMetadata("nonexistent", responseProbe.ref)
+      val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
+      error.message should include("No game with gameId: nonexistent")
+    }
+
+    "allow a second player to join a lobby and change its status to ReadyToStart" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+      val alice = Player("alice")
+      val bob = Player("bob")
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
+
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      val GameManager.GameCreated(gameId) = responseProbe.expectMessageType[GameManager.GameCreated]
+
+      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      val response = responseProbe.expectMessageType[GameManager.LobbyJoined]
+      response.metadata.status shouldBe GameLifecycleStatus.ReadyToStart
+    }
+
+    "prevent a player from joining a lobby again" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+      val alice = Player("alice")
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
+
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      val GameManager.GameCreated(gameId) = responseProbe.expectMessageType[GameManager.GameCreated]
+
+      gm ! GameManager.JoinLobby(gameId, alice, responseProbe.ref)
+      val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
+      error.message should include("already in game")
+
+      gm ! GameManager.GetLobbyMetadata(gameId, responseProbe.ref)
+      val GameManager.LobbyMetadata(metadata) = responseProbe.expectMessageType[GameManager.LobbyMetadata]
+
+      metadata.status shouldBe GameLifecycleStatus.WaitingForPlayers
+    }
+
+    "prevent a player from joining a nonexistent lobby" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+      val alice = Player("alice")
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
+
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+      gm ! GameManager.JoinLobby("nonexistent", alice, responseProbe.ref)
+
+      val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
+      error.message should include("No such lobby")
+    }
+
+    "prevent too many players from joining a lobby" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+      val alice = Player("alice")
+      val bob = Player("bob")
+      val carl = Player("carl")
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
+
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+
+      // Alice creates the lobby
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      val GameManager.GameCreated(gameId) = responseProbe.receiveMessage()
+
+      // Bob joins
+      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbyJoined]
+
+      // Carl tries to join - should be rejected
+      gm ! GameManager.JoinLobby(gameId, carl, responseProbe.ref)
+      val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
+      error.message should include("lobby is full")
+    }
+
+    "allow a host to start a game from a ready lobby and persist the snapshot" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+      val alice = Player("alice")
+      val bob = Player("bob")
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
+
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      val GameManager.GameCreated(gameId) = responseProbe.receiveMessage()
+
+      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbyJoined]
+
+      gm ! GameManager.StartGame(gameId, alice.id, responseProbe.ref)
+      responseProbe.expectMessage(GameManager.GameStarted(gameId))
+
+      val snapshot = persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+      snapshot.gameId shouldBe gameId
+    }
+
+    "prevent a non-host player from starting the game" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+      val alice = Player("alice")
+      val bob = Player("bob")
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
+
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      val GameManager.GameCreated(gameId) = responseProbe.receiveMessage()
+
+      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbyJoined]
+
+      // Bob tries to start the game
+      gm ! GameManager.StartGame(gameId, bob.id, responseProbe.ref)
+      val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
+      error.message should include("Only host can start")
+    }
+
+    "prevent a player from starting a nonexistent game" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+      val alice = Player("alice")
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
+
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+
+      gm ! GameManager.StartGame("nonexistent", alice.id, responseProbe.ref)
+      val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
+      error.message should include("No such game")
+    }
+
+    "list available lobbies" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+      val alice = Player("alice")
+      val bob = Player("bob")
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
+
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+
+      // Game 1: InProgress
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      val GameManager.GameCreated(gameId1) = responseProbe.receiveMessage()
+      gm ! GameManager.JoinLobby(gameId1, bob, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbyJoined]
+      gm ! GameManager.StartGame(gameId1, alice.id, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.GameStarted]
+
+      // Game 2: ReadyToStart
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      val GameManager.GameCreated(gameId2) = responseProbe.receiveMessage()
+      gm ! GameManager.JoinLobby(gameId2, bob, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbyJoined]
+
+      // Game 2: WaitingForPlayers
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      val GameManager.GameCreated(gameId3) = responseProbe.receiveMessage()
+
+      gm ! GameManager.ListLobbies(responseProbe.ref)
+      val response = responseProbe.expectMessageType[GameManager.LobbiesListed]
+      response.lobbies.map(_.gameId) should contain only (gameId2, gameId3)
+    }
+
+    "mark game as completed when receiving GameCompleted message" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+      val alice = Player("alice")
+      val bob = Player("bob")
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
+
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      val GameManager.GameCreated(gameId) = responseProbe.receiveMessage()
+
+      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbyJoined]
+
+      gm ! GameManager.StartGame(gameId, alice.id, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.GameStarted]
+
+      // game actor sends a GameCompleted message to the GameManager
+      gm ! GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed)
+
+      gm ! GameManager.GetLobbyMetadata(gameId, responseProbe.ref)
+      val GameManager.LobbyMetadata(metadata) = responseProbe.expectMessageType[GameManager.LobbyMetadata]
+      metadata.status shouldBe GameLifecycleStatus.Completed
+    }
+
+    "handle trying to mark a nonexistent game as completed" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
+
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+
+      // game actor sends a GameCompleted message to the GameManager
+      gm ! GameManager.GameCompleted("nonexistent", GameLifecycleStatus.Completed)
+
+      // no-op: behavior remains the same and GameManager can continue receiving messages
+      gm ! GameManager.ListLobbies(responseProbe.ref)
+      val response = responseProbe.expectMessageType[GameManager.LobbiesListed]
+      response.lobbies.size shouldBe 0
+    }
+
+    "prevent a player from joining a lobby of a game that's already started" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+      val alice = Player("alice")
+      val bob = Player("bob")
+      val carl = Player("carl")
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
+
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+
+      // Alice creates the lobby
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      val GameManager.GameCreated(gameId) = responseProbe.receiveMessage()
+
+      // Bob joins
+      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbyJoined]
+
+      // Game bgeins
+      gm ! GameManager.StartGame(gameId, alice.id, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.GameStarted]
+
+      // Carl tries to join - should be rejected
+      gm ! GameManager.JoinLobby(gameId, carl, responseProbe.ref)
+      val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
+      error.message should include("game already started or ended")
+    }
+
+    "allow a player to leave a lobby" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+      val alice = Player("alice")
+      val bob = Player("bob")
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
+
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+
+      // Alice creates the lobby
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      val GameManager.GameCreated(gameId) = responseProbe.receiveMessage()
+
+      // Bob joins
+      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbyJoined]
+
+      // Bob leaves
+      gm ! GameManager.LeaveLobby(gameId, bob.id, responseProbe.ref)
+      val bobLeft = responseProbe.expectMessageType[GameManager.LobbyLeft]
+      bobLeft.message should include("left lobby")
+
+      // Alice leaves
+      gm ! GameManager.LeaveLobby(gameId, alice.id, responseProbe.ref)
+      val aliceLeft = responseProbe.expectMessageType[GameManager.LobbyLeft]
+      aliceLeft.message should include("host left")
+    }
+
+    "handle a player trying to leave a nonexistent lobby" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+      val alice = Player("alice")
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
+
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+
+      gm ! GameManager.LeaveLobby("nonexistent", alice.id, responseProbe.ref)
+      val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
+      error.message should include("No such lobby")
     }
   }
 }

--- a/game-service-server/src/test/scala/com/andy327/server/actors/core/GameManagerSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/core/GameManagerSpec.scala
@@ -279,7 +279,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
       gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
 
-      gm ! GameManager.StartGame(gameId, alice.id, responseProbe.ref)
+      gm ! GameManager.StartGame(gameId, alice, responseProbe.ref)
       responseProbe.expectMessage(GameManager.GameStarted(gameId))
 
       val snapshot = persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
@@ -303,7 +303,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
       responseProbe.expectMessageType[GameManager.LobbyJoined]
 
       // Bob tries to start the game
-      gm ! GameManager.StartGame(gameId, bob.id, responseProbe.ref)
+      gm ! GameManager.StartGame(gameId, bob, responseProbe.ref)
       val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
       error.message should include("Only host can start")
     }
@@ -317,7 +317,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.StartGame("nonexistent", alice.id, responseProbe.ref)
+      gm ! GameManager.StartGame("nonexistent", alice, responseProbe.ref)
       val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
       error.message should include("No such game")
     }
@@ -337,7 +337,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
       val GameManager.GameCreated(gameId1) = responseProbe.receiveMessage()
       gm ! GameManager.JoinLobby(gameId1, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
-      gm ! GameManager.StartGame(gameId1, alice.id, responseProbe.ref)
+      gm ! GameManager.StartGame(gameId1, alice, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.GameStarted]
 
       // Game 2: ReadyToStart
@@ -371,7 +371,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
       gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
 
-      gm ! GameManager.StartGame(gameId, alice.id, responseProbe.ref)
+      gm ! GameManager.StartGame(gameId, alice, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.GameStarted]
 
       // game actor sends a GameCompleted message to the GameManager
@@ -419,7 +419,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
       responseProbe.expectMessageType[GameManager.LobbyJoined]
 
       // Game bgeins
-      gm ! GameManager.StartGame(gameId, alice.id, responseProbe.ref)
+      gm ! GameManager.StartGame(gameId, alice, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.GameStarted]
 
       // Carl tries to join - should be rejected
@@ -447,12 +447,12 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
       responseProbe.expectMessageType[GameManager.LobbyJoined]
 
       // Bob leaves
-      gm ! GameManager.LeaveLobby(gameId, bob.id, responseProbe.ref)
+      gm ! GameManager.LeaveLobby(gameId, bob, responseProbe.ref)
       val bobLeft = responseProbe.expectMessageType[GameManager.LobbyLeft]
       bobLeft.message should include("left lobby")
 
       // Alice leaves
-      gm ! GameManager.LeaveLobby(gameId, alice.id, responseProbe.ref)
+      gm ! GameManager.LeaveLobby(gameId, alice, responseProbe.ref)
       val aliceLeft = responseProbe.expectMessageType[GameManager.LobbyLeft]
       aliceLeft.message should include("host left")
     }
@@ -466,7 +466,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.LeaveLobby("nonexistent", alice.id, responseProbe.ref)
+      gm ! GameManager.LeaveLobby("nonexistent", alice, responseProbe.ref)
       val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
       error.message should include("No such lobby")
     }

--- a/game-service-server/src/test/scala/com/andy327/server/actors/core/GameManagerSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/core/GameManagerSpec.scala
@@ -158,7 +158,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId) = responseProbe.expectMessageType[GameManager.LobbyCreated]
+      val GameManager.LobbyCreated(gameId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
       val response = responseProbe.expectMessageType[GameManager.LobbyJoined]
@@ -174,7 +174,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId) = responseProbe.expectMessageType[GameManager.LobbyCreated]
+      val GameManager.LobbyCreated(gameId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       gm ! GameManager.JoinLobby(gameId, alice, responseProbe.ref)
       val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
@@ -213,7 +213,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
 
       // Alice creates the lobby
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId) = responseProbe.receiveMessage()
+      val GameManager.LobbyCreated(gameId, _) = responseProbe.receiveMessage()
 
       // Bob joins
       gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
@@ -238,7 +238,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
 
       // Alice creates the lobby
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId) = responseProbe.receiveMessage()
+      val GameManager.LobbyCreated(gameId, _) = responseProbe.receiveMessage()
 
       // Bob joins
       gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
@@ -265,7 +265,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId) = responseProbe.receiveMessage()
+      val GameManager.LobbyCreated(gameId, _) = responseProbe.receiveMessage()
 
       gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
@@ -288,7 +288,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId) = responseProbe.receiveMessage()
+      val GameManager.LobbyCreated(gameId, _) = responseProbe.receiveMessage()
 
       gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
@@ -325,7 +325,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
 
       // Game 1: InProgress
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId1) = responseProbe.receiveMessage()
+      val GameManager.LobbyCreated(gameId1, _) = responseProbe.receiveMessage()
       gm ! GameManager.JoinLobby(gameId1, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
       gm ! GameManager.StartGame(gameId1, alice, responseProbe.ref)
@@ -333,13 +333,13 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
 
       // Game 2: ReadyToStart
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId2) = responseProbe.receiveMessage()
+      val GameManager.LobbyCreated(gameId2, _) = responseProbe.receiveMessage()
       gm ! GameManager.JoinLobby(gameId2, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
 
       // Game 2: WaitingForPlayers
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId3) = responseProbe.receiveMessage()
+      val GameManager.LobbyCreated(gameId3, _) = responseProbe.receiveMessage()
 
       gm ! GameManager.ListLobbies(responseProbe.ref)
       val response = responseProbe.expectMessageType[GameManager.LobbiesListed]
@@ -357,7 +357,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId) = responseProbe.receiveMessage()
+      val GameManager.LobbyCreated(gameId, _) = responseProbe.receiveMessage()
 
       gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
@@ -402,7 +402,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
 
       // Alice creates the lobby
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId) = responseProbe.receiveMessage()
+      val GameManager.LobbyCreated(gameId, _) = responseProbe.receiveMessage()
 
       // Bob joins
       gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
@@ -444,7 +444,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId) = responseProbe.receiveMessage()
+      val GameManager.LobbyCreated(gameId, _) = responseProbe.receiveMessage()
 
       // Bob joins
       gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)

--- a/game-service-server/src/test/scala/com/andy327/server/actors/persistence/PostgresActorSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/persistence/PostgresActorSpec.scala
@@ -1,5 +1,7 @@
 package com.andy327.server.actors.persistence
 
+import java.util.UUID
+
 import scala.util.control.NoStackTrace
 
 import cats.effect.IO
@@ -8,7 +10,7 @@ import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
-import com.andy327.model.core.{Game, GameType}
+import com.andy327.model.core.{Game, GameType, PlayerId}
 import com.andy327.model.tictactoe.TicTacToe
 import com.andy327.persistence.db.GameRepository
 
@@ -34,7 +36,9 @@ class PostgresActorSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike w
     override def loadAllGames(): IO[Map[String, (GameType, Game[_, _, _, _, _])]] = throw loadError
   }
 
-  val freshGame: TicTacToe = TicTacToe.empty("alice", "bob")
+  val alice: PlayerId = UUID.randomUUID()
+  val bob: PlayerId = UUID.randomUUID()
+  val freshGame: TicTacToe = TicTacToe.empty(alice, bob)
 
   "PostgresActor" should {
     "reply with SnapshotLoaded on successful LoadSnapshot" in {

--- a/game-service-server/src/test/scala/com/andy327/server/actors/tictactoe/TicTacToeActorSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/tictactoe/TicTacToeActorSpec.scala
@@ -3,22 +3,27 @@ package com.andy327.server.actors.tictactoe
 import scala.util.control.NoStackTrace
 
 import org.apache.pekko.actor.testkit.typed.scaladsl.ActorTestKit
+import org.apache.pekko.actor.typed.ActorRef
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.model.core.Game
 import com.andy327.model.tictactoe.{GameError, Location, O, TicTacToe, X}
+import com.andy327.server.actors.core.GameManager
 import com.andy327.server.actors.persistence.PersistenceProtocol
 import com.andy327.server.http.json.{GameState, TicTacToeState}
+import com.andy327.server.lobby.GameLifecycleStatus
 
 class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
   private val testKit = ActorTestKit()
   import testKit._
 
+  private val dummyGameManager: ActorRef[GameManager.Command] = createTestProbe[GameManager.Command]().ref
+
   "TicTacToeActor" should {
     "return an empty 3×3 board on GetState" in {
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
-      val (_, behavior) = TicTacToeActor.create("game-1", Seq("alice", "bob"), persistProbe.ref)
+      val (_, behavior) = TicTacToeActor.create("game-1", Seq("alice", "bob"), persistProbe.ref, dummyGameManager)
       val actor = spawn(behavior)
 
       val replyProbe = createTestProbe[Either[GameError, GameState]]()
@@ -41,7 +46,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
 
       val thrown = intercept[IllegalArgumentException] {
-        TicTacToeActor.create("bad-game", Seq("only-one-player"), persistProbe.ref)
+        TicTacToeActor.create("bad-game", Seq("only-one-player"), persistProbe.ref, dummyGameManager)
       }
 
       thrown.getMessage should include("Tic-Tac-Toe needs exactly two players")
@@ -53,8 +58,8 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
         playerO = "bob",
         board = Vector(
           Vector(Some(X), Some(O), Some(X)),
-          Vector(None, Some(O), Some(X)),
-          Vector(None, Some(O), None)
+          Vector(Some(O), Some(O), Some(X)),
+          Vector(None, None, Some(X))
         ),
         currentPlayer = O,
         winner = Some(X),
@@ -64,7 +69,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
 
       // build behavior from snapshot and spawn it
-      val behavior = TicTacToeActor.fromSnapshot("restored-game", snapshotState, persistProbe.ref)
+      val behavior = TicTacToeActor.fromSnapshot("restored-game", snapshotState, persistProbe.ref, dummyGameManager)
       val actor = spawn(behavior)
 
       // ask for state and verify it matches the snapshot
@@ -96,7 +101,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
 
       // build behavior from snapshot and spawn it
-      val behavior = TicTacToeActor.fromSnapshot("dummy-game", dummyGame, persistProbe.ref)
+      val behavior = TicTacToeActor.fromSnapshot("dummy-game", dummyGame, persistProbe.ref, dummyGameManager)
       val actor = spawn(behavior)
 
       persistProbe.expectTerminated(actor)
@@ -104,7 +109,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
     "apply a valid move and switch currentPlayer" in {
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
-      val (_, behavior) = TicTacToeActor.create("game-2", Seq("alice", "bob"), persistProbe.ref)
+      val (_, behavior) = TicTacToeActor.create("game-2", Seq("alice", "bob"), persistProbe.ref, dummyGameManager)
       val actor = spawn(behavior)
 
       val replyProbe = createTestProbe[Either[GameError, GameState]]()
@@ -135,7 +140,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
     "reject a move when it is not the player's turn" in {
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
-      val (_, behavior) = TicTacToeActor.create("game-3", Seq("alice", "bob"), persistProbe.ref)
+      val (_, behavior) = TicTacToeActor.create("game-3", Seq("alice", "bob"), persistProbe.ref, dummyGameManager)
       val actor = spawn(behavior)
 
       val replyProbe = createTestProbe[Either[GameError, GameState]]()
@@ -149,7 +154,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
     "reject a move from a player not in the game" in {
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
-      val (_, behavior) = TicTacToeActor.create("game-4", Seq("alice", "bob"), persistProbe.ref)
+      val (_, behavior) = TicTacToeActor.create("game-4", Seq("alice", "bob"), persistProbe.ref, dummyGameManager)
       val actor = spawn(behavior)
 
       val replyProbe = createTestProbe[Either[GameError, GameState]]()
@@ -161,7 +166,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
     "reject an invalid move" in {
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
-      val (_, behavior) = TicTacToeActor.create("game-5", Seq("alice", "bob"), persistProbe.ref)
+      val (_, behavior) = TicTacToeActor.create("game-5", Seq("alice", "bob"), persistProbe.ref, dummyGameManager)
       val actor = spawn(behavior)
 
       val replyProbe = createTestProbe[Either[GameError, GameState]]()
@@ -187,7 +192,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
         isDraw = true
       )
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
-      val actor = spawn(TicTacToeActor.fromSnapshot("game-6", completedGame, persistProbe.ref))
+      val actor = spawn(TicTacToeActor.fromSnapshot("game-6", completedGame, persistProbe.ref, dummyGameManager))
 
       val replyProbe = createTestProbe[Either[GameError, GameState]]()
 
@@ -200,7 +205,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
     "log success and continue when SnapShotSaved succeeds" in {
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
-      val (_, behavior) = TicTacToeActor.create("game-7", Seq("alice", "bob"), persistProbe.ref)
+      val (_, behavior) = TicTacToeActor.create("game-7", Seq("alice", "bob"), persistProbe.ref, dummyGameManager)
       val actor = spawn(behavior)
 
       val replyProbe = createTestProbe[Either[GameError, GameState]]()
@@ -224,7 +229,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
     "log error and continue when SnapshotSaved fails" in {
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
-      val (_, behavior) = TicTacToeActor.create("game-8", Seq("alice", "bob"), persistProbe.ref)
+      val (_, behavior) = TicTacToeActor.create("game-8", Seq("alice", "bob"), persistProbe.ref, dummyGameManager)
       val actor = spawn(behavior)
 
       // Send SnapshotSaved failure message
@@ -241,7 +246,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
     "log success and continue when SnapshotLoaded succeeds" in {
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
-      val (_, behavior) = TicTacToeActor.create("game-9", Seq("alice", "bob"), persistProbe.ref)
+      val (_, behavior) = TicTacToeActor.create("game-9", Seq("alice", "bob"), persistProbe.ref, dummyGameManager)
       val actor = spawn(behavior)
 
       // Simulate successful snapshot load (with no restored game)
@@ -257,7 +262,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
     "log error and continue when SnapshotLoaded fails" in {
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
-      val (_, behavior) = TicTacToeActor.create("game-10", Seq("alice", "bob"), persistProbe.ref)
+      val (_, behavior) = TicTacToeActor.create("game-10", Seq("alice", "bob"), persistProbe.ref, dummyGameManager)
       val actor = spawn(behavior)
 
       // Simulate a snapshot load failure
@@ -270,6 +275,32 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
       val result = replyProbe.receiveMessage()
       result shouldBe a[Right[_, _]]
+    }
+
+    "notify the GameManager when a game completes" in {
+      val persistProbe = createTestProbe[PersistenceProtocol.Command]()
+      val gameManagerProbe = createTestProbe[GameManager.Command]()
+      val (_, behavior) = TicTacToeActor.create("game-11", Seq("alice", "bob"), persistProbe.ref, gameManagerProbe.ref)
+      val actor = spawn(behavior)
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+
+      val moves = Seq(
+        ("alice", Location(0, 0)), // X
+        ("bob", Location(1, 0)), // O
+        ("alice", Location(0, 1)), // X
+        ("bob", Location(1, 1)), // O
+        ("alice", Location(0, 2)) // X wins
+      )
+
+      moves.foreach { case (player, loc) =>
+        actor ! TicTacToeActor.MakeMove(player, loc, replyProbe.ref)
+        replyProbe.receiveMessage() shouldBe a[Right[_, _]]
+        val _ = persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+      }
+
+      // Confirm GameManager was notified
+      val completedMsg = gameManagerProbe.receiveMessage()
+      completedMsg shouldBe GameManager.GameCompleted("game-11", GameLifecycleStatus.Completed)
     }
   }
 }

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -1,0 +1,185 @@
+package com.andy327.server.http.json
+
+import java.util.UUID
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import spray.json._
+
+import com.andy327.model.core.GameType
+import com.andy327.model.tictactoe.TicTacToe
+import com.andy327.server.actors.core.GameManager.{ErrorResponse, LobbyCreated, LobbyJoined}
+import com.andy327.server.http.json.GameStateConverters
+import com.andy327.server.http.json.TicTacToeState._
+import com.andy327.server.lobby._
+
+class SerializationSpec extends AnyWordSpec with Matchers {
+  import JsonProtocol._
+
+  "UUID RootJsonFormat" should {
+    "deserialize a valid UUID string" in {
+      val uuid = UUID.randomUUID()
+      JsString(uuid.toString).convertTo[UUID] shouldBe uuid
+    }
+
+    "fail on invalid UUID string" in {
+      val invalid = JsString("not-a-uuid")
+      val ex = intercept[DeserializationException] {
+        invalid.convertTo[UUID]
+      }
+      ex.getMessage should include("Invalid UUID string")
+    }
+
+    "fail on non-string JSON value" in {
+      val invalid = JsNumber(42)
+      val ex = intercept[DeserializationException] {
+        invalid.convertTo[UUID]
+      }
+      ex.getMessage should include("Expected UUID string")
+    }
+  }
+
+  "IncomingPlayer JSON format" should {
+    "round-trip with id" in {
+      val incoming = IncomingPlayer(Some(UUID.randomUUID()), "sam")
+      val json = incoming.toJson
+      json.convertTo[IncomingPlayer] shouldBe incoming
+    }
+
+    "round-trip without id" in {
+      val incoming = IncomingPlayer(None, "guest")
+      val json = incoming.toJson
+      json.convertTo[IncomingPlayer] shouldBe incoming
+    }
+  }
+
+  "Player JSON format" should {
+    "round-trip serialize and deserialize" in {
+      val player = Player(UUID.randomUUID(), "bob")
+      val json = player.toJson
+      json.convertTo[Player] shouldBe player
+    }
+  }
+
+  "GameType RootJsonFormat" should {
+    "deserialize a known game type" in {
+      JsString("TicTacToe").convertTo[GameType] shouldBe GameType.TicTacToe
+    }
+
+    "fail on unknown game type string" in {
+      val ex = intercept[DeserializationException] {
+        JsString("UnimplementedGame").convertTo[GameType]
+      }
+      ex.getMessage should include("Unknown GameType")
+    }
+
+    "fail on non-string game type JSON" in {
+      val ex = intercept[DeserializationException] {
+        JsNumber(42).convertTo[GameType]
+      }
+      ex.getMessage should include("Expected GameType string")
+    }
+  }
+
+  "GameLifecycleStatus RootJsonFormat" should {
+    "serialize and deserialize all known values" in {
+      val values: Seq[GameLifecycleStatus] = Seq(
+        GameLifecycleStatus.WaitingForPlayers,
+        GameLifecycleStatus.ReadyToStart,
+        GameLifecycleStatus.InProgress,
+        GameLifecycleStatus.Completed,
+        GameLifecycleStatus.Cancelled
+      )
+
+      values.foreach { status =>
+        val json = status.toJson
+        json.convertTo[GameLifecycleStatus] shouldBe status
+      }
+    }
+
+    "fail on unknown string" in {
+      val ex = intercept[DeserializationException] {
+        JsString("Paused").convertTo[GameLifecycleStatus]
+      }
+      ex.getMessage should include("Unknown GameLifecycleStatus")
+    }
+
+    "fail on non-string JSON" in {
+      val ex = intercept[DeserializationException] {
+        JsArray(Vector.empty).convertTo[GameLifecycleStatus]
+      }
+      ex.getMessage should include("Expected GameLifecycleStatus as string")
+    }
+  }
+
+  "GameMetadata JSON format" should {
+    "round-trip serialize and deserialize" in {
+      val host = Player("host")
+      val joiner = Player("guest")
+      val metadata = GameMetadata(
+        gameId = "game-id",
+        gameType = GameType.TicTacToe,
+        players = Map(host.id -> host, joiner.id -> joiner),
+        hostId = host.id,
+        status = GameLifecycleStatus.ReadyToStart
+      )
+      val json = metadata.toJson
+      json.convertTo[GameMetadata] shouldBe metadata
+    }
+  }
+
+  "LobbyCreated JSON format" should {
+    "round-trip serialize and deserialize" in {
+      val lobby = LobbyCreated("game-id", Player(UUID.randomUUID(), "host"))
+      val json = lobby.toJson
+      json.convertTo[LobbyCreated] shouldBe lobby
+    }
+  }
+
+  "LobbyJoined JSON format" should {
+    "round-trip serialize and deserialize" in {
+      val host = Player("host")
+      val joiner = Player("guest")
+      val lobby = LobbyJoined(
+        gameId = "game-id",
+        metadata = GameMetadata(
+          gameId = "game-id",
+          gameType = GameType.TicTacToe,
+          players = Map(host.id -> host, joiner.id -> joiner),
+          hostId = host.id,
+          status = GameLifecycleStatus.InProgress
+        ),
+        joinedPlayer = joiner
+      )
+      val json = lobby.toJson
+      json.convertTo[LobbyJoined] shouldBe lobby
+    }
+  }
+
+  "ErrorResponse JSON format" should {
+    "round-trip serialize and deserialize" in {
+      val error = ErrorResponse("Something went wrong")
+      val json = error.toJson
+      json.convertTo[ErrorResponse] shouldBe error
+    }
+  }
+
+  "TicTacToeMove JSON format" should {
+    "round-trip serialize and deserialize" in {
+      val move = TicTacToeMove(UUID.randomUUID(), row = 1, col = 2)
+      val json = move.toJson
+      json.convertTo[TicTacToeMove] shouldBe move
+    }
+  }
+
+  "TicTacToeState view" should {
+    "round-trip serialize and deserialize" in {
+      val alice = Player("alice")
+      val bob = Player("bob")
+      val game = TicTacToe.empty(alice.id, bob.id)
+      val view = GameStateConverters.serializeGame(game)
+      val json = view.toJson
+      json.convertTo[TicTacToeState] shouldBe view
+    }
+  }
+}

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/TicTacToeRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/TicTacToeRoutesSpec.scala
@@ -47,7 +47,7 @@ class TicTacToeRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteT
     }
 
     "join a lobby with a second player" in {
-      val host = Player(UUID.randomUUID(), "alice")
+      val host = Player("alice")
       val hostEntity = HttpEntity(ContentTypes.`application/json`, host.toJson.compactPrint)
       val gameId = Post("/tictactoe/lobby", hostEntity) ~> routes ~> check {
         responseAs[GameManager.LobbyCreated].gameId
@@ -63,19 +63,19 @@ class TicTacToeRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteT
     }
 
     "not allow too many players to join a lobby" in {
-      val host = Player(UUID.randomUUID(), "alice")
+      val host = Player("alice")
       val hostEntity = HttpEntity(ContentTypes.`application/json`, host.toJson.compactPrint)
       val gameId = Post("/tictactoe/lobby", hostEntity) ~> routes ~> check {
         responseAs[GameManager.LobbyCreated].gameId
       }
 
-      val player2 = Player(UUID.randomUUID(), "bob")
+      val player2 = Player("bob")
       val join1 = HttpEntity(ContentTypes.`application/json`, player2.toJson.compactPrint)
       Post(s"/tictactoe/lobby/$gameId/join", join1) ~> routes ~> check {
         status shouldBe StatusCodes.OK
       }
 
-      val player3 = Player(UUID.randomUUID(), "carl")
+      val player3 = Player("carl")
       val join2 = HttpEntity(ContentTypes.`application/json`, player3.toJson.compactPrint)
       Post(s"/tictactoe/lobby/$gameId/join", join2) ~> routes ~> check {
         status shouldBe StatusCodes.BadRequest
@@ -83,19 +83,19 @@ class TicTacToeRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteT
     }
 
     "start a game after a lobby has enough players" in {
-      val host = Player(UUID.randomUUID(), "alice")
+      val host = Player("alice")
       val hostEntity = HttpEntity(ContentTypes.`application/json`, host.toJson.compactPrint)
       val gameId = Post("/tictactoe/lobby", hostEntity) ~> routes ~> check {
         responseAs[GameManager.LobbyCreated].gameId
       }
 
-      val player2 = Player(UUID.randomUUID(), "bob")
+      val player2 = Player("bob")
       val joinEntity = HttpEntity(ContentTypes.`application/json`, player2.toJson.compactPrint)
       Post(s"/tictactoe/lobby/$gameId/join", joinEntity) ~> routes ~> check {
         status shouldBe StatusCodes.OK
       }
 
-      val startEntity = HttpEntity(ContentTypes.`application/json`, host.toJson.compactPrint)
+      val startEntity = HttpEntity(ContentTypes.`application/json`, host.id.toJson.compactPrint)
       Post(s"/tictactoe/lobby/$gameId/start", startEntity) ~> routes ~> check {
         status shouldBe StatusCodes.OK
         responseAs[String] shouldBe gameId
@@ -103,13 +103,13 @@ class TicTacToeRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteT
     }
 
     "reject starting a game with not enough players" in {
-      val host = Player(UUID.randomUUID(), "alice")
+      val host = Player("alice")
       val hostEntity = HttpEntity(ContentTypes.`application/json`, host.toJson.compactPrint)
       val gameId = Post("/tictactoe/lobby", hostEntity) ~> routes ~> check {
         responseAs[GameManager.LobbyCreated].gameId
       }
 
-      val startEntity = HttpEntity(ContentTypes.`application/json`, host.toJson.compactPrint)
+      val startEntity = HttpEntity(ContentTypes.`application/json`, host.id.toJson.compactPrint)
       Post(s"/tictactoe/lobby/$gameId/start", startEntity) ~> routes ~> check {
         status shouldBe StatusCodes.BadRequest
         responseAs[String] should include("Only host can start, and game must be ready to start")
@@ -118,7 +118,7 @@ class TicTacToeRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteT
 
     "list all lobbies" in {
       // Create a new lobby
-      val player = Player(UUID.randomUUID(), "alice")
+      val player = Player("alice")
       val requestEntity = HttpEntity(ContentTypes.`application/json`, player.toJson.compactPrint)
       val gameId = Post("/tictactoe/lobby", requestEntity) ~> routes ~> check {
         responseAs[GameManager.LobbyCreated].gameId
@@ -132,19 +132,19 @@ class TicTacToeRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteT
     }
 
     "submit a move to a valid game" in {
-      val host = Player(UUID.randomUUID(), "alice")
+      val host = Player("alice")
       val hostEntity = HttpEntity(ContentTypes.`application/json`, host.toJson.compactPrint)
       val gameId = Post("/tictactoe/lobby", hostEntity) ~> routes ~> check {
         responseAs[GameManager.LobbyCreated].gameId
       }
 
-      val player2 = Player(UUID.randomUUID(), "bob")
+      val player2 = Player("bob")
       val joinEntity = HttpEntity(ContentTypes.`application/json`, player2.toJson.compactPrint)
       Post(s"/tictactoe/lobby/$gameId/join", joinEntity) ~> routes ~> check {
         status shouldBe StatusCodes.OK
       }
 
-      val startEntity = HttpEntity(ContentTypes.`application/json`, host.toJson.compactPrint)
+      val startEntity = HttpEntity(ContentTypes.`application/json`, host.id.toJson.compactPrint)
       Post(s"/tictactoe/lobby/$gameId/start", startEntity) ~> routes ~> check {
         status shouldBe StatusCodes.OK
       }
@@ -167,19 +167,19 @@ class TicTacToeRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteT
     }
 
     "fetch game status" in {
-      val host = Player(UUID.randomUUID(), "alice")
+      val host = Player("alice")
       val hostEntity = HttpEntity(ContentTypes.`application/json`, host.toJson.compactPrint)
       val gameId = Post("/tictactoe/lobby", hostEntity) ~> routes ~> check {
         responseAs[GameManager.LobbyCreated].gameId
       }
 
-      val player2 = Player(UUID.randomUUID(), "bob")
+      val player2 = Player("bob")
       val joinEntity = HttpEntity(ContentTypes.`application/json`, player2.toJson.compactPrint)
       Post(s"/tictactoe/lobby/$gameId/join", joinEntity) ~> routes ~> check {
         status shouldBe StatusCodes.OK
       }
 
-      val startEntity = HttpEntity(ContentTypes.`application/json`, host.toJson.compactPrint)
+      val startEntity = HttpEntity(ContentTypes.`application/json`, host.id.toJson.compactPrint)
       Post(s"/tictactoe/lobby/$gameId/start", startEntity) ~> routes ~> check {
         status shouldBe StatusCodes.OK
       }
@@ -212,7 +212,7 @@ class TicTacToeRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteT
       }
 
     "return 500 for unexpected responses" in {
-      val dummyId = Player(UUID.randomUUID(), "dummy")
+      val dummyId = Player("dummy")
       val dummyState = TicTacToeState(Vector(), "X", None, draw = false)
       val unexpectedBehavior = Behaviors.receiveMessage[GameManager.Command] {
         case GameManager.CreateLobby(_, _, replyTo) =>
@@ -241,7 +241,9 @@ class TicTacToeRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteT
       val dummySystem = ActorSystem(unexpectedBehavior, "UnexpectedResponseSystem")
       val errorRoutes = new TicTacToeRoutes(dummySystem).routes
 
-      val playerJson = Player(UUID.randomUUID(), "alice").toJson.compactPrint
+      val player = Player("alice")
+      val hostIdJson = player.id.toJson.compactPrint
+      val playerJson = player.toJson.compactPrint
       val moveJson = TicTacToeMove(UUID.randomUUID(), 0, 0).toJson.compactPrint
 
       val requests = Table(
@@ -253,7 +255,7 @@ class TicTacToeRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteT
         ),
         (
           "POST /lobby/start",
-          Post("/tictactoe/lobby/fake-id/start").withEntity(ContentTypes.`application/json`, playerJson)
+          Post("/tictactoe/lobby/fake-id/start").withEntity(ContentTypes.`application/json`, hostIdJson)
         ),
         ("GET /lobbies", Get("/tictactoe/lobbies")),
         ("POST /move", Post("/tictactoe/fake-id/move").withEntity(ContentTypes.`application/json`, moveJson)),

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/TicTacToeRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/TicTacToeRoutesSpec.scala
@@ -1,21 +1,27 @@
 package com.andy327.server.http.routes
 
+import java.util.UUID
+
 import scala.concurrent.duration._
 
 import org.apache.pekko.actor.testkit.typed.scaladsl.ActorTestKit
 import org.apache.pekko.actor.typed.ActorSystem
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
-import org.apache.pekko.http.scaladsl.model.{ContentTypes, StatusCodes}
+import org.apache.pekko.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import org.apache.pekko.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
 import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
 import org.apache.pekko.util.Timeout
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.wordspec.AnyWordSpec
 import spray.json._
 
+import com.andy327.model.core.PlayerId
 import com.andy327.server.actors.core.{GameManager, InMemRepo}
 import com.andy327.server.actors.persistence.PersistenceProtocol
 import com.andy327.server.http.json.JsonProtocol._
 import com.andy327.server.http.json.{TicTacToeMove, TicTacToeState}
+import com.andy327.server.lobby.{GameMetadata, Player}
 
 class TicTacToeRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
   private val testKit = ActorTestKit()
@@ -29,71 +35,168 @@ class TicTacToeRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteT
   private val routes = new TicTacToeRoutes(typedSystem).routes
 
   "TicTacToeRoutes" should {
-    "create a new TicTacToe game via POST /tictactoe?playerX=alice&playerO=bob" in
-      Post("/tictactoe?playerX=alice&playerO=bob") ~> routes ~> check {
+    "create a new lobby" in {
+      val player = Player(UUID.randomUUID(), "alice")
+      val requestEntity = HttpEntity(ContentTypes.`application/json`, player.toJson.compactPrint)
+      Post("/tictactoe/lobby", requestEntity) ~> routes ~> check {
         status shouldBe StatusCodes.OK
-        responseAs[String].nonEmpty shouldBe true // gameId as plain text
-      }
-
-    "make a valid move via POST /tictactoe/{gameId}/move" in
-      // Create game first
-      Post("/tictactoe?playerX=alice&playerO=bob") ~> routes ~> check {
-        status shouldBe StatusCodes.OK
-        val gameId = responseAs[String]
-
-        val move = TicTacToeMove("alice", 0, 0)
-        val moveJson = move.toJson.compactPrint
-
-        Post(s"/tictactoe/$gameId/move").withEntity(ContentTypes.`application/json`, moveJson) ~> routes ~> check {
-          status shouldBe StatusCodes.OK
-          val gameState = responseAs[String].parseJson.convertTo[TicTacToeState]
-          gameState.board(0)(0) shouldBe "X"
-        }
-      }
-
-    "reject a move from an unknown player" in
-      Post("/tictactoe?playerX=alice&playerO=bob") ~> routes ~> check {
-        val gameId = responseAs[String]
-
-        val badMove = TicTacToeMove("eve", 1, 1)
-        val badMoveJson = badMove.toJson.compactPrint
-
-        Post(s"/tictactoe/$gameId/move").withEntity(ContentTypes.`application/json`, badMoveJson) ~> routes ~> check {
-          status shouldBe StatusCodes.NotFound
-          responseAs[String].toLowerCase should include("unknown player")
-        }
-      }
-
-    "get current state via GET /tictactoe/{gameId}/status" in
-      Post("/tictactoe?playerX=alice&playerO=bob") ~> routes ~> check {
-        val gameId = responseAs[String]
-
-        Get(s"/tictactoe/$gameId/status") ~> routes ~> check {
-          status shouldBe StatusCodes.OK
-          val gameState = responseAs[String].parseJson.convertTo[TicTacToeState]
-          gameState.currentPlayer shouldBe "X"
-        }
-      }
-
-    "return 400 if game creation fails with ErrorResponse" in {
-      val errorBehavior = Behaviors.receiveMessage[GameManager.Command] {
-        case GameManager.CreateGame(_, _, replyTo) =>
-          replyTo ! GameManager.ErrorResponse("Error in GameManager")
-          Behaviors.same
-        case _ => Behaviors.same
-      }
-
-      val dummySystem = ActorSystem(errorBehavior, "ErrorResponseSystem")
-      val errorRoutes = new TicTacToeRoutes(dummySystem).routes
-
-      Post("/tictactoe?playerX=alice&playerO=bob") ~> errorRoutes ~> check {
-        status shouldBe StatusCodes.BadRequest
-        responseAs[String] should include("Error in GameManager")
+        responseAs[String].length should be > 0
       }
     }
 
+    "join a lobby with a second player" in {
+      val host = Player(UUID.randomUUID(), "alice")
+      val hostEntity = HttpEntity(ContentTypes.`application/json`, host.toJson.compactPrint)
+      val gameId = Post("/tictactoe/lobby", hostEntity) ~> routes ~> check {
+        responseAs[String]
+      }
+
+      val player2 = Player(UUID.randomUUID(), "bob")
+      val joinEntity = HttpEntity(ContentTypes.`application/json`, player2.toJson.compactPrint)
+      Post(s"/tictactoe/lobby/$gameId/join", joinEntity) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+        val metadata = responseAs[GameMetadata]
+        metadata.players.values.toSet should contain only (host, player2)
+      }
+    }
+
+    "not allow too many players to join a lobby" in {
+      val host = Player(UUID.randomUUID(), "alice")
+      val hostEntity = HttpEntity(ContentTypes.`application/json`, host.toJson.compactPrint)
+      val gameId = Post("/tictactoe/lobby", hostEntity) ~> routes ~> check {
+        responseAs[String]
+      }
+
+      val player2 = Player(UUID.randomUUID(), "bob")
+      val join1 = HttpEntity(ContentTypes.`application/json`, player2.toJson.compactPrint)
+      Post(s"/tictactoe/lobby/$gameId/join", join1) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+      }
+
+      val player3 = Player(UUID.randomUUID(), "carl")
+      val join2 = HttpEntity(ContentTypes.`application/json`, player3.toJson.compactPrint)
+      Post(s"/tictactoe/lobby/$gameId/join", join2) ~> routes ~> check {
+        status shouldBe StatusCodes.BadRequest
+      }
+    }
+
+    "start a game after a lobby has enough players" in {
+      val host = Player(UUID.randomUUID(), "alice")
+      val hostEntity = HttpEntity(ContentTypes.`application/json`, host.toJson.compactPrint)
+      val gameId = Post("/tictactoe/lobby", hostEntity) ~> routes ~> check {
+        responseAs[String]
+      }
+
+      val player2 = Player(UUID.randomUUID(), "bob")
+      val joinEntity = HttpEntity(ContentTypes.`application/json`, player2.toJson.compactPrint)
+      Post(s"/tictactoe/lobby/$gameId/join", joinEntity) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+      }
+
+      val startEntity = HttpEntity(ContentTypes.`application/json`, host.toJson.compactPrint)
+      Post(s"/tictactoe/lobby/$gameId/start", startEntity) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+        responseAs[String] shouldBe gameId
+      }
+    }
+
+    "reject starting a game with not enough players" in {
+      val host = Player(UUID.randomUUID(), "alice")
+      val hostEntity = HttpEntity(ContentTypes.`application/json`, host.toJson.compactPrint)
+      val gameId = Post("/tictactoe/lobby", hostEntity) ~> routes ~> check {
+        responseAs[String]
+      }
+
+      val startEntity = HttpEntity(ContentTypes.`application/json`, host.toJson.compactPrint)
+      Post(s"/tictactoe/lobby/$gameId/start", startEntity) ~> routes ~> check {
+        status shouldBe StatusCodes.BadRequest
+        responseAs[String] should include("Only host can start, and game must be ready to start")
+      }
+    }
+
+    "list all lobbies" in {
+      // Create a new lobby
+      val player = Player(UUID.randomUUID(), "alice")
+      val requestEntity = HttpEntity(ContentTypes.`application/json`, player.toJson.compactPrint)
+      val gameId = Post("/tictactoe/lobby", requestEntity) ~> routes ~> check {
+        responseAs[String]
+      }
+
+      // Check for lobby in list of active lobbies
+      Get("/tictactoe/lobbies") ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+        responseAs[List[GameMetadata]].map(_.gameId) should contain(gameId)
+      }
+    }
+
+    "submit a move to a valid game" in {
+      val host = Player(UUID.randomUUID(), "alice")
+      val hostEntity = HttpEntity(ContentTypes.`application/json`, host.toJson.compactPrint)
+      val gameId = Post("/tictactoe/lobby", hostEntity) ~> routes ~> check {
+        responseAs[String]
+      }
+
+      val player2 = Player(UUID.randomUUID(), "bob")
+      val joinEntity = HttpEntity(ContentTypes.`application/json`, player2.toJson.compactPrint)
+      Post(s"/tictactoe/lobby/$gameId/join", joinEntity) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+      }
+
+      val startEntity = HttpEntity(ContentTypes.`application/json`, host.toJson.compactPrint)
+      Post(s"/tictactoe/lobby/$gameId/start", startEntity) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+      }
+
+      val move = TicTacToeMove(host.id, 0, 0)
+      val moveEntity = HttpEntity(ContentTypes.`application/json`, move.toJson.compactPrint)
+      Post(s"/tictactoe/$gameId/move", moveEntity) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+        val gameState = responseAs[String].parseJson.convertTo[TicTacToeState]
+        gameState.board(0)(0) shouldBe "X"
+      }
+    }
+
+    "fail to move in a nonexistent game" in {
+      val move = TicTacToeMove(UUID.randomUUID(), 0, 0)
+      val moveEntity = HttpEntity(ContentTypes.`application/json`, move.toJson.compactPrint)
+      Post(s"/tictactoe/nonexistent/move", moveEntity) ~> routes ~> check {
+        status shouldBe StatusCodes.NotFound
+      }
+    }
+
+    "fetch game status" in {
+      val host = Player(UUID.randomUUID(), "alice")
+      val hostEntity = HttpEntity(ContentTypes.`application/json`, host.toJson.compactPrint)
+      val gameId = Post("/tictactoe/lobby", hostEntity) ~> routes ~> check {
+        responseAs[String]
+      }
+
+      val player2 = Player(UUID.randomUUID(), "bob")
+      val joinEntity = HttpEntity(ContentTypes.`application/json`, player2.toJson.compactPrint)
+      Post(s"/tictactoe/lobby/$gameId/join", joinEntity) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+      }
+
+      val startEntity = HttpEntity(ContentTypes.`application/json`, host.toJson.compactPrint)
+      Post(s"/tictactoe/lobby/$gameId/start", startEntity) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+      }
+
+      Get(s"/tictactoe/$gameId/status") ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+        val gameState = responseAs[String].parseJson.convertTo[TicTacToeState]
+        gameState.currentPlayer shouldBe "X"
+      }
+    }
+
+    "return 404 for status of unknown game" in
+      Get("/tictactoe/nonexistent/status") ~> routes ~> check {
+        status shouldBe StatusCodes.NotFound
+      }
+
     "return 404 for invalid game ID on move" in {
-      val move = TicTacToeMove("alice", 0, 0)
+      val alice: PlayerId = UUID.randomUUID()
+      val move = TicTacToeMove(alice, 0, 0)
       val moveJson = move.toJson.compactPrint
 
       Post("/tictactoe/invalid-game-id/move").withEntity(ContentTypes.`application/json`, moveJson) ~> routes ~> check {
@@ -107,40 +210,60 @@ class TicTacToeRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteT
       }
 
     "return 500 for unexpected responses" in {
+      val dummyState = TicTacToeState(Vector(), "X", None, draw = false)
       val unexpectedBehavior = Behaviors.receiveMessage[GameManager.Command] {
-        case GameManager.CreateGame(_, _, replyTo) =>
-          val dummyState = TicTacToeState(Vector(), "X", None, false)
-          replyTo ! GameManager.GameStatus(dummyState) // triggers fallback in /tictactoe
+        case GameManager.CreateLobby(_, _, replyTo) =>
+          replyTo ! GameManager.GameStatus(dummyState) // triggers /lobby fallback
           Behaviors.same
+
+        case GameManager.JoinLobby(_, _, replyTo) =>
+          replyTo ! GameManager.LobbyCreated("unexpected") // triggers /join fallback
+          Behaviors.same
+
+        case GameManager.StartGame(_, _, replyTo) =>
+          replyTo ! GameManager.LobbiesListed(Nil) // triggers /start fallback
+          Behaviors.same
+
+        case GameManager.ListLobbies(replyTo) =>
+          replyTo ! GameManager.GameStarted("unexpected") // triggers /lobbies fallback
+          Behaviors.same
+
         case GameManager.ForwardToGame(_, _, Some(replyTo)) =>
-          replyTo ! GameManager.GameCreated("unexpected-id") // triggers fallback in /move and /status
+          replyTo ! GameManager.LobbyCreated("unexpected") // triggers /move + /status fallback
           Behaviors.same
+
         case _ => Behaviors.same
       }
-      val dummySystem = ActorSystem(unexpectedBehavior, "UnexpectedResponseSystem")
-      val dummyMoveJson = TicTacToeMove("alice", 0, 0).toJson.compactPrint
 
+      val dummySystem = ActorSystem(unexpectedBehavior, "UnexpectedResponseSystem")
       val errorRoutes = new TicTacToeRoutes(dummySystem).routes
 
-      // Trigger fallback in /tictactoe route
-      Post("/tictactoe?playerX=alice&playerO=bob") ~> errorRoutes ~> check {
-        status shouldBe StatusCodes.InternalServerError
-        responseAs[String] should include("Unexpected response")
-      }
+      val playerJson = Player(UUID.randomUUID(), "alice").toJson.compactPrint
+      val moveJson = TicTacToeMove(UUID.randomUUID(), 0, 0).toJson.compactPrint
 
-      // Trigger fallback in /move route
-      Post("/tictactoe/fake-id/move").withEntity(
-        ContentTypes.`application/json`,
-        dummyMoveJson
-      ) ~> errorRoutes ~> check {
-        status shouldBe StatusCodes.InternalServerError
-        responseAs[String] should include("Unexpected response")
-      }
+      val requests = Table(
+        ("description", "request"),
+        ("POST /lobby", Post("/tictactoe/lobby").withEntity(ContentTypes.`application/json`, playerJson)),
+        (
+          "POST /lobby/join",
+          Post("/tictactoe/lobby/fake-id/join").withEntity(ContentTypes.`application/json`, playerJson)
+        ),
+        (
+          "POST /lobby/start",
+          Post("/tictactoe/lobby/fake-id/start").withEntity(ContentTypes.`application/json`, playerJson)
+        ),
+        ("GET /lobbies", Get("/tictactoe/lobbies")),
+        ("POST /move", Post("/tictactoe/fake-id/move").withEntity(ContentTypes.`application/json`, moveJson)),
+        ("GET /status", Get("/tictactoe/fake-id/status"))
+      )
 
-      // Trigger fallback in /status route
-      Get("/tictactoe/fake-id/status") ~> errorRoutes ~> check {
-        status shouldBe StatusCodes.InternalServerError
-        responseAs[String] should include("Unexpected response")
+      forAll(requests) { (description, req) =>
+        withClue(s"$description should return 500 with fallback message") {
+          req ~> errorRoutes ~> check {
+            status shouldBe StatusCodes.InternalServerError
+            responseAs[String] should include("Unexpected")
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
* adds support for creating and joining lobbies
* games are started now once a lobby is created and has sufficient players
* moves and other operations are tracked by a player's UUID instead of a name
* lobby requests return the player uuid, generating a new id when necessary
* round-trip serialization tests are handled in a separate Spec