### PR TITLE
add websocket support with PlayerActor fan-out (closes #7, closes #8)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,7 +89,8 @@ lazy val server = (project in file(s"$baseName-server"))
       "org.slf4j" % "slf4j-simple" % versions("slf4j"),
       "org.scalatest" %% "scalatest" % versions("scalatest") % Test,
       "org.apache.pekko" %% "pekko-actor-testkit-typed" % versions("pekko") % Test,
-      "org.apache.pekko" %% "pekko-http-testkit" % versions("pekko-http") % Test
+      "org.apache.pekko" %% "pekko-http-testkit" % versions("pekko-http") % Test,
+      "org.apache.pekko" %% "pekko-stream-testkit" % versions("pekko") % Test
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -81,6 +81,7 @@ lazy val server = (project in file(s"$baseName-server"))
       "org.apache.pekko" %% "pekko-actor-typed" % versions("pekko"),
       "org.apache.pekko" %% "pekko-http" % versions("pekko-http"),
       "org.apache.pekko" %% "pekko-stream" % versions("pekko"),
+      "org.apache.pekko" %% "pekko-stream-typed" % versions("pekko"),
       "org.apache.pekko" %% "pekko-http-spray-json" % versions("pekko-http"),
       "com.github.jwt-scala" %% "jwt-core" % versions("jwt-scala"),
       "com.github.jwt-scala" %% "jwt-circe" % versions("jwt-scala"),

--- a/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
@@ -21,7 +21,7 @@ import com.andy327.persistence.db.GameRepository
 import com.andy327.persistence.db.postgres.{PostgresGameRepository, PostgresTransactor}
 import com.andy327.server.actors.core.GameManager
 import com.andy327.server.actors.persistence.PostgresActor
-import com.andy327.server.http.routes.{AuthRoutes, GameRoutes, LobbyRoutes}
+import com.andy327.server.http.routes.{AuthRoutes, GameRoutes, LobbyRoutes, WebSocketRoutes}
 
 /**
  * GameServer is the main entry point of the game-service.
@@ -78,7 +78,8 @@ object GameServer {
     val routes = concat(
       new AuthRoutes().routes,
       new LobbyRoutes(system).routes,
-      new GameRoutes(GameType.TicTacToe, system).routes
+      new GameRoutes(GameType.TicTacToe, system).routes,
+      new WebSocketRoutes(system).routes
     )
 
     // Start HTTP server

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/GameManager.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/GameManager.scala
@@ -7,6 +7,7 @@ import cats.effect.unsafe.IORuntime
 
 import org.apache.pekko.actor.typed.scaladsl.{Behaviors, StashBuffer}
 import org.apache.pekko.actor.typed.{ActorRef, Behavior}
+import org.apache.pekko.http.scaladsl.model.ws.Message
 
 import com.andy327.model.core.{Game, GameError, GameId, GameType, PlayerId}
 import com.andy327.persistence.db.GameRepository
@@ -49,7 +50,11 @@ object GameManager {
   final case class RunGameOperation(gameId: GameId, op: GameOperation, replyTo: ActorRef[GameResponse]) extends Command
   final case class SubscribeToLobby(gameId: GameId, playerRef: ActorRef[PlayerActor.Command]) extends Command
   final case class SubscribeToGame(gameId: GameId, playerRef: ActorRef[PlayerActor.Command]) extends Command
-  final case class RegisterPlayer(player: Player, replyTo: ActorRef[ActorRef[PlayerActor.Command]]) extends Command
+  final case class RegisterPlayer(
+      player: Player,
+      wsOut: ActorRef[Message],
+      replyTo: ActorRef[ActorRef[PlayerActor.Command]]
+  ) extends Command
   final case class PlayerDisconnected(playerId: PlayerId) extends Command
 
   final protected[core] case class RestoreGames(games: Map[GameId, (GameType, Game[_, _, _, _, _])]) extends Command
@@ -201,8 +206,8 @@ object GameManager {
           }
           Behaviors.same
 
-        case RegisterPlayer(player, replyTo) =>
-          playerManager ! PlayerManager.RegisterPlayer(player, replyTo)
+        case RegisterPlayer(player, wsOut, replyTo) =>
+          playerManager ! PlayerManager.RegisterPlayer(player, wsOut, replyTo)
           Behaviors.same
 
         case PlayerDisconnected(playerId) =>

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/GameManager.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/GameManager.scala
@@ -27,6 +27,14 @@ import com.andy327.server.lobby.{GameLifecycleStatus, LobbyError, LobbyMetadata,
  *
  * When a game completes, its actor is stopped and the game ID is moved to a completed set. Subsequent status queries
  * for completed games are served directly from the database.
+ *
+ * Actor relationships:
+ *   - Parent: root (top-level, created by [[com.andy327.server.GameServer]])
+ *   - Children: [[LobbyManager]], [[PlayerManager]], one game actor per active game
+ *   - Receives from: HTTP route handlers (all public `Command` messages)
+ *   - Sends to: [[LobbyManager]] (lobby commands), [[PlayerManager]] (player session commands), game actors
+ *     (game operations via [[GameActor.GameCommand]]), [[com.andy327.server.actors.persistence.PersistenceProtocol]]
+ *     (`SaveSnapshot` on game start)
  */
 object GameManager {
   sealed trait Command

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/GameManager.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/GameManager.scala
@@ -1,6 +1,6 @@
 package com.andy327.server.actors.core
 
-import scala.util.Success
+import scala.util.{Failure, Success}
 
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
@@ -19,7 +19,8 @@ import com.andy327.server.lobby.{GameLifecycleStatus, LobbyError, LobbyMetadata,
  * A supervisor actor responsible for game actor lifecycle and request routing.
  *
  * GameManager owns the map of live game actors and handles actor spawning, game operation forwarding, and game
- * completion. Lobby lifecycle state is delegated to a LobbyManager child actor.
+ * completion. Lobby lifecycle state is delegated to a LobbyManager child actor. Player session tracking is delegated
+ * to a PlayerManager child actor.
  *
  * On startup, GameManager asynchronously restores persisted games from the database, stashing incoming messages until
  * restoration is complete.
@@ -38,6 +39,10 @@ object GameManager {
   final case class GetLobbyInfo(gameId: GameId, replyTo: ActorRef[GameResponse]) extends Command
   final case class GameCompleted(gameId: GameId, result: GameLifecycleStatus.GameEnded) extends Command
   final case class RunGameOperation(gameId: GameId, op: GameOperation, replyTo: ActorRef[GameResponse]) extends Command
+  final case class SubscribeToLobby(gameId: GameId, playerRef: ActorRef[PlayerActor.Command]) extends Command
+  final case class SubscribeToGame(gameId: GameId, playerRef: ActorRef[PlayerActor.Command]) extends Command
+  final case class RegisterPlayer(player: Player, replyTo: ActorRef[ActorRef[PlayerActor.Command]]) extends Command
+  final case class PlayerDisconnected(playerId: PlayerId) extends Command
 
   final protected[core] case class RestoreGames(games: Map[GameId, (GameType, Game[_, _, _, _, _])]) extends Command
 
@@ -46,7 +51,8 @@ object GameManager {
       gameId: GameId,
       gameType: GameType,
       players: Set[PlayerId],
-      replyTo: ActorRef[GameResponse]
+      replyTo: ActorRef[GameResponse],
+      subscribers: Set[ActorRef[PlayerActor.Command]] = Set.empty
   ) extends Command
 
   final private case class WrappedGameResponse(response: Either[GameError, GameState], replyTo: ActorRef[GameResponse])
@@ -85,6 +91,7 @@ object GameManager {
         implicit val runtime: IORuntime = IORuntime.global
 
         val lobbyManager = context.spawn(LobbyManager(context.self), "lobby-manager")
+        val playerManager = context.spawn(PlayerManager(), "player-manager")
 
         context.pipeToSelf(IO.defer(gameRepo.loadAllGames()).attempt.unsafeToFuture()) {
           case Success(Right(games)) =>
@@ -95,7 +102,7 @@ object GameManager {
             RestoreGames(Map.empty)
         }
 
-        initializing(lobbyManager, persistActor, gameRepo, stash, onReady)
+        initializing(lobbyManager, playerManager, persistActor, gameRepo, stash, onReady)
       }
     }
 
@@ -105,6 +112,7 @@ object GameManager {
     */
   private def initializing(
       lobbyManager: ActorRef[LobbyManager.Command],
+      playerManager: ActorRef[PlayerManager.Command],
       persistActor: ActorRef[PersistenceProtocol.Command],
       gameRepo: GameRepository,
       stash: StashBuffer[Command],
@@ -121,7 +129,7 @@ object GameManager {
 
         context.log.info(s"Initialized ${restoredActors.size} game actors from snapshots")
         onReady.foreach(_ ! Ready)
-        stash.unstashAll(running(restoredActors, Map.empty, lobbyManager, persistActor, gameRepo))
+        stash.unstashAll(running(restoredActors, Map.empty, lobbyManager, playerManager, persistActor, gameRepo))
 
       case other =>
         stash.stash(other)
@@ -140,6 +148,7 @@ object GameManager {
       activeGames: Map[GameId, (GameType, ActorRef[GameActor.GameCommand])],
       completedGameTypes: Map[GameId, GameType],
       lobbyManager: ActorRef[LobbyManager.Command],
+      playerManager: ActorRef[PlayerManager.Command],
       persistActor: ActorRef[PersistenceProtocol.Command],
       gameRepo: GameRepository
   ): Behavior[Command] =
@@ -171,10 +180,34 @@ object GameManager {
           lobbyManager ! LobbyManager.GetLobbyInfo(gameId, replyTo)
           Behaviors.same
 
-        case SpawnGame(gameId, gameType, players, replyTo) =>
+        case SubscribeToLobby(gameId, playerRef) =>
+          lobbyManager ! LobbyManager.SubscribeToLobby(gameId, playerRef)
+          Behaviors.same
+
+        case SubscribeToGame(gameId, playerRef) =>
+          activeGames.get(gameId) match {
+            case Some((gameType, gameActor)) =>
+              gameActor ! GameRegistry.forType(gameType).module.subscribeCommand(playerRef)
+            case None =>
+              context.log.warn(s"SubscribeToGame: no active game found for $gameId")
+          }
+          Behaviors.same
+
+        case RegisterPlayer(player, replyTo) =>
+          playerManager ! PlayerManager.RegisterPlayer(player, replyTo)
+          Behaviors.same
+
+        case PlayerDisconnected(playerId) =>
+          playerManager ! PlayerManager.PlayerDisconnected(playerId)
+          Behaviors.same
+
+        case SpawnGame(gameId, gameType, players, replyTo, subscribers) =>
           val gameActor = GameRegistry.forType(gameType).actor
           val (game, behavior) = gameActor.create(gameId, players.toSeq, persistActor, context.self)
           val actorRef = context.spawn(behavior, s"game-$gameId").unsafeUpcast[GameActor.GameCommand]
+
+          val module = GameRegistry.forType(gameType).module
+          subscribers.foreach(ref => actorRef ! module.subscribeCommand(ref))
 
           persistActor ! PersistenceProtocol.SaveSnapshot(
             gameId,
@@ -189,6 +222,7 @@ object GameManager {
             activeGames + (gameId -> (gameType, actorRef)),
             completedGameTypes,
             lobbyManager,
+            playerManager,
             persistActor,
             gameRepo
           )
@@ -203,6 +237,7 @@ object GameManager {
                 activeGames - gameId,
                 completedGameTypes + (gameId -> gameType),
                 lobbyManager,
+                playerManager,
                 persistActor,
                 gameRepo
               )
@@ -229,6 +264,9 @@ object GameManager {
                     case GameOperation.GetState =>
                       context.pipeToSelf(gameRepo.loadGame(gameId, gameType).attempt.unsafeToFuture()) {
                         case Success(result) => CompletedGameLoaded(result, gameType, replyTo)
+                        // $COVERAGE-OFF$ .attempt converts IO failures to Success(Left(ex)); Failure is unreachable
+                        case Failure(ex) => CompletedGameLoaded(Left(ex), gameType, replyTo)
+                        // $COVERAGE-ON$
                       }
                     case _ =>
                       replyTo ! ErrorResponse("Game has already ended")

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/LobbyManager.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/LobbyManager.scala
@@ -25,6 +25,12 @@ import com.andy327.server.lobby.{GameLifecycleStatus, LobbyError, LobbyMetadata,
  *
  * All commands reply directly to the original replyTo ActorRef[GameManager.GameResponse], so callers see no difference
  * from before the extraction.
+ *
+ * Actor relationships:
+ *   - Parent: [[GameManager]]
+ *   - Receives from: [[GameManager]] (all lobby `Command` messages)
+ *   - Sends to: [[GameManager]] (`SpawnGame` to trigger game actor creation), [[PlayerActor]] (fan-out
+ *     `LobbyUpdated` and `GameEnded` events via `SendEvent`)
  */
 object LobbyManager {
   sealed trait Command

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/LobbyManager.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/LobbyManager.scala
@@ -20,6 +20,9 @@ import com.andy327.server.lobby.{GameLifecycleStatus, LobbyError, LobbyMetadata,
  * (Completed or Cancelled), it is moved to a Scaffeine TTL cache and evicted after [[recentlyEndedTtl]]. This bounds
  * memory growth while still allowing short-lived status queries for recently-finished games.
  *
+ * PlayerActors subscribe to a lobby via SubscribeToLobby and receive LobbyUpdated events on each state change. When a
+ * game starts, the subscriber set is handed off to the new GameActor via SpawnGame.
+ *
  * All commands reply directly to the original replyTo ActorRef[GameManager.GameResponse], so callers see no difference
  * from before the extraction.
  */
@@ -36,6 +39,7 @@ object LobbyManager {
       extends Command
   final case class ListLobbies(replyTo: ActorRef[GameManager.GameResponse]) extends Command
   final case class GetLobbyInfo(gameId: GameId, replyTo: ActorRef[GameManager.GameResponse]) extends Command
+  final case class SubscribeToLobby(gameId: GameId, playerRef: ActorRef[PlayerActor.Command]) extends Command
 
   /** Sent by GameManager when a game ends, to update lobby status. */
   final private[core] case class MarkCompleted(gameId: GameId, result: GameLifecycleStatus.GameEnded) extends Command
@@ -46,12 +50,26 @@ object LobbyManager {
     val recentlyEnded: Cache[GameId, LobbyMetadata] = Scaffeine()
       .expireAfterWrite(recentlyEndedTtl)
       .build[GameId, LobbyMetadata]()
-    running(Map.empty, recentlyEnded, gameManager)
+    running(Map.empty, recentlyEnded, Map.empty, gameManager)
   }
+
+  /**
+   * Sends a [[PlayerEvent]] to every PlayerActor subscribed to the given lobby.
+   *
+   * Called after any state-changing lobby command (join, leave, cancellation, completion) so that all connected players
+   * receive the update without the caller needing to know which actors are subscribed.
+   */
+  private def fanOut(
+      subscribers: Map[GameId, Set[ActorRef[PlayerActor.Command]]],
+      gameId: GameId,
+      event: PlayerEvent
+  ): Unit =
+    subscribers.getOrElse(gameId, Set.empty).foreach(_ ! PlayerActor.SendEvent(event))
 
   private def running(
       lobbies: Map[GameId, LobbyMetadata],
       recentlyEnded: Cache[GameId, LobbyMetadata],
+      subscribers: Map[GameId, Set[ActorRef[PlayerActor.Command]]],
       gameManager: ActorRef[GameManager.Command]
   ): Behavior[Command] = Behaviors.receive { (context, message) =>
     message match {
@@ -59,7 +77,7 @@ object LobbyManager {
         context.log.info(s"Creating new lobby for game type $gameType with host ${host.name}")
         val lobby = LobbyMetadata.newLobby(gameType, host)
         replyTo ! GameManager.LobbyCreated(lobby.gameId, host)
-        running(lobbies + (lobby.gameId -> lobby), recentlyEnded, gameManager)
+        running(lobbies + (lobby.gameId -> lobby), recentlyEnded, subscribers, gameManager)
 
       case JoinLobby(gameId, player, replyTo) =>
         lobbies.get(gameId) match {
@@ -77,7 +95,8 @@ object LobbyManager {
                 else GameLifecycleStatus.WaitingForPlayers
               val updatedMetadata = metadata.copy(players = updatedPlayers, status = updatedStatus)
               replyTo ! GameManager.LobbyJoined(gameId, updatedMetadata, player)
-              running(lobbies + (gameId -> updatedMetadata), recentlyEnded, gameManager)
+              fanOut(subscribers, gameId, PlayerEvent.LobbyUpdated(updatedMetadata))
+              running(lobbies + (gameId -> updatedMetadata), recentlyEnded, subscribers, gameManager)
             }
 
           case Some(_) =>
@@ -106,12 +125,14 @@ object LobbyManager {
               context.log.info(s"Host (${player.name}) left lobby $gameId. Cancelling game...")
               val cancelled = newMetadata.copy(status = GameLifecycleStatus.Cancelled)
               recentlyEnded.put(gameId, cancelled)
+              fanOut(subscribers, gameId, PlayerEvent.GameEnded(GameLifecycleStatus.Cancelled))
               replyTo ! GameManager.LobbyLeft(gameId, s"Lobby $gameId ended - host left")
-              running(lobbies - gameId, recentlyEnded, gameManager)
+              running(lobbies - gameId, recentlyEnded, subscribers - gameId, gameManager)
             } else {
               context.log.info(s"Player ${player.name} left lobby $gameId")
               replyTo ! GameManager.LobbyLeft(gameId, s"${player.name} left lobby $gameId")
-              running(lobbies + (gameId -> newMetadata), recentlyEnded, gameManager)
+              fanOut(subscribers, gameId, PlayerEvent.LobbyUpdated(newMetadata))
+              running(lobbies + (gameId -> newMetadata), recentlyEnded, subscribers, gameManager)
             }
 
           case None =>
@@ -124,8 +145,15 @@ object LobbyManager {
           case Some(metadata) if metadata.hostId == playerId && metadata.status == GameLifecycleStatus.ReadyToStart =>
             context.log.info(s"Lobby $gameId validated for start — delegating game actor spawn to GameManager")
             val updatedMetadata = metadata.copy(status = GameLifecycleStatus.InProgress)
-            gameManager ! GameManager.SpawnGame(gameId, metadata.gameType, metadata.players.keySet, replyTo)
-            running(lobbies + (gameId -> updatedMetadata), recentlyEnded, gameManager)
+            val lobbySubscribers = subscribers.getOrElse(gameId, Set.empty)
+            gameManager ! GameManager.SpawnGame(
+              gameId,
+              metadata.gameType,
+              metadata.players.keySet,
+              replyTo,
+              lobbySubscribers
+            )
+            running(lobbies + (gameId -> updatedMetadata), recentlyEnded, subscribers - gameId, gameManager)
 
           case Some(metadata) if metadata.hostId != playerId =>
             replyTo ! GameManager.LobbyErrorResponse(LobbyError.NotHostError(gameId))
@@ -154,13 +182,19 @@ object LobbyManager {
         }
         Behaviors.same
 
+      case SubscribeToLobby(gameId, playerRef) =>
+        val updated = subscribers.getOrElse(gameId, Set.empty) + playerRef
+        lobbies.get(gameId).foreach(meta => playerRef ! PlayerActor.SendEvent(PlayerEvent.LobbyUpdated(meta)))
+        running(lobbies, recentlyEnded, subscribers + (gameId -> updated), gameManager)
+
       case MarkCompleted(gameId, result) =>
         lobbies.get(gameId) match {
           case Some(metadata) =>
             context.log.info(s"Marking lobby $gameId as $result")
             val updated = metadata.copy(status = result)
             recentlyEnded.put(gameId, updated)
-            running(lobbies - gameId, recentlyEnded, gameManager)
+            fanOut(subscribers, gameId, PlayerEvent.GameEnded(result))
+            running(lobbies - gameId, recentlyEnded, subscribers - gameId, gameManager)
           case None =>
             context.log.warn(s"Tried to mark unknown lobby $gameId as completed")
             Behaviors.same

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/PlayerActor.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/PlayerActor.scala
@@ -1,0 +1,29 @@
+package com.andy327.server.actors.core
+
+import org.apache.pekko.actor.typed.Behavior
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+
+import com.andy327.server.lobby.Player
+
+/**
+ * An actor representing an individual player's session.
+ *
+ * Receives push events from LobbyManager and game actors. In this commit the WebSocket sink is not yet wired; the
+ * next commit adds the wsOut ref and serializes events to JSON for delivery to the client.
+ */
+object PlayerActor {
+  sealed trait Command
+  final case class SendEvent(event: PlayerEvent) extends Command
+  case object Disconnect extends Command
+
+  def apply(player: Player): Behavior[Command] =
+    Behaviors.setup { context =>
+      context.log.info(s"PlayerActor started for player ${player.name} (${player.id})")
+      Behaviors.receiveMessage {
+        case SendEvent(_) =>
+          Behaviors.same
+        case Disconnect =>
+          Behaviors.stopped
+      }
+    }
+}

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/PlayerActor.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/PlayerActor.scala
@@ -1,31 +1,36 @@
 package com.andy327.server.actors.core
 
-import org.apache.pekko.actor.typed.Behavior
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko.actor.typed.{ActorRef, Behavior}
+import org.apache.pekko.http.scaladsl.model.ws.{Message, TextMessage}
 
+import com.andy327.server.http.json.JsonProtocol._
 import com.andy327.server.lobby.Player
 
 /**
  * An actor representing an individual player's session.
  *
- * Receives push events from LobbyManager and game actors. In this commit the WebSocket sink is not yet wired; the
- * next commit adds the wsOut ref and serializes events to JSON for delivery to the client.
+ * Receives push events from LobbyManager and game actors, serializes them to JSON, and forwards them to the WebSocket
+ * sink via the `wsOut` ActorRef. Each event is encoded as a tagged JSON object so the client can dispatch on the
+ * `type` field.
  *
  * Actor relationships:
  *   - Parent: [[PlayerManager]]
  *   - Receives from: [[LobbyManager]] and game actors (fan-out `SendEvent`), [[PlayerManager]] (`Disconnect`)
- *   - Sends to: WebSocket client (not yet wired; planned for Issue #8)
+ *   - Sends to: WebSocket client via `wsOut` (`TextMessage`)
  */
 object PlayerActor {
   sealed trait Command
   final case class SendEvent(event: PlayerEvent) extends Command
   case object Disconnect extends Command
 
-  def apply(player: Player): Behavior[Command] =
+  def apply(player: Player, wsOut: ActorRef[Message]): Behavior[Command] =
     Behaviors.setup { context =>
       context.log.info(s"PlayerActor started for player ${player.name} (${player.id})")
       Behaviors.receiveMessage {
-        case SendEvent(_) =>
+        case SendEvent(event) =>
+          val json = playerEventFormat.write(event).compactPrint
+          wsOut ! TextMessage(json)
           Behaviors.same
         case Disconnect =>
           Behaviors.stopped

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/PlayerActor.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/PlayerActor.scala
@@ -10,6 +10,11 @@ import com.andy327.server.lobby.Player
  *
  * Receives push events from LobbyManager and game actors. In this commit the WebSocket sink is not yet wired; the
  * next commit adds the wsOut ref and serializes events to JSON for delivery to the client.
+ *
+ * Actor relationships:
+ *   - Parent: [[PlayerManager]]
+ *   - Receives from: [[LobbyManager]] and game actors (fan-out `SendEvent`), [[PlayerManager]] (`Disconnect`)
+ *   - Sends to: WebSocket client (not yet wired; planned for Issue #8)
  */
 object PlayerActor {
   sealed trait Command

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/PlayerEvent.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/PlayerEvent.scala
@@ -1,0 +1,13 @@
+package com.andy327.server.actors.core
+
+import com.andy327.server.http.json.GameState
+import com.andy327.server.lobby.{GameLifecycleStatus, LobbyMetadata}
+
+/** Events pushed from the server to a connected player. */
+sealed trait PlayerEvent
+
+object PlayerEvent {
+  final case class LobbyUpdated(metadata: LobbyMetadata) extends PlayerEvent
+  final case class GameStateUpdated(state: GameState) extends PlayerEvent
+  final case class GameEnded(result: GameLifecycleStatus.GameEnded) extends PlayerEvent
+}

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/PlayerManager.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/PlayerManager.scala
@@ -2,6 +2,7 @@ package com.andy327.server.actors.core
 
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
 import org.apache.pekko.actor.typed.{ActorRef, Behavior}
+import org.apache.pekko.http.scaladsl.model.ws.Message
 
 import com.andy327.model.core.PlayerId
 import com.andy327.server.lobby.Player
@@ -22,7 +23,11 @@ import com.andy327.server.lobby.Player
 object PlayerManager {
   sealed trait Command
 
-  final case class RegisterPlayer(player: Player, replyTo: ActorRef[ActorRef[PlayerActor.Command]]) extends Command
+  final case class RegisterPlayer(
+      player: Player,
+      wsOut: ActorRef[Message],
+      replyTo: ActorRef[ActorRef[PlayerActor.Command]]
+  ) extends Command
   final case class LookupPlayer(playerId: PlayerId, replyTo: ActorRef[Option[ActorRef[PlayerActor.Command]]])
       extends Command
   final case class PlayerDisconnected(playerId: PlayerId) extends Command
@@ -32,9 +37,9 @@ object PlayerManager {
   private def running(players: Map[PlayerId, ActorRef[PlayerActor.Command]], spawnCount: Int): Behavior[Command] =
     Behaviors.receive { (context, message) =>
       message match {
-        case RegisterPlayer(player, replyTo) =>
+        case RegisterPlayer(player, wsOut, replyTo) =>
           players.get(player.id).foreach(context.stop)
-          val ref = context.spawn(PlayerActor(player), s"player-${player.id}-$spawnCount")
+          val ref = context.spawn(PlayerActor(player, wsOut), s"player-${player.id}-$spawnCount")
           replyTo ! ref
           running(players + (player.id -> ref), spawnCount + 1)
 

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/PlayerManager.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/PlayerManager.scala
@@ -9,7 +9,15 @@ import com.andy327.server.lobby.Player
 /**
  * A child actor of GameManager that tracks one PlayerActor per connected player.
  *
- * On reconnect (same PlayerId), the old PlayerActor is stopped and replaced with a new one.
+ * On reconnect (same PlayerId), the old PlayerActor is stopped and replaced with a new one. A monotonically
+ * increasing `spawnCount` is appended to each child name to avoid Pekko's uniqueness constraint during the brief
+ * window while the old actor is still stopping.
+ *
+ * Actor relationships:
+ *   - Parent: [[GameManager]]
+ *   - Children: [[PlayerActor]] (one per currently-connected player)
+ *   - Receives from: [[GameManager]] (`RegisterPlayer`, `LookupPlayer`, `PlayerDisconnected`)
+ *   - Sends to: [[PlayerActor]] (`Disconnect` on explicit disconnect or reconnect)
  */
 object PlayerManager {
   sealed trait Command

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/PlayerManager.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/PlayerManager.scala
@@ -1,0 +1,42 @@
+package com.andy327.server.actors.core
+
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko.actor.typed.{ActorRef, Behavior}
+
+import com.andy327.model.core.PlayerId
+import com.andy327.server.lobby.Player
+
+/**
+ * A child actor of GameManager that tracks one PlayerActor per connected player.
+ *
+ * On reconnect (same PlayerId), the old PlayerActor is stopped and replaced with a new one.
+ */
+object PlayerManager {
+  sealed trait Command
+
+  final case class RegisterPlayer(player: Player, replyTo: ActorRef[ActorRef[PlayerActor.Command]]) extends Command
+  final case class LookupPlayer(playerId: PlayerId, replyTo: ActorRef[Option[ActorRef[PlayerActor.Command]]])
+      extends Command
+  final case class PlayerDisconnected(playerId: PlayerId) extends Command
+
+  def apply(): Behavior[Command] = running(Map.empty, 0)
+
+  private def running(players: Map[PlayerId, ActorRef[PlayerActor.Command]], spawnCount: Int): Behavior[Command] =
+    Behaviors.receive { (context, message) =>
+      message match {
+        case RegisterPlayer(player, replyTo) =>
+          players.get(player.id).foreach(context.stop)
+          val ref = context.spawn(PlayerActor(player), s"player-${player.id}-$spawnCount")
+          replyTo ! ref
+          running(players + (player.id -> ref), spawnCount + 1)
+
+        case LookupPlayer(playerId, replyTo) =>
+          replyTo ! players.get(playerId)
+          Behaviors.same
+
+        case PlayerDisconnected(playerId) =>
+          players.get(playerId).foreach(_ ! PlayerActor.Disconnect)
+          running(players - playerId, spawnCount)
+      }
+    }
+}

--- a/game-service-server/src/main/scala/com/andy327/server/actors/tictactoe/TicTacToeActor.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/tictactoe/TicTacToeActor.scala
@@ -28,6 +28,14 @@ import com.andy327.server.lobby.GameLifecycleStatus
  * - `GetState`: returns a snapshot of the current game state
  * - `Subscribe` / `Unsubscribe`: register or deregister a PlayerActor for push events
  * - `SnapshotSaved` / `SnapshotLoaded`: internal protocol for persistence status
+ *
+ * Actor relationships:
+ *   - Parent: [[com.andy327.server.actors.core.GameManager]]
+ *   - Receives from: [[com.andy327.server.actors.core.GameManager]] (`MakeMove`, `GetState`, `Subscribe`,
+ *     `Unsubscribe`)
+ *   - Sends to: [[com.andy327.server.actors.core.GameManager]] (`GameCompleted`),
+ *     [[com.andy327.server.actors.persistence.PersistenceProtocol]] (`SaveSnapshot` after each move),
+ *     [[com.andy327.server.actors.core.PlayerActor]] (fan-out `GameStateUpdated` and `GameEnded` via `SendEvent`)
  */
 object TicTacToeActor extends GameActor[TicTacToe, TicTacToeState] {
   import TicTacToeState._

--- a/game-service-server/src/main/scala/com/andy327/server/actors/tictactoe/TicTacToeActor.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/tictactoe/TicTacToeActor.scala
@@ -5,7 +5,7 @@ import org.apache.pekko.actor.typed.{ActorRef, Behavior}
 
 import com.andy327.model.core.{Game, GameId, PlayerId}
 import com.andy327.model.tictactoe._
-import com.andy327.server.actors.core.{GameActor, GameManager}
+import com.andy327.server.actors.core.{GameActor, GameManager, PlayerActor, PlayerEvent}
 import com.andy327.server.actors.persistence.PersistenceProtocol
 import com.andy327.server.http.json.{GameStateConverters, TicTacToeState}
 import com.andy327.server.lobby.GameLifecycleStatus
@@ -18,6 +18,7 @@ import com.andy327.server.lobby.GameLifecycleStatus
  * - Validating and applying game rules
  * - Persisting game state changes via a persistence actor
  * - Notifying the GameManager when a game has completed (win or draw)
+ * - Fanning out state updates and game-end events to subscribed PlayerActors
  * - Supporting recovery from snapshot-based persistence on startup
  *
  * It uses a game-agnostic `GameActor` interface, and plugs into the game service via the GameRegistry and GameModule.
@@ -25,6 +26,7 @@ import com.andy327.server.lobby.GameLifecycleStatus
  * Commands:
  * - `MakeMove`: attempts to apply a move by a player
  * - `GetState`: returns a snapshot of the current game state
+ * - `Subscribe` / `Unsubscribe`: register or deregister a PlayerActor for push events
  * - `SnapshotSaved` / `SnapshotLoaded`: internal protocol for persistence status
  */
 object TicTacToeActor extends GameActor[TicTacToe, TicTacToeState] {
@@ -34,6 +36,8 @@ object TicTacToeActor extends GameActor[TicTacToe, TicTacToeState] {
   final case class MakeMove(playerId: PlayerId, loc: Location, replyTo: ActorRef[Either[GameError, TicTacToeState]])
       extends Command
   final case class GetState(replyTo: ActorRef[Either[GameError, TicTacToeState]]) extends Command
+  final case class Subscribe(playerRef: ActorRef[PlayerActor.Command]) extends Command
+  final case class Unsubscribe(playerRef: ActorRef[PlayerActor.Command]) extends Command
 
   sealed trait Internal extends Command
   final case class SnapshotSaved(result: Either[Throwable, Unit]) extends Internal
@@ -59,7 +63,7 @@ object TicTacToeActor extends GameActor[TicTacToe, TicTacToeState] {
     val game = TicTacToe.empty(playerX, playerO)
     val behavior = Behaviors.setup[Command] { context =>
       context.log.info(s"[$gameId] starting new game")
-      active(game, gameId, persist, gameManager)
+      active(game, gameId, persist, gameManager, Set.empty)
     }
 
     (game, behavior)
@@ -77,7 +81,7 @@ object TicTacToeActor extends GameActor[TicTacToe, TicTacToeState] {
   ): Behavior[Command] =
     Behaviors.setup { context =>
       game match {
-        case ttt: TicTacToe => active(ttt, gameId, persist, gameManager)
+        case ttt: TicTacToe => active(ttt, gameId, persist, gameManager, Set.empty)
         case _              =>
           context.log.error(s"Unexpected snapshot type for game $gameId: $game")
           Behaviors.stopped
@@ -92,7 +96,8 @@ object TicTacToeActor extends GameActor[TicTacToe, TicTacToeState] {
       game: TicTacToe,
       gameId: GameId,
       persist: ActorRef[PersistenceProtocol.Command],
-      gameManager: ActorRef[GameManager.Command]
+      gameManager: ActorRef[GameManager.Command],
+      subscribers: Set[ActorRef[PlayerActor.Command]]
   ): Behavior[Command] = Behaviors.receive { (context, msg) =>
     msg match {
       case MakeMove(_, _, replyTo) if game.gameStatus != InProgress =>
@@ -107,23 +112,26 @@ object TicTacToeActor extends GameActor[TicTacToe, TicTacToeState] {
               case Right(nextState) =>
                 context.log.info(s"Game $gameId updated:\n${nextState.render}")
 
-                // Persist in background
                 persist ! PersistenceProtocol.SaveSnapshot(
                   gameId = gameId,
                   gameType = gameType,
                   game = nextState,
                   replyTo = context.messageAdapter(_ => SnapshotSaved(Right(())))
                 )
-                replyTo ! Right(GameStateConverters.serializeGame(nextState))
+
+                val serialized = GameStateConverters.serializeGame(nextState)
+                replyTo ! Right(serialized)
+                subscribers.foreach(_ ! PlayerActor.SendEvent(PlayerEvent.GameStateUpdated(serialized)))
 
                 nextState.gameStatus match {
                   case Won(_) | Draw =>
                     context.log.info(s"[$gameId] game completed with status: ${nextState.gameStatus}")
+                    subscribers.foreach(_ ! PlayerActor.SendEvent(PlayerEvent.GameEnded(GameLifecycleStatus.Completed)))
                     gameManager ! GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed)
-                    active(nextState, gameId, persist, gameManager)
+                    active(nextState, gameId, persist, gameManager, subscribers)
 
                   case InProgress =>
-                    active(nextState, gameId, persist, gameManager)
+                    active(nextState, gameId, persist, gameManager, subscribers)
                 }
 
               case Left(err) =>
@@ -146,6 +154,12 @@ object TicTacToeActor extends GameActor[TicTacToe, TicTacToeState] {
       case GetState(replyTo) =>
         replyTo ! Right(GameStateConverters.serializeGame(game))
         Behaviors.same
+
+      case Subscribe(playerRef) =>
+        active(game, gameId, persist, gameManager, subscribers + playerRef)
+
+      case Unsubscribe(playerRef) =>
+        active(game, gameId, persist, gameManager, subscribers - playerRef)
 
       case SnapshotSaved(result) =>
         result match {

--- a/game-service-server/src/main/scala/com/andy327/server/game/modules/GameModule.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/game/modules/GameModule.scala
@@ -5,7 +5,7 @@ import org.apache.pekko.actor.typed.ActorRef
 import spray.json.JsValue
 
 import com.andy327.model.core.{Game, GameError}
-import com.andy327.server.actors.core.GameActor
+import com.andy327.server.actors.core.{GameActor, PlayerActor}
 import com.andy327.server.game.{GameOperation, MovePayload}
 import com.andy327.server.http.json.GameState
 
@@ -44,4 +44,10 @@ trait GameModule {
    * Used when a game actor has been stopped and state must be served from persistent storage.
    */
   def serialize(game: Game[_, _, _, _, _]): GameState
+
+  /**
+   * Produces a game-specific Subscribe command that can be sent to a game actor to register a PlayerActor as a
+   * subscriber for push events.
+   */
+  def subscribeCommand(playerRef: ActorRef[PlayerActor.Command]): GameActor.GameCommand
 }

--- a/game-service-server/src/main/scala/com/andy327/server/game/modules/TicTacToeModule.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/game/modules/TicTacToeModule.scala
@@ -11,7 +11,7 @@ import spray.json._
 
 import com.andy327.model.core.{Game, GameError}
 import com.andy327.model.tictactoe.{Location, TicTacToe}
-import com.andy327.server.actors.core.GameActor
+import com.andy327.server.actors.core.{GameActor, PlayerActor}
 import com.andy327.server.actors.tictactoe.TicTacToeActor
 import com.andy327.server.game.MovePayload.TicTacToeMove
 import com.andy327.server.game.{GameOperation, MovePayload}
@@ -62,6 +62,9 @@ object TicTacToeModule extends GameModule {
     case GameOperation.GetState =>
       Right(TicTacToeActor.GetState(replyTo))
   }
+
+  override def subscribeCommand(playerRef: ActorRef[PlayerActor.Command]): GameActor.GameCommand =
+    TicTacToeActor.Subscribe(playerRef)
 
   override def serialize(game: Game[_, _, _, _, _]): GameState = game match {
     case ttt: TicTacToe => GameStateConverters.serializeGame(ttt)

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -8,6 +8,7 @@ import spray.json._
 
 import com.andy327.model.core.GameType
 import com.andy327.server.actors.core.GameManager.{ErrorResponse, GameStarted, LobbyCreated, LobbyJoined, LobbyLeft}
+import com.andy327.server.actors.core.PlayerEvent
 import com.andy327.server.http.auth.PlayerRequest
 import com.andy327.server.lobby.{GameLifecycleStatus, LobbyMetadata, Player}
 
@@ -74,6 +75,34 @@ object JsonProtocol extends DefaultJsonProtocol {
     jsonFormat2(TicTacToeMoveRequest.apply)
 
   implicit val ticTacToeStateFormat: RootJsonFormat[TicTacToeState] = jsonFormat4(TicTacToeState.apply)
+
+  /**
+   * Write-only format for PlayerEvent — serialises server-push events to JSON for delivery over WebSocket.
+   *
+   * Each variant is encoded as a JSON object with a `type` discriminator field so the client can
+   * dispatch on the event kind without additional out-of-band information:
+   *   - `{"type":"LobbyUpdated",    "metadata":{...}}`
+   *   - `{"type":"GameStateUpdated","state":{...}}`
+   *   - `{"type":"GameEnded",       "result":"Completed"}`
+   *
+   * Reading is not supported; deserializationError is raised if attempted.
+   */
+  implicit val playerEventFormat: RootJsonFormat[PlayerEvent] = new RootJsonFormat[PlayerEvent] {
+    def write(event: PlayerEvent): JsValue = event match {
+      case PlayerEvent.LobbyUpdated(metadata) =>
+        JsObject("type" -> JsString("LobbyUpdated"), "metadata" -> lobbyMetadataFormat.write(metadata))
+      case PlayerEvent.GameStateUpdated(state) =>
+        val stateJson = state match {
+          case s: TicTacToeState => ticTacToeStateFormat.write(s)
+        }
+        JsObject("type" -> JsString("GameStateUpdated"), "state" -> stateJson)
+      case PlayerEvent.GameEnded(result) =>
+        JsObject("type" -> JsString("GameEnded"), "result" -> gameLifecycleStatusFormat.write(result))
+    }
+
+    def read(json: JsValue): PlayerEvent =
+      deserializationError("PlayerEvent deserialization is not supported")
+  }
 
   /** Polymorphic marshaller that knows how to serialise any GameState into an HttpResponse. */
   implicit val gameStateMarshaller: ToResponseMarshaller[GameState] =

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -79,8 +79,8 @@ object JsonProtocol extends DefaultJsonProtocol {
   /**
    * Write-only format for PlayerEvent — serialises server-push events to JSON for delivery over WebSocket.
    *
-   * Each variant is encoded as a JSON object with a `type` discriminator field so the client can
-   * dispatch on the event kind without additional out-of-band information:
+   * Each variant is encoded as a JSON object with a `type` discriminator field so the client can dispatch on the
+   * event kind without additional out-of-band information:
    *   - `{"type":"LobbyUpdated",    "metadata":{...}}`
    *   - `{"type":"GameStateUpdated","state":{...}}`
    *   - `{"type":"GameEnded",       "result":"Completed"}`

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/WebSocketRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/WebSocketRoutes.scala
@@ -1,0 +1,75 @@
+package com.andy327.server.http.routes
+
+import scala.concurrent.duration._
+
+import org.apache.pekko.actor.typed.scaladsl.AskPattern._
+import org.apache.pekko.actor.typed.{ActorRef, ActorSystem}
+import org.apache.pekko.http.scaladsl.model.ws.Message
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.stream.OverflowStrategy
+import org.apache.pekko.stream.scaladsl.{Flow, Sink}
+import org.apache.pekko.stream.typed.scaladsl.ActorSource
+import org.apache.pekko.util.Timeout
+
+import com.andy327.server.actors.core.{GameManager, PlayerActor}
+import com.andy327.server.http.auth.JwtPlayerDirectives._
+import com.andy327.server.lobby.Player
+
+/**
+ * HTTP route that upgrades connections to WebSocket sessions.
+ *
+ * On connect the client must supply a valid Bearer token (obtained via POST /auth/token). The server materializes an
+ * ActorSource-backed stream, spawns a PlayerActor wired to it via GameManager.RegisterPlayer, and begins forwarding
+ * push events (lobby updates, game state, game-end notifications) as JSON TextMessages. Inbound client messages are
+ * currently discarded. When the WebSocket closes, PlayerDisconnected is sent to GameManager so that the associated
+ * PlayerActor is stopped.
+ *
+ * Route: GET /ws   (Auth: Bearer token required)
+ *
+ * Actor relationships:
+ *   - Sends to: `GameManager` (`RegisterPlayer` on connect, `PlayerDisconnected` on close)
+ */
+class WebSocketRoutes(gameManager: ActorSystem[GameManager.Command]) {
+  implicit private val system: ActorSystem[GameManager.Command] = gameManager
+  implicit private val timeout: Timeout = Timeout(5.seconds)
+  private val ec = system.executionContext
+
+  val routes: Route = path("ws") {
+    authenticatePlayer { player =>
+      handleWebSocketMessages(buildFlow(player))
+    }
+  }
+
+  /**
+   * Builds a WebSocket Flow for the given authenticated player.
+   *
+   * Pre-materializes an ActorSource to obtain a `wsOut: ActorRef[Message]` before the stream starts, then asks
+   * GameManager to register the player (which spawns a PlayerActor bound to that ref). The outbound side of the flow
+   * carries server-push events; the inbound side is drained with Sink.ignore. When the stream terminates (WebSocket
+   * closed by either side), PlayerDisconnected is sent to GameManager to clean up the PlayerActor.
+   */
+  private def buildFlow(player: Player): Flow[Message, Message, Any] = {
+    // Materialize the ActorRef up front so we can pass it to RegisterPlayer before the stream runs
+    val (wsOut, source) = ActorSource
+      .actorRef[Message](
+        completionMatcher = PartialFunction.empty,
+        failureMatcher = PartialFunction.empty,
+        bufferSize = 16,
+        overflowStrategy = OverflowStrategy.dropHead
+      )
+      .preMaterialize()
+
+    // Spawn a PlayerActor wired to wsOut — reply is discarded since wsOut is all we need here
+    (gameManager ? ((replyTo: ActorRef[ActorRef[PlayerActor.Command]]) =>
+      GameManager.RegisterPlayer(player, wsOut, replyTo)
+    )).foreach(_ => ())(ec)
+
+    // On WebSocket close (either side), stop the PlayerActor via GameManager
+    val outbound = source.watchTermination() { (_, done) =>
+      done.onComplete(_ => gameManager ! GameManager.PlayerDisconnected(player.id))(ec)
+    }
+
+    Flow.fromSinkAndSource(Sink.ignore, outbound)
+  }
+}

--- a/game-service-server/src/test/scala/com/andy327/server/actors/core/GameManagerSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/core/GameManagerSpec.scala
@@ -9,6 +9,7 @@ import cats.effect.IO
 
 import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
 import org.apache.pekko.actor.typed.ActorRef
+import org.apache.pekko.http.scaladsl.model.ws.Message
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -609,8 +610,9 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
 
       val gm = spawn(GameManager(persistProbe.ref, gameRepo))
 
+      val wsProbe = TestProbe[Message]()
       val replyProbe = TestProbe[ActorRef[PlayerActor.Command]]()
-      gm ! GameManager.RegisterPlayer(alice, replyProbe.ref)
+      gm ! GameManager.RegisterPlayer(alice, wsProbe.ref, replyProbe.ref)
 
       val ref = replyProbe.expectMessageType[ActorRef[PlayerActor.Command]]
       ref should not be null
@@ -623,8 +625,9 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
 
       val gm = spawn(GameManager(persistProbe.ref, gameRepo))
 
+      val wsProbe = TestProbe[Message]()
       val registerProbe = TestProbe[ActorRef[PlayerActor.Command]]()
-      gm ! GameManager.RegisterPlayer(alice, registerProbe.ref)
+      gm ! GameManager.RegisterPlayer(alice, wsProbe.ref, registerProbe.ref)
       registerProbe.expectMessageType[ActorRef[PlayerActor.Command]]
 
       gm ! GameManager.PlayerDisconnected(alice.id)

--- a/game-service-server/src/test/scala/com/andy327/server/actors/core/GameManagerSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/core/GameManagerSpec.scala
@@ -8,12 +8,14 @@ import scala.util.control.NoStackTrace
 import cats.effect.IO
 
 import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
+import org.apache.pekko.actor.typed.ActorRef
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.model.core.{Game, GameId, GameType, PlayerId}
 import com.andy327.model.tictactoe.TicTacToe
 import com.andy327.persistence.db.GameRepository
+import com.andy327.server.actors.core.{PlayerActor, PlayerEvent}
 import com.andy327.server.actors.persistence.PersistenceProtocol
 import com.andy327.server.game.{GameOperation, MovePayload}
 import com.andy327.server.http.json.TicTacToeState.TicTacToeView
@@ -598,6 +600,143 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
 
       val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
       error.message should include("out of bounds")
+    }
+
+    "register a player and return its actor ref" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+      val alice = Player("alice")
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
+
+      val replyProbe = TestProbe[ActorRef[PlayerActor.Command]]()
+      gm ! GameManager.RegisterPlayer(alice, replyProbe.ref)
+
+      val ref = replyProbe.expectMessageType[ActorRef[PlayerActor.Command]]
+      ref should not be null
+    }
+
+    "remove a player on PlayerDisconnected without crashing" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+      val alice = Player("alice")
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
+
+      val registerProbe = TestProbe[ActorRef[PlayerActor.Command]]()
+      gm ! GameManager.RegisterPlayer(alice, registerProbe.ref)
+      registerProbe.expectMessageType[ActorRef[PlayerActor.Command]]
+
+      gm ! GameManager.PlayerDisconnected(alice.id)
+
+      // GM is still responsive after disconnect
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+      gm ! GameManager.ListLobbies(responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbiesListed]
+    }
+
+    "forward SubscribeToLobby so the subscriber receives the current lobby state" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+      val alice = Player("alice")
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
+
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      val GameManager.LobbyCreated(gameId, _) = responseProbe.receiveMessage()
+
+      val subscriberProbe = TestProbe[PlayerActor.Command]()
+      gm ! GameManager.SubscribeToLobby(gameId, subscriberProbe.ref)
+
+      // subscriber receives initial lobby state immediately
+      val event = subscriberProbe.expectMessageType[PlayerActor.SendEvent]
+      event.event shouldBe a[PlayerEvent.LobbyUpdated]
+    }
+
+    "forward SubscribeToGame so the subscriber receives events after a move" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+      val alice = Player("alice")
+      val bob = Player("bob")
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
+
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      val GameManager.LobbyCreated(gameId, host) = responseProbe.receiveMessage()
+
+      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbyJoined]
+
+      gm ! GameManager.StartGame(gameId, host.id, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.GameStarted]
+
+      val subscriberProbe = TestProbe[PlayerActor.Command]()
+      gm ! GameManager.SubscribeToGame(gameId, subscriberProbe.ref)
+
+      gm ! GameManager.RunGameOperation(
+        gameId,
+        GameOperation.MakeMove(alice.id, MovePayload.TicTacToeMove(0, 0)),
+        responseProbe.ref
+      )
+      responseProbe.expectMessageType[GameManager.GameStatus]
+
+      val event = subscriberProbe.expectMessageType[PlayerActor.SendEvent]
+      event.event shouldBe a[PlayerEvent.GameStateUpdated]
+    }
+
+    "deliver GameStateUpdated to a lobby subscriber after the game starts" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+      val alice = Player("alice")
+      val bob = Player("bob")
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
+
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      val GameManager.LobbyCreated(gameId, host) = responseProbe.receiveMessage()
+
+      // Subscribe before the game starts — subscriber is held in LobbyManager
+      val subscriberProbe = TestProbe[PlayerActor.Command]()
+      gm ! GameManager.SubscribeToLobby(gameId, subscriberProbe.ref)
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial LobbyUpdated snapshot
+
+      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbyJoined]
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent] // LobbyUpdated on join
+
+      // Start the game — LobbyManager passes subscriber in SpawnGame; line 210 fires
+      gm ! GameManager.StartGame(gameId, host.id, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.GameStarted]
+
+      // Make a move; the subscriber should now receive GameStateUpdated from the game actor
+      gm ! GameManager.RunGameOperation(
+        gameId,
+        GameOperation.MakeMove(alice.id, MovePayload.TicTacToeMove(0, 0)),
+        responseProbe.ref
+      )
+      responseProbe.expectMessageType[GameManager.GameStatus]
+
+      val event = subscriberProbe.expectMessageType[PlayerActor.SendEvent]
+      event.event shouldBe a[PlayerEvent.GameStateUpdated]
+    }
+
+    "handle SubscribeToGame for an unknown game without crashing" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+      val nonexistentId: GameId = java.util.UUID.randomUUID()
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo))
+
+      val subscriberProbe = TestProbe[PlayerActor.Command]()
+      gm ! GameManager.SubscribeToGame(nonexistentId, subscriberProbe.ref)
+
+      // GM is still responsive
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+      gm ! GameManager.ListLobbies(responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbiesListed]
     }
 
     "return an error when forwarding to a nonexistent game" in {

--- a/game-service-server/src/test/scala/com/andy327/server/actors/core/LobbyManagerSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/core/LobbyManagerSpec.scala
@@ -142,6 +142,75 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       metadata.status shouldBe GameLifecycleStatus.WaitingForPlayers
     }
 
+    "push LobbyUpdated to a subscriber when a player joins" in {
+      val gmProbe = TestProbe[GameManager.Command]()
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+      val subscriberProbe = TestProbe[PlayerActor.Command]()
+      val lm = spawn(LobbyManager(gmProbe.ref))
+      val alice = Player("alice")
+      val bob = Player("bob")
+
+      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      val GameManager.LobbyCreated(gameId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
+
+      lm ! LobbyManager.SubscribeToLobby(gameId, subscriberProbe.ref)
+      // immediate push of current state on subscribe
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent]
+
+      lm ! LobbyManager.JoinLobby(gameId, bob, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbyJoined]
+
+      val event = subscriberProbe.expectMessageType[PlayerActor.SendEvent]
+      event.event shouldBe a[PlayerEvent.LobbyUpdated]
+    }
+
+    "push GameEnded(Cancelled) to subscribers when the host leaves" in {
+      val gmProbe = TestProbe[GameManager.Command]()
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+      val subscriberProbe = TestProbe[PlayerActor.Command]()
+      val lm = spawn(LobbyManager(gmProbe.ref))
+      val alice = Player("alice")
+
+      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      val GameManager.LobbyCreated(gameId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
+
+      lm ! LobbyManager.SubscribeToLobby(gameId, subscriberProbe.ref)
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial state
+
+      lm ! LobbyManager.LeaveLobby(gameId, alice, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbyLeft]
+
+      val event = subscriberProbe.expectMessageType[PlayerActor.SendEvent]
+      event.event shouldBe PlayerEvent.GameEnded(GameLifecycleStatus.Cancelled)
+    }
+
+    "pass subscriber refs to SpawnGame and remove them from the subscriber map" in {
+      val gmProbe = TestProbe[GameManager.Command]()
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+      val subscriberProbe = TestProbe[PlayerActor.Command]()
+      val lm = spawn(LobbyManager(gmProbe.ref))
+      val alice = Player("alice")
+      val bob = Player("bob")
+
+      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      val GameManager.LobbyCreated(gameId, host) = responseProbe.expectMessageType[GameManager.LobbyCreated]
+
+      lm ! LobbyManager.JoinLobby(gameId, bob, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbyJoined]
+
+      lm ! LobbyManager.SubscribeToLobby(gameId, subscriberProbe.ref)
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial state
+
+      lm ! LobbyManager.StartGame(gameId, host.id, responseProbe.ref)
+      val spawnMsg = gmProbe.expectMessageType[GameManager.SpawnGame]
+      spawnMsg.subscribers should contain(subscriberProbe.ref)
+
+      // subscriber is removed from LobbyManager after handoff to game actor
+      lm ! LobbyManager.ListLobbies(responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbiesListed]
+      subscriberProbe.expectNoMessage()
+    }
+
     "ignore MarkCompleted for an unknown lobby" in {
       val gmProbe = TestProbe[GameManager.Command]()
       val responseProbe = TestProbe[GameManager.GameResponse]()

--- a/game-service-server/src/test/scala/com/andy327/server/actors/core/PlayerActorSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/core/PlayerActorSpec.scala
@@ -1,6 +1,7 @@
 package com.andy327.server.actors.core
 
 import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
+import org.apache.pekko.http.scaladsl.model.ws.{Message, TextMessage}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -12,9 +13,10 @@ class PlayerActorSpec extends AnyWordSpecLike with Matchers {
   import testKit._
 
   "PlayerActor" should {
-    "remain alive after receiving SendEvent" in {
+    "forward SendEvent as a TextMessage to wsOut" in {
       val alice = Player("alice")
-      val actor = spawn(PlayerActor(alice))
+      val wsProbe = TestProbe[Message]()
+      val actor = spawn(PlayerActor(alice, wsProbe.ref))
 
       val dummyState = TicTacToeState(
         board = Vector.fill(3)(Vector.fill(3)("")),
@@ -24,16 +26,18 @@ class PlayerActorSpec extends AnyWordSpecLike with Matchers {
       )
 
       actor ! PlayerActor.SendEvent(PlayerEvent.GameStateUpdated(dummyState))
+      val msg1 = wsProbe.expectMessageType[TextMessage.Strict]
+      msg1.text should include("GameStateUpdated")
 
-      // send a second event to confirm the actor is still processing messages
-      val replyProbe = TestProbe[GameManager.GameResponse]()
+      // send a second event to confirm the actor is still alive and processing
       actor ! PlayerActor.SendEvent(PlayerEvent.GameStateUpdated(dummyState))
-      replyProbe.expectNoMessage()
+      wsProbe.expectMessageType[TextMessage.Strict]
     }
 
     "stop when it receives Disconnect" in {
       val alice = Player("alice")
-      val actor = spawn(PlayerActor(alice))
+      val wsProbe = TestProbe[Message]()
+      val actor = spawn(PlayerActor(alice, wsProbe.ref))
       val probe = TestProbe[PlayerActor.Command]()
 
       actor ! PlayerActor.Disconnect

--- a/game-service-server/src/test/scala/com/andy327/server/actors/core/PlayerActorSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/core/PlayerActorSpec.scala
@@ -1,0 +1,43 @@
+package com.andy327.server.actors.core
+
+import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import com.andy327.server.http.json.TicTacToeState
+import com.andy327.server.lobby.Player
+
+class PlayerActorSpec extends AnyWordSpecLike with Matchers {
+  private val testKit = ActorTestKit()
+  import testKit._
+
+  "PlayerActor" should {
+    "remain alive after receiving SendEvent" in {
+      val alice = Player("alice")
+      val actor = spawn(PlayerActor(alice))
+
+      val dummyState = TicTacToeState(
+        board = Vector.fill(3)(Vector.fill(3)("")),
+        currentPlayer = "X",
+        winner = None,
+        draw = false
+      )
+
+      actor ! PlayerActor.SendEvent(PlayerEvent.GameStateUpdated(dummyState))
+
+      // send a second event to confirm the actor is still processing messages
+      val replyProbe = TestProbe[GameManager.GameResponse]()
+      actor ! PlayerActor.SendEvent(PlayerEvent.GameStateUpdated(dummyState))
+      replyProbe.expectNoMessage()
+    }
+
+    "stop when it receives Disconnect" in {
+      val alice = Player("alice")
+      val actor = spawn(PlayerActor(alice))
+      val probe = TestProbe[PlayerActor.Command]()
+
+      actor ! PlayerActor.Disconnect
+      probe.expectTerminated(actor)
+    }
+  }
+}

--- a/game-service-server/src/test/scala/com/andy327/server/actors/core/PlayerManagerSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/core/PlayerManagerSpec.scala
@@ -4,6 +4,7 @@ import java.util.UUID
 
 import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
 import org.apache.pekko.actor.typed.ActorRef
+import org.apache.pekko.http.scaladsl.model.ws.Message
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -16,10 +17,11 @@ class PlayerManagerSpec extends AnyWordSpecLike with Matchers {
   "PlayerManager" should {
     "register a player and return its actor ref" in {
       val pm = spawn(PlayerManager())
+      val wsProbe = TestProbe[Message]()
       val replyProbe = TestProbe[ActorRef[PlayerActor.Command]]()
       val alice = Player("alice")
 
-      pm ! PlayerManager.RegisterPlayer(alice, replyProbe.ref)
+      pm ! PlayerManager.RegisterPlayer(alice, wsProbe.ref, replyProbe.ref)
 
       val ref = replyProbe.expectMessageType[ActorRef[PlayerActor.Command]]
       ref should not be null
@@ -27,11 +29,12 @@ class PlayerManagerSpec extends AnyWordSpecLike with Matchers {
 
     "return Some(ref) for a registered player" in {
       val pm = spawn(PlayerManager())
+      val wsProbe = TestProbe[Message]()
       val registerProbe = TestProbe[ActorRef[PlayerActor.Command]]()
       val lookupProbe = TestProbe[Option[ActorRef[PlayerActor.Command]]]()
       val alice = Player("alice")
 
-      pm ! PlayerManager.RegisterPlayer(alice, registerProbe.ref)
+      pm ! PlayerManager.RegisterPlayer(alice, wsProbe.ref, registerProbe.ref)
       val ref = registerProbe.expectMessageType[ActorRef[PlayerActor.Command]]
 
       pm ! PlayerManager.LookupPlayer(alice.id, lookupProbe.ref)
@@ -48,13 +51,14 @@ class PlayerManagerSpec extends AnyWordSpecLike with Matchers {
 
     "stop the old actor and return a new ref on reconnect" in {
       val pm = spawn(PlayerManager())
+      val wsProbe = TestProbe[Message]()
       val replyProbe = TestProbe[ActorRef[PlayerActor.Command]]()
       val alice = Player("alice")
 
-      pm ! PlayerManager.RegisterPlayer(alice, replyProbe.ref)
+      pm ! PlayerManager.RegisterPlayer(alice, wsProbe.ref, replyProbe.ref)
       val firstRef = replyProbe.expectMessageType[ActorRef[PlayerActor.Command]]
 
-      pm ! PlayerManager.RegisterPlayer(alice, replyProbe.ref)
+      pm ! PlayerManager.RegisterPlayer(alice, wsProbe.ref, replyProbe.ref)
       val secondRef = replyProbe.expectMessageType[ActorRef[PlayerActor.Command]]
 
       secondRef should not be theSameInstanceAs(firstRef)
@@ -63,11 +67,12 @@ class PlayerManagerSpec extends AnyWordSpecLike with Matchers {
 
     "remove a player on PlayerDisconnected" in {
       val pm = spawn(PlayerManager())
+      val wsProbe = TestProbe[Message]()
       val registerProbe = TestProbe[ActorRef[PlayerActor.Command]]()
       val lookupProbe = TestProbe[Option[ActorRef[PlayerActor.Command]]]()
       val alice = Player("alice")
 
-      pm ! PlayerManager.RegisterPlayer(alice, registerProbe.ref)
+      pm ! PlayerManager.RegisterPlayer(alice, wsProbe.ref, registerProbe.ref)
       registerProbe.expectMessageType[ActorRef[PlayerActor.Command]]
 
       pm ! PlayerManager.PlayerDisconnected(alice.id)

--- a/game-service-server/src/test/scala/com/andy327/server/actors/core/PlayerManagerSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/core/PlayerManagerSpec.scala
@@ -1,0 +1,79 @@
+package com.andy327.server.actors.core
+
+import java.util.UUID
+
+import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
+import org.apache.pekko.actor.typed.ActorRef
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import com.andy327.server.lobby.Player
+
+class PlayerManagerSpec extends AnyWordSpecLike with Matchers {
+  private val testKit = ActorTestKit()
+  import testKit._
+
+  "PlayerManager" should {
+    "register a player and return its actor ref" in {
+      val pm = spawn(PlayerManager())
+      val replyProbe = TestProbe[ActorRef[PlayerActor.Command]]()
+      val alice = Player("alice")
+
+      pm ! PlayerManager.RegisterPlayer(alice, replyProbe.ref)
+
+      val ref = replyProbe.expectMessageType[ActorRef[PlayerActor.Command]]
+      ref should not be null
+    }
+
+    "return Some(ref) for a registered player" in {
+      val pm = spawn(PlayerManager())
+      val registerProbe = TestProbe[ActorRef[PlayerActor.Command]]()
+      val lookupProbe = TestProbe[Option[ActorRef[PlayerActor.Command]]]()
+      val alice = Player("alice")
+
+      pm ! PlayerManager.RegisterPlayer(alice, registerProbe.ref)
+      val ref = registerProbe.expectMessageType[ActorRef[PlayerActor.Command]]
+
+      pm ! PlayerManager.LookupPlayer(alice.id, lookupProbe.ref)
+      lookupProbe.expectMessage(Some(ref))
+    }
+
+    "return None for an unknown player" in {
+      val pm = spawn(PlayerManager())
+      val lookupProbe = TestProbe[Option[ActorRef[PlayerActor.Command]]]()
+
+      pm ! PlayerManager.LookupPlayer(UUID.randomUUID(), lookupProbe.ref)
+      lookupProbe.expectMessage(None)
+    }
+
+    "stop the old actor and return a new ref on reconnect" in {
+      val pm = spawn(PlayerManager())
+      val replyProbe = TestProbe[ActorRef[PlayerActor.Command]]()
+      val alice = Player("alice")
+
+      pm ! PlayerManager.RegisterPlayer(alice, replyProbe.ref)
+      val firstRef = replyProbe.expectMessageType[ActorRef[PlayerActor.Command]]
+
+      pm ! PlayerManager.RegisterPlayer(alice, replyProbe.ref)
+      val secondRef = replyProbe.expectMessageType[ActorRef[PlayerActor.Command]]
+
+      secondRef should not be theSameInstanceAs(firstRef)
+      replyProbe.expectTerminated(firstRef)
+    }
+
+    "remove a player on PlayerDisconnected" in {
+      val pm = spawn(PlayerManager())
+      val registerProbe = TestProbe[ActorRef[PlayerActor.Command]]()
+      val lookupProbe = TestProbe[Option[ActorRef[PlayerActor.Command]]]()
+      val alice = Player("alice")
+
+      pm ! PlayerManager.RegisterPlayer(alice, registerProbe.ref)
+      registerProbe.expectMessageType[ActorRef[PlayerActor.Command]]
+
+      pm ! PlayerManager.PlayerDisconnected(alice.id)
+
+      pm ! PlayerManager.LookupPlayer(alice.id, lookupProbe.ref)
+      lookupProbe.expectMessage(None)
+    }
+  }
+}

--- a/game-service-server/src/test/scala/com/andy327/server/actors/tictactoe/TicTacToeActorSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/tictactoe/TicTacToeActorSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.model.core.{Game, GameId, PlayerId}
 import com.andy327.model.tictactoe.{GameError, Location, O, TicTacToe, X}
-import com.andy327.server.actors.core.GameManager
+import com.andy327.server.actors.core.{GameManager, PlayerActor, PlayerEvent}
 import com.andy327.server.actors.persistence.PersistenceProtocol
 import com.andy327.server.http.json.{GameState, TicTacToeState}
 import com.andy327.server.lobby.GameLifecycleStatus
@@ -282,6 +282,62 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
       val result = replyProbe.receiveMessage()
       result shouldBe a[Right[_, _]]
+    }
+
+    "push GameStateUpdated to subscribers after a valid move" in {
+      val persistProbe = createTestProbe[PersistenceProtocol.Command]()
+      val subscriberProbe = createTestProbe[PlayerActor.Command]()
+      val (_, behavior) = TicTacToeActor.create(UUID.randomUUID(), Seq(alice, bob), persistProbe.ref, dummyGameManager)
+      val actor = spawn(behavior)
+
+      actor ! TicTacToeActor.Subscribe(subscriberProbe.ref)
+      actor ! TicTacToeActor.MakeMove(alice, Location(0, 0), createTestProbe[Either[GameError, GameState]]().ref)
+
+      val event = subscriberProbe.expectMessageType[PlayerActor.SendEvent]
+      event.event shouldBe a[PlayerEvent.GameStateUpdated]
+    }
+
+    "push GameEnded to subscribers when the game completes" in {
+      val persistProbe = createTestProbe[PersistenceProtocol.Command]()
+      val subscriberProbe = createTestProbe[PlayerActor.Command]()
+      val gameManagerProbe = createTestProbe[GameManager.Command]()
+      val gameId: GameId = UUID.randomUUID()
+      val (_, behavior) = TicTacToeActor.create(gameId, Seq(alice, bob), persistProbe.ref, gameManagerProbe.ref)
+      val actor = spawn(behavior)
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+
+      actor ! TicTacToeActor.Subscribe(subscriberProbe.ref)
+
+      val moves = Seq(
+        (alice, Location(0, 0)),
+        (bob, Location(1, 0)),
+        (alice, Location(0, 1)),
+        (bob, Location(1, 1)),
+        (alice, Location(0, 2)) // X wins
+      )
+
+      moves.foreach { case (player, loc) =>
+        actor ! TicTacToeActor.MakeMove(player, loc, replyProbe.ref)
+        replyProbe.receiveMessage()
+        subscriberProbe.expectMessageType[PlayerActor.SendEvent] // GameStateUpdated per move
+        val _ = persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+      }
+
+      val endEvent = subscriberProbe.expectMessageType[PlayerActor.SendEvent]
+      endEvent.event shouldBe PlayerEvent.GameEnded(GameLifecycleStatus.Completed)
+    }
+
+    "not push events to unsubscribed players" in {
+      val persistProbe = createTestProbe[PersistenceProtocol.Command]()
+      val subscriberProbe = createTestProbe[PlayerActor.Command]()
+      val (_, behavior) = TicTacToeActor.create(UUID.randomUUID(), Seq(alice, bob), persistProbe.ref, dummyGameManager)
+      val actor = spawn(behavior)
+
+      actor ! TicTacToeActor.Subscribe(subscriberProbe.ref)
+      actor ! TicTacToeActor.Unsubscribe(subscriberProbe.ref)
+      actor ! TicTacToeActor.MakeMove(alice, Location(0, 0), createTestProbe[Either[GameError, GameState]]().ref)
+
+      subscriberProbe.expectNoMessage()
     }
 
     "notify the GameManager when a game completes" in {

--- a/game-service-server/src/test/scala/com/andy327/server/game/modules/TicTacToeModuleSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/game/modules/TicTacToeModuleSpec.scala
@@ -7,6 +7,7 @@ import spray.json._
 
 import com.andy327.model.core.GameError
 import com.andy327.model.tictactoe.Location
+import com.andy327.server.actors.core.PlayerActor
 import com.andy327.server.actors.tictactoe.TicTacToeActor
 import com.andy327.server.game.{GameOperation, MovePayload}
 import com.andy327.server.http.json.GameState
@@ -49,6 +50,22 @@ class TicTacToeModuleSpec extends AnyWordSpecLike with Matchers {
 
         case other => fail(s"Unexpected result: $other")
       }
+    }
+
+    "convert GetState to a GetState GameCommand" in {
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+
+      val result = TicTacToeModule.toGameCommand(GameOperation.GetState, replyProbe.ref)
+
+      result shouldBe Right(TicTacToeActor.GetState(replyProbe.ref))
+    }
+
+    "produce a Subscribe command for a given PlayerActor ref" in {
+      val playerProbe = TestProbe[PlayerActor.Command]()
+
+      val result = TicTacToeModule.subscribeCommand(playerProbe.ref)
+
+      result shouldBe TicTacToeActor.Subscribe(playerProbe.ref)
     }
 
     "return error when passing unsupported MovePayload to toGameCommand" in {

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -9,6 +9,7 @@ import spray.json._
 import com.andy327.model.core.GameType
 import com.andy327.model.tictactoe.TicTacToe
 import com.andy327.server.actors.core.GameManager.{ErrorResponse, LobbyCreated, LobbyJoined, LobbyLeft}
+import com.andy327.server.actors.core.PlayerEvent
 import com.andy327.server.http.json.GameStateConverters
 import com.andy327.server.http.json.TicTacToeState._
 import com.andy327.server.lobby._
@@ -179,6 +180,48 @@ class SerializationSpec extends AnyWordSpec with Matchers {
       val view = GameStateConverters.serializeGame(game)
       val json = view.toJson
       json.convertTo[TicTacToeState] shouldBe view
+    }
+  }
+
+  "playerEventFormat" should {
+    "serialize LobbyUpdated with type discriminator and metadata" in {
+      val host = Player("host")
+      val metadata = LobbyMetadata(
+        gameId = java.util.UUID.randomUUID(),
+        gameType = GameType.TicTacToe,
+        players = Map(host.id -> host),
+        hostId = host.id,
+        status = GameLifecycleStatus.WaitingForPlayers
+      )
+      val event: PlayerEvent = PlayerEvent.LobbyUpdated(metadata)
+      val json = event.toJson.asJsObject
+      json.fields("type") shouldBe JsString("LobbyUpdated")
+      (json.fields should contain).key("metadata")
+    }
+
+    "serialize GameStateUpdated with type discriminator and state" in {
+      val alice = Player("alice")
+      val bob = Player("bob")
+      val game = TicTacToe.empty(alice.id, bob.id)
+      val state = GameStateConverters.serializeGame(game)
+      val event: PlayerEvent = PlayerEvent.GameStateUpdated(state)
+      val json = event.toJson.asJsObject
+      json.fields("type") shouldBe JsString("GameStateUpdated")
+      (json.fields should contain).key("state")
+    }
+
+    "serialize GameEnded with type discriminator and result" in {
+      val event: PlayerEvent = PlayerEvent.GameEnded(GameLifecycleStatus.Completed)
+      val json = event.toJson.asJsObject
+      json.fields("type") shouldBe JsString("GameEnded")
+      json.fields("result") shouldBe JsString("Completed")
+    }
+
+    "throw DeserializationException on read" in {
+      val ex = intercept[DeserializationException] {
+        JsObject("type" -> JsString("LobbyUpdated")).convertTo[PlayerEvent]
+      }
+      ex.getMessage should include("PlayerEvent deserialization is not supported")
     }
   }
 }

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/WebSocketRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/WebSocketRoutesSpec.scala
@@ -1,0 +1,52 @@
+package com.andy327.server.http.routes
+
+import org.apache.pekko.actor.testkit.typed.scaladsl.ActorTestKit
+import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.model.headers.RawHeader
+import org.apache.pekko.http.scaladsl.testkit.{ScalatestRouteTest, WSProbe}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import com.andy327.server.actors.core.{GameManager, InMemRepo}
+import com.andy327.server.actors.persistence.PersistenceProtocol
+import com.andy327.server.lobby.Player
+import com.andy327.server.testutil.AuthTestHelper.createTestToken
+
+class WebSocketRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
+  private val typedKit = ActorTestKit()
+  private val persistProbe = typedKit.createTestProbe[PersistenceProtocol.Command]()
+  private val gameRepo = new InMemRepo
+  private val typedSystem: ActorSystem[GameManager.Command] =
+    ActorSystem(GameManager(persistProbe.ref, gameRepo), "WebSocketRoutesSpecSystem")
+
+  private val routes = new WebSocketRoutes(typedSystem).routes
+
+  "WebSocketRoutes" should {
+    "reject a connection with no Authorization header" in {
+      val wsClient = WSProbe()
+      WS("/ws", wsClient.flow) ~> routes ~> check {
+        status shouldBe StatusCodes.Unauthorized
+      }
+    }
+
+    "reject a connection with an invalid token" in {
+      val wsClient = WSProbe()
+      WS("/ws", wsClient.flow) ~> addHeader(RawHeader("Authorization", "Bearer not-a-real-token")) ~>
+      routes ~> check {
+        status shouldBe StatusCodes.Unauthorized
+      }
+    }
+
+    "upgrade the connection to WebSocket with a valid token" in {
+      val alice = Player("alice")
+      val token = createTestToken(alice)
+      val wsClient = WSProbe()
+
+      WS("/ws", wsClient.flow) ~> addHeader(RawHeader("Authorization", s"Bearer $token")) ~>
+      routes ~> check {
+        isWebSocketUpgrade shouldBe true
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Introduces `PlayerActor` (one per connected player) that holds a WebSocket sink ref and forwards serialized `PlayerEvent`s as JSON `TextMessage`s
- Adds `PlayerManager` child actor under `GameManager` to track live player refs by ID, with reconnect support via a spawn counter
- Implements `GET /ws` endpoint in `WebSocketRoutes`: authenticates via Bearer token, pre-materializes an `ActorSource`-backed stream, registers the player through `GameManager`, and sends `PlayerDisconnected` on WebSocket close
- Adds write-only `playerEventFormat` in `JsonProtocol` with a `type` discriminator field for `LobbyUpdated`, `GameStateUpdated`, and `GameEnded`
