### PR TITLE
Add ConnectFour game support (Closes #10)

### DIFF
--- a/game-service-model/src/main/scala/com/andy327/model/connectfour/ConnectFour.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/connectfour/ConnectFour.scala
@@ -1,0 +1,132 @@
+package com.andy327.model.connectfour
+
+import com.andy327.model.core.{Game, PlayerId, Renderable}
+
+import GameError._
+
+object ConnectFour {
+  val Rows: Int = 6
+  val Cols: Int = 7
+  val WinLength: Int = 4
+
+  /** Creates a new empty ConnectFour game with the specified players.
+    *
+    * Red always moves first.
+    */
+  def empty(playerRed: PlayerId, playerYellow: PlayerId): ConnectFour = ConnectFour(
+    playerRed = playerRed,
+    playerYellow = playerYellow,
+    board = Vector.fill(Rows, Cols)(Option.empty[Mark]),
+    currentPlayer = Red,
+    winner = None,
+    isDraw = false
+  )
+
+  /** Returns the lowest empty row index in the given column, or None if the column is full.
+    *
+    * Row indices increase downward (row 0 is top, row 5 is bottom), so pieces fall to the highest-indexed empty row.
+    */
+  private def lowestEmptyRow(board: Board, col: Int): Option[Int] =
+    (Rows - 1 to 0 by -1).find(row => board(row)(col).isEmpty)
+
+  /** Counts consecutive same-mark pieces in one direction from (row, col), not including (row, col) itself. */
+  private def countDir(board: Board, row: Int, col: Int, dr: Int, dc: Int, mark: Mark): Int = {
+    var count = 0
+    var r = row + dr
+    var c = col + dc
+    while (r >= 0 && r < Rows && c >= 0 && c < Cols && board(r)(c).contains(mark)) {
+      count += 1
+      r += dr
+      c += dc
+    }
+    count
+  }
+
+  private val WinDirections: Seq[(Int, Int)] = Seq((0, 1), (1, 0), (1, 1), (1, -1))
+
+  /** Returns true if placing `mark` at `(row, col)` on `board` creates a line of [[WinLength]] or more.
+    *
+    * Checks all four axis directions: horizontal, vertical, diagonal down-right, diagonal down-left.
+    */
+  private def isWinningMove(board: Board, row: Int, col: Int, mark: Mark): Boolean =
+    WinDirections.exists { case (dr, dc) =>
+      countDir(board, row, col, dr, dc, mark) +
+        countDir(board, row, col, -dr, -dc, mark) + 1 >= WinLength
+    }
+}
+
+/** Represents an instance of a ConnectFour game, including both the current state and the rules for how the game
+  * evolves.
+  *
+  * ConnectFour is played on a 6-row × 7-column board. Players alternate dropping pieces into columns; each piece falls
+  * to the lowest empty row. The first player to connect four pieces in a horizontal, vertical, or diagonal line wins.
+  * If the board fills with no winner the game is a draw.
+  *
+  * @param playerRed the player ID assigned to Red (moves first)
+  * @param playerYellow the player ID assigned to Yellow
+  * @param board the 6×7 board; `board(row)(col)` holds the mark at that cell or None if empty
+  * @param currentPlayer the mark (Red or Yellow) whose turn it is
+  * @param winner the winning mark if the game is over, otherwise None
+  * @param isDraw true if the board is full with no winner
+  */
+final case class ConnectFour(
+    playerRed: PlayerId,
+    playerYellow: PlayerId,
+    board: Board,
+    currentPlayer: Mark,
+    winner: Option[Mark],
+    isDraw: Boolean
+) extends Game[Drop, ConnectFour, Mark, GameStatus, GameError]
+    with Renderable {
+
+  import ConnectFour._
+
+  def currentState: ConnectFour = this
+
+  def gameStatus: GameStatus =
+    winner.map(Won(_)).getOrElse(if (isDraw) Draw else InProgress)
+
+  private def nextPlayer: Mark = currentPlayer match {
+    case Red    => Yellow
+    case Yellow => Red
+  }
+
+  /** Drops a piece for `player` into the column specified by `drop`.
+    *
+    * Validates turn order, column bounds, and column capacity. On success returns the updated game state with the piece
+    * placed at the lowest empty row. Detects win (four in a line through the placed cell) and draw (board full with no
+    * winner) after each move.
+    */
+  def play(player: Mark, drop: Drop): Either[GameError, ConnectFour] =
+    if (gameStatus != InProgress)
+      Left(GameOver)
+    else if (player != currentPlayer)
+      Left(InvalidTurn)
+    else if (drop.col < 0 || drop.col >= Cols)
+      Left(InvalidColumn)
+    else
+      lowestEmptyRow(board, drop.col) match {
+        case None      => Left(ColumnFull)
+        case Some(row) =>
+          val newBoard = board.updated(row, board(row).updated(drop.col, Some(player)))
+          val won = isWinningMove(newBoard, row, drop.col, player)
+          val draw = !won && newBoard.forall(_.forall(_.isDefined))
+          Right(
+            copy(
+              board = newBoard,
+              currentPlayer = nextPlayer,
+              winner = if (won) Some(player) else None,
+              isDraw = draw
+            )
+          )
+      }
+
+  /** Returns a human-readable representation of the board for logging. */
+  def render: String = {
+    val border = "-" * (Cols * 2 + 1)
+    val rows = board
+      .map(_.map(_.fold(".")(_.toString)).mkString("|", "|", "|"))
+      .mkString("\n")
+    s"$border\n$rows\n$border"
+  }
+}

--- a/game-service-model/src/main/scala/com/andy327/model/connectfour/GameError.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/connectfour/GameError.scala
@@ -1,0 +1,33 @@
+package com.andy327.model.connectfour
+
+import com.andy327.model.core.{GameError => CoreGameError, PlayerId}
+
+/** Game-specific error types for ConnectFour.
+  *
+  * These errors represent invalid game actions or states, such as dropping into a full column, moving out of turn, or
+  * interacting with a finished game.
+  */
+sealed trait GameError extends CoreGameError
+
+object GameError {
+
+  case class InvalidPlayer(playerId: PlayerId) extends GameError {
+    val message: String = s"Unknown player: $playerId"
+  }
+
+  case object InvalidTurn extends GameError {
+    val message = "It's not your turn."
+  }
+
+  case object InvalidColumn extends GameError {
+    val message = "Column is out of bounds."
+  }
+
+  case object ColumnFull extends GameError {
+    val message = "That column is full."
+  }
+
+  case object GameOver extends GameError {
+    val message = "The game is already over."
+  }
+}

--- a/game-service-model/src/main/scala/com/andy327/model/connectfour/GameStatus.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/connectfour/GameStatus.scala
@@ -1,0 +1,20 @@
+package com.andy327.model.connectfour
+
+/** The outcome state of a ConnectFour game.
+  *
+  * Transitions are one-way: a game starts as [[InProgress]] and moves to either [[Won]] or [[Draw]] once the board
+  * reaches a terminal position.
+  */
+sealed trait GameStatus
+
+/** The game is still being played — no winner yet and at least one empty cell remains. */
+case object InProgress extends GameStatus
+
+/** A player has connected four pieces in a line.
+  *
+  * @param winner the mark (Red or Yellow) that won.
+  */
+case class Won(winner: Mark) extends GameStatus
+
+/** The board is completely filled and no player connected four in a line. */
+case object Draw extends GameStatus

--- a/game-service-model/src/main/scala/com/andy327/model/connectfour/package.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/connectfour/package.scala
@@ -1,0 +1,28 @@
+package com.andy327.model
+
+package object connectfour {
+
+  /** The 6×7 game board, represented as a row-major vector of cells.
+    *
+    * Row 0 is the top; row 5 is the bottom. Each cell holds the mark of the player who dropped a piece there, or None
+    * if the cell is empty.
+    */
+  type Board = Vector[Vector[Option[Mark]]]
+
+  /** Identifies which player owns a cell.
+    *
+    * Red always moves first.
+    */
+  sealed trait Mark {
+    def symbol: String
+    override def toString: String = symbol
+  }
+  case object Red extends Mark { val symbol = "R" }
+  case object Yellow extends Mark { val symbol = "Y" }
+
+  /** A move in ConnectFour: drop a piece into the given column.
+    *
+    * The piece falls to the lowest empty row.
+    */
+  case class Drop(col: Int)
+}

--- a/game-service-model/src/main/scala/com/andy327/model/connectfour/package.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/connectfour/package.scala
@@ -13,10 +13,7 @@ package object connectfour {
     *
     * Red always moves first.
     */
-  sealed trait Mark {
-    def symbol: String
-    override def toString: String = symbol
-  }
+  sealed trait Mark extends com.andy327.model.core.Mark
   case object Red extends Mark { val symbol = "R" }
   case object Yellow extends Mark { val symbol = "Y" }
 

--- a/game-service-model/src/main/scala/com/andy327/model/core/GameType.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/core/GameType.scala
@@ -21,13 +21,19 @@ object GameType {
     val (minPlayers, maxPlayers) = (2, 2)
   }
 
+  /** A two-player strategy game where players drop pieces into a 6-row x 7-column grid, aiming to connect four. */
+  case object ConnectFour extends GameType {
+    val (minPlayers, maxPlayers) = (2, 2)
+  }
+
   /** Parses a string into a GameType instance.
     *
     * @param s the name of the game type (case-insensitive)
     * @return Some(GameType) if recognized, or None if the input is invalid
     */
   def fromString(s: String): Option[GameType] = s.toLowerCase match {
-    case "tictactoe" => Some(TicTacToe)
-    case _           => None
+    case "tictactoe"   => Some(TicTacToe)
+    case "connectfour" => Some(ConnectFour)
+    case _             => None
   }
 }

--- a/game-service-model/src/main/scala/com/andy327/model/core/GameTypeTag.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/core/GameTypeTag.scala
@@ -1,5 +1,6 @@
 package com.andy327.model.core
 
+import com.andy327.model.connectfour.ConnectFour
 import com.andy327.model.tictactoe.TicTacToe
 
 /** Type class used to associate a specific game model type (e.g., TicTacToe) with its corresponding GameType (e.g.,
@@ -21,5 +22,9 @@ object GameTypeTag {
 
   implicit val ticTacToeTag: GameTypeTag[TicTacToe] = new GameTypeTag[TicTacToe] {
     override val value: GameType = GameType.TicTacToe
+  }
+
+  implicit val connectFourTag: GameTypeTag[ConnectFour] = new GameTypeTag[ConnectFour] {
+    override val value: GameType = GameType.ConnectFour
   }
 }

--- a/game-service-model/src/main/scala/com/andy327/model/core/Mark.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/core/Mark.scala
@@ -1,0 +1,11 @@
+package com.andy327.model.core
+
+/** Shared contract for player marks (tokens/pieces) used in turn-based games.
+  *
+  * Each mark has a single-character symbol used for serialization and display. Game-specific mark types (e.g.,
+  * `tictactoe.Mark`, `connectfour.Mark`) extend this trait as sealed hierarchies in their own packages.
+  */
+trait Mark {
+  def symbol: String
+  override def toString: String = symbol
+}

--- a/game-service-model/src/main/scala/com/andy327/model/tictactoe/package.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/tictactoe/package.scala
@@ -8,10 +8,7 @@ package object tictactoe {
   type Board = Vector[Vector[Option[Mark]]]
 
   /** Identifies which player owns a cell. X always moves first. */
-  sealed trait Mark {
-    def symbol: String
-    override def toString: String = symbol
-  }
+  sealed trait Mark extends com.andy327.model.core.Mark
   case object X extends Mark { val symbol = "X" }
   case object O extends Mark { val symbol = "O" }
 

--- a/game-service-model/src/test/scala/com/andy327/model/connectfour/ConnectFourSpec.scala
+++ b/game-service-model/src/test/scala/com/andy327/model/connectfour/ConnectFourSpec.scala
@@ -1,0 +1,149 @@
+package com.andy327.model.connectfour
+
+import java.util.UUID
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import com.andy327.model.core.PlayerId
+
+class ConnectFourSpec extends AnyWordSpec with Matchers {
+  val alice: PlayerId = UUID.randomUUID()
+  val bob: PlayerId = UUID.randomUUID()
+
+  "A ConnectFour game" should {
+
+    "start with an empty board and Red moving first" in {
+      val game = ConnectFour.empty(alice, bob)
+      game.board.flatten.flatten shouldBe empty
+      game.currentPlayer shouldBe Red
+      game.gameStatus shouldBe InProgress
+    }
+
+    "place a piece at the lowest empty row when a column is chosen" in {
+      val Right(game) = ConnectFour.empty(alice, bob).play(Red, Drop(3))
+      game.board(5)(3) shouldBe Some(Red) // falls to the bottom row
+      game.currentPlayer shouldBe Yellow
+    }
+
+    "stack pieces on top of each other in the same column" in {
+      val Right(g1) = ConnectFour.empty(alice, bob).play(Red, Drop(0))
+      val Right(g2) = g1.play(Yellow, Drop(0))
+      g2.board(5)(0) shouldBe Some(Red) // first piece at bottom
+      g2.board(4)(0) shouldBe Some(Yellow) // second piece stacked above
+    }
+
+    "reject a move when it is not the player's turn" in {
+      val game = ConnectFour.empty(alice, bob)
+      game.play(Yellow, Drop(0)) shouldBe Left(GameError.InvalidTurn)
+    }
+
+    "reject a move for a column that is out of bounds" in {
+      val game = ConnectFour.empty(alice, bob)
+      game.play(Red, Drop(-1)) shouldBe Left(GameError.InvalidColumn)
+      game.play(Red, Drop(7)) shouldBe Left(GameError.InvalidColumn)
+    }
+
+    "reject a move when the column is full" in {
+      // Fill column 0 with alternating pieces (6 rows)
+      val full = (0 until ConnectFour.Rows).foldLeft(ConnectFour.empty(alice, bob)) { (game, _) =>
+        game.play(game.currentPlayer, Drop(0)).toOption.get
+      }
+      full.play(full.currentPlayer, Drop(0)) shouldBe Left(GameError.ColumnFull)
+    }
+
+    "detect a horizontal win" in {
+      // Red wins bottom row cols 0–3; Yellow stacks safely in col 6
+      val game = ConnectFour.empty(alice, bob)
+        .play(Red, Drop(0)).toOption.get // Red  (5,0)
+        .play(Yellow, Drop(6)).toOption.get // Yellow (5,6)
+        .play(Red, Drop(1)).toOption.get // Red  (5,1)
+        .play(Yellow, Drop(6)).toOption.get // Yellow (4,6)
+        .play(Red, Drop(2)).toOption.get // Red  (5,2)
+        .play(Yellow, Drop(6)).toOption.get // Yellow (3,6)
+        .play(Red, Drop(3)).toOption.get // Red  (5,3) — wins
+
+      game.gameStatus shouldBe Won(Red)
+    }
+
+    "detect a vertical win" in {
+      // Red fills column 0 from the bottom; Yellow stacks in col 1
+      val game = ConnectFour.empty(alice, bob)
+        .play(Red, Drop(0)).toOption.get // Red  (5,0)
+        .play(Yellow, Drop(1)).toOption.get // Yellow (5,1)
+        .play(Red, Drop(0)).toOption.get // Red  (4,0)
+        .play(Yellow, Drop(1)).toOption.get // Yellow (4,1)
+        .play(Red, Drop(0)).toOption.get // Red  (3,0)
+        .play(Yellow, Drop(1)).toOption.get // Yellow (3,1)
+        .play(Red, Drop(0)).toOption.get // Red  (2,0) — wins
+
+      game.gameStatus shouldBe Won(Red)
+    }
+
+    "detect a diagonal win" in {
+      // Red wins on the up-right diagonal: (5,0) (4,1) (3,2) (2,3)
+      // Yellow pieces fill the required foundation cells in cols 1–3; Red uses col 4 as filler
+      val game = ConnectFour.empty(alice, bob)
+        .play(Red, Drop(0)).toOption.get // Red  (5,0) — diagonal
+        .play(Yellow, Drop(1)).toOption.get // Yellow (5,1) — foundation for col 1
+        .play(Red, Drop(4)).toOption.get // Red  (5,4) — filler
+        .play(Yellow, Drop(2)).toOption.get // Yellow (5,2) — foundation for col 2
+        .play(Red, Drop(1)).toOption.get // Red  (4,1) — diagonal
+        .play(Yellow, Drop(3)).toOption.get // Yellow (5,3) — foundation for col 3
+        .play(Red, Drop(4)).toOption.get // Red  (4,4) — filler
+        .play(Yellow, Drop(2)).toOption.get // Yellow (4,2) — foundation for col 2
+        .play(Red, Drop(4)).toOption.get // Red  (3,4) — filler
+        .play(Yellow, Drop(3)).toOption.get // Yellow (4,3) — foundation for col 3
+        .play(Red, Drop(2)).toOption.get // Red  (3,2) — diagonal
+        .play(Yellow, Drop(3)).toOption.get // Yellow (3,3) — foundation for col 3
+        .play(Red, Drop(3)).toOption.get // Red  (2,3) — diagonal, wins
+
+      game.gameStatus shouldBe Won(Red)
+    }
+
+    "detect a draw when the board is full with no winner" in {
+      val fullBoard = ConnectFour(
+        playerRed = alice,
+        playerYellow = bob,
+        board = Vector.fill(ConnectFour.Rows, ConnectFour.Cols)(Option.empty[Mark]),
+        currentPlayer = Red,
+        winner = None,
+        isDraw = true
+      )
+      fullBoard.gameStatus shouldBe Draw
+    }
+
+    "reject a move after the game is won" in {
+      val won = ConnectFour.empty(alice, bob)
+        .play(Red, Drop(0)).toOption.get
+        .play(Yellow, Drop(6)).toOption.get
+        .play(Red, Drop(1)).toOption.get
+        .play(Yellow, Drop(6)).toOption.get
+        .play(Red, Drop(2)).toOption.get
+        .play(Yellow, Drop(6)).toOption.get
+        .play(Red, Drop(3)).toOption.get // Red wins
+
+      won.gameStatus shouldBe Won(Red)
+      won.play(Yellow, Drop(0)) shouldBe Left(GameError.GameOver)
+    }
+
+    "render the board as a human-readable string" in {
+      val game = ConnectFour.empty(alice, bob)
+        .play(Red, Drop(0)).toOption.get // Red  (5,0)
+        .play(Yellow, Drop(1)).toOption.get // Yellow (5,1)
+        .play(Red, Drop(1)).toOption.get // Red  (4,1)
+
+      val expected =
+        "---------------\n" +
+          "|.|.|.|.|.|.|.|\n" +
+          "|.|.|.|.|.|.|.|\n" +
+          "|.|.|.|.|.|.|.|\n" +
+          "|.|.|.|.|.|.|.|\n" +
+          "|.|R|.|.|.|.|.|\n" +
+          "|R|Y|.|.|.|.|.|\n" +
+          "---------------"
+
+      game.render shouldBe expected
+    }
+  }
+}

--- a/game-service-persistence/src/main/scala/com/andy327/persistence/db/postgres/PostgresGameRepository.scala
+++ b/game-service-persistence/src/main/scala/com/andy327/persistence/db/postgres/PostgresGameRepository.scala
@@ -18,7 +18,6 @@ import com.andy327.persistence.db.schema.GameTypeCodecs
   * serialized to JSON using Circe and stored as a string in the database.
   */
 class PostgresGameRepository(xa: Transactor[IO]) extends GameRepository {
-  import GameTypeCodecs._
 
   private val logger = LoggerFactory.getLogger(getClass)
 

--- a/game-service-persistence/src/main/scala/com/andy327/persistence/db/postgres/PostgresGameRepository.scala
+++ b/game-service-persistence/src/main/scala/com/andy327/persistence/db/postgres/PostgresGameRepository.scala
@@ -11,7 +11,6 @@ import doobie._
 import doobie.implicits._
 
 import com.andy327.model.core.{Game, GameId, GameType}
-import com.andy327.model.tictactoe.TicTacToe
 import com.andy327.persistence.db.GameRepository
 import com.andy327.persistence.db.schema.GameTypeCodecs
 
@@ -20,7 +19,6 @@ import com.andy327.persistence.db.schema.GameTypeCodecs
   */
 class PostgresGameRepository(xa: Transactor[IO]) extends GameRepository {
   import GameTypeCodecs._
-  import io.circe.syntax._
 
   private val logger = LoggerFactory.getLogger(getClass)
 
@@ -38,11 +36,8 @@ class PostgresGameRepository(xa: Transactor[IO]) extends GameRepository {
     * existing row is updated.
     */
   override def saveGame(gameId: GameId, gameType: GameType, game: Game[_, _, _, _, _]): IO[Unit] = {
-    val (jsonStr, gameTypeStr) = gameType match {
-      case GameType.TicTacToe =>
-        val typedGame = game.asInstanceOf[TicTacToe]
-        (typedGame.asJson.noSpaces, "TicTacToe")
-    }
+    val jsonStr = GameTypeCodecs.serializeGame(gameType, game)
+    val gameTypeStr = gameType.toString
 
     sql"""
       INSERT INTO games (game_id, game_type, game_state)

--- a/game-service-persistence/src/main/scala/com/andy327/persistence/db/schema/GameTypeCodecs.scala
+++ b/game-service-persistence/src/main/scala/com/andy327/persistence/db/schema/GameTypeCodecs.scala
@@ -2,8 +2,10 @@ package com.andy327.persistence.db.schema
 
 import io.circe.generic.semiauto.deriveCodec
 import io.circe.parser.decode
+import io.circe.syntax._
 import io.circe.{Codec, Decoder, Encoder}
 
+import com.andy327.model.connectfour.{ConnectFour, Mark => ConnectFourMark, Red, Yellow}
 import com.andy327.model.core.{Game, GameType}
 import com.andy327.model.tictactoe.{Mark, O, TicTacToe, X}
 
@@ -16,15 +18,17 @@ import com.andy327.model.tictactoe.{Mark, O, TicTacToe, X}
 object GameTypeCodecs {
   implicit val gameTypeCodec: Codec[GameType] = Codec.from(
     Decoder.decodeString.emap {
-      case "TicTacToe" => Right(GameType.TicTacToe)
-      case other       => Left(s"Unknown GameType: $other")
+      case "TicTacToe"   => Right(GameType.TicTacToe)
+      case "ConnectFour" => Right(GameType.ConnectFour)
+      case other         => Left(s"Unknown GameType: $other")
     },
-    Encoder.encodeString.contramap { case GameType.TicTacToe =>
-      "TicTacToe"
+    Encoder.encodeString.contramap[GameType] {
+      case GameType.TicTacToe   => "TicTacToe"
+      case GameType.ConnectFour => "ConnectFour"
     }
   )
 
-  implicit val markCodec: Codec[Mark] = Codec.from(
+  implicit val ticTacToeMarkCodec: Codec[Mark] = Codec.from(
     Decoder.decodeString.emap {
       case "X"   => Right(X)
       case "O"   => Right(O)
@@ -35,9 +39,27 @@ object GameTypeCodecs {
 
   implicit val ticTacToeCodec: Codec[TicTacToe] = deriveCodec[TicTacToe]
 
+  implicit val connectFourMarkCodec: Codec[ConnectFourMark] = Codec.from(
+    Decoder.decodeString.emap {
+      case "R"   => Right(Red)
+      case "Y"   => Right(Yellow)
+      case other => Left(s"Invalid ConnectFour Mark: expected 'R' or 'Y', got '$other'")
+    },
+    Encoder.encodeString.contramap[ConnectFourMark](_.symbol)
+  )
+
+  implicit val connectFourCodec: Codec[ConnectFour] = deriveCodec[ConnectFour]
+
+  /** Serializes a game instance to a JSON string using the codec for the given GameType. */
+  def serializeGame(gameType: GameType, game: Game[_, _, _, _, _]): String = gameType match {
+    case GameType.TicTacToe   => game.asInstanceOf[TicTacToe].asJson.noSpaces
+    case GameType.ConnectFour => game.asInstanceOf[ConnectFour].asJson.noSpaces
+  }
+
   /** Deserializes a game state JSON string into a Game instance based on the provided GameType. */
   def deserializeGame(gameType: GameType, json: String): Either[Throwable, Game[_, _, _, _, _]] =
     gameType match {
-      case GameType.TicTacToe => decode[TicTacToe](json).left.map(err => new Exception(err))
+      case GameType.TicTacToe   => decode[TicTacToe](json).left.map(err => new Exception(err))
+      case GameType.ConnectFour => decode[ConnectFour](json).left.map(err => new Exception(err))
     }
 }

--- a/game-service-persistence/src/test/scala/com/andy327/persistence/db/schema/GameTypeCodecsSpec.scala
+++ b/game-service-persistence/src/test/scala/com/andy327/persistence/db/schema/GameTypeCodecsSpec.scala
@@ -7,6 +7,7 @@ import io.circe.syntax._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import com.andy327.model.connectfour.{ConnectFour, Drop, Red}
 import com.andy327.model.core.{GameType, PlayerId}
 import com.andy327.model.tictactoe.{Location, TicTacToe, X}
 
@@ -40,7 +41,7 @@ class GameTypeCodecsSpec extends AnyWordSpec with Matchers {
       result shouldBe Right(game)
     }
 
-    "fail to decode an unknown Mark type" in {
+    "fail to decode an unknown TicTacToe Mark type" in {
       val json = """{
         "playerX":"alice",
         "playerO":"bob",
@@ -58,10 +59,39 @@ class GameTypeCodecsSpec extends AnyWordSpec with Matchers {
       result.isLeft shouldBe true
     }
 
-    "return Left if game JSON is invalid" in {
+    "return Left if TicTacToe game JSON is invalid" in {
       val badJson = """{ "not": "valid" }"""
 
       val result = deserializeGame(GameType.TicTacToe, badJson)
+      result.isLeft shouldBe true
+    }
+
+    "correctly encode and decode GameType.ConnectFour" in {
+      val t: GameType = GameType.ConnectFour
+      val json = t.asJson.noSpaces
+      json shouldBe "\"ConnectFour\""
+
+      val decoded = decode[GameType](json)
+      decoded shouldBe Right(GameType.ConnectFour)
+    }
+
+    "deserialize a valid ConnectFour game from JSON" in {
+      val game = ConnectFour.empty(alice, bob).play(Red, Drop(3)).toOption.get
+      val json = game.asJson.noSpaces
+      val result = deserializeGame(GameType.ConnectFour, json)
+      result shouldBe Right(game)
+    }
+
+    "fail to decode an invalid ConnectFour Mark" in {
+      val baseJson = ConnectFour.empty(alice, bob).asJson.noSpaces
+      val corruptedJson = baseJson.replace("\"currentPlayer\":\"R\"", "\"currentPlayer\":\"Z\"")
+      val result = deserializeGame(GameType.ConnectFour, corruptedJson)
+      result.isLeft shouldBe true
+    }
+
+    "return Left if ConnectFour game JSON is invalid" in {
+      val badJson = """{ "not": "valid" }"""
+      val result = deserializeGame(GameType.ConnectFour, badJson)
       result.isLeft shouldBe true
     }
   }

--- a/game-service-persistence/src/test/scala/com/andy327/persistence/db/schema/GameTypeCodecsSpec.scala
+++ b/game-service-persistence/src/test/scala/com/andy327/persistence/db/schema/GameTypeCodecsSpec.scala
@@ -34,11 +34,10 @@ class GameTypeCodecsSpec extends AnyWordSpec with Matchers {
       err.getMessage should include("Unknown GameType")
     }
 
-    "deserialize a valid TicTacToe game from JSON" in {
+    "round-trip a TicTacToe game through serializeGame and deserializeGame" in {
       val game = TicTacToe.empty(alice, bob).play(X, Location(0, 0)).toOption.get
-      val json = game.asJson.noSpaces
-      val result = deserializeGame(GameType.TicTacToe, json)
-      result shouldBe Right(game)
+      val json = serializeGame(GameType.TicTacToe, game)
+      deserializeGame(GameType.TicTacToe, json) shouldBe Right(game)
     }
 
     "fail to decode an unknown TicTacToe Mark type" in {
@@ -75,11 +74,10 @@ class GameTypeCodecsSpec extends AnyWordSpec with Matchers {
       decoded shouldBe Right(GameType.ConnectFour)
     }
 
-    "deserialize a valid ConnectFour game from JSON" in {
+    "round-trip a ConnectFour game through serializeGame and deserializeGame" in {
       val game = ConnectFour.empty(alice, bob).play(Red, Drop(3)).toOption.get
-      val json = game.asJson.noSpaces
-      val result = deserializeGame(GameType.ConnectFour, json)
-      result shouldBe Right(game)
+      val json = serializeGame(GameType.ConnectFour, game)
+      deserializeGame(GameType.ConnectFour, json) shouldBe Right(game)
     }
 
     "fail to decode an invalid ConnectFour Mark" in {

--- a/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
@@ -75,6 +75,7 @@ object GameServer {
       new AuthRoutes().routes,
       new LobbyRoutes(system).routes,
       new GameRoutes(GameType.TicTacToe, system).routes,
+      new GameRoutes(GameType.ConnectFour, system).routes,
       new WebSocketRoutes(system).routes
     )
 

--- a/game-service-server/src/main/scala/com/andy327/server/actors/connectfour/ConnectFourActor.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/connectfour/ConnectFourActor.scala
@@ -1,35 +1,39 @@
-package com.andy327.server.actors.tictactoe
+package com.andy327.server.actors.connectfour
 
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
 import org.apache.pekko.actor.typed.{ActorRef, Behavior}
 
+import com.andy327.model.connectfour.{ConnectFour, Draw, Drop, GameError, InProgress, Mark, Red, Won, Yellow}
 import com.andy327.model.core.{Game, GameId, PlayerId}
-import com.andy327.model.tictactoe._
 import com.andy327.server.actors.core.{GameActor, GameManager, PlayerActor, PlayerEvent}
 import com.andy327.server.actors.persistence.PersistenceProtocol
-import com.andy327.server.http.json.{GameStateConverters, TicTacToeState}
+import com.andy327.server.http.json.{ConnectFourState, GameStateConverters}
 import com.andy327.server.lobby.GameLifecycleStatus
 
-/** [[com.andy327.server.actors.core.GameActor]] implementation for TicTacToe.
+/** [[com.andy327.server.actors.core.GameActor]] implementation for ConnectFour.
   *
-  * Validates moves against a 3×3 board: checks turn order, player membership, cell occupancy, and bounds.
-  * Detects a win (three in a row/column/diagonal) or draw (board full) after each move.
+  * Validates moves against a 6×7 board: checks turn order, player membership, column bounds, and column capacity.
+  * Pieces fall to the lowest empty row (gravity). Detects a win (four in a line in any direction) or draw (board full)
+  * after each drop.
   *
   * @see [[com.andy327.server.actors.core.GameActor]] for the full actor lifecycle and behavioral contract.
   */
-object TicTacToeActor extends GameActor[TicTacToe] {
-  import TicTacToeState._
+object ConnectFourActor extends GameActor[ConnectFour] {
+  import ConnectFourState._
 
   sealed trait Command extends GameActor.GameCommand
 
   // --- Commands received from GameManager (via GameRegistry routing) ---
 
-  /** Attempt to apply a move at `loc` on behalf of `playerId`. */
-  final case class MakeMove(playerId: PlayerId, loc: Location, replyTo: ActorRef[Either[GameError, TicTacToeState]])
-      extends Command
+  /** Attempt to drop a piece into `drop.col` on behalf of `playerId`. */
+  final case class MakeMove(
+      playerId: PlayerId,
+      drop: Drop,
+      replyTo: ActorRef[Either[GameError, ConnectFourState]]
+  ) extends Command
 
   /** Return the current serialized board state without mutating it. */
-  final case class GetState(replyTo: ActorRef[Either[GameError, TicTacToeState]]) extends Command
+  final case class GetState(replyTo: ActorRef[Either[GameError, ConnectFourState]]) extends Command
 
   /** Register a PlayerActor to receive push events (state updates and game-end notifications). */
   final case class Subscribe(playerRef: ActorRef[PlayerActor.Command]) extends Command
@@ -45,9 +49,6 @@ object TicTacToeActor extends GameActor[TicTacToe] {
   /** Delivered by a `messageAdapter` after PersistenceProtocol.SaveSnapshot completes. */
   final case class SnapshotSaved(result: Either[Throwable, Unit]) extends Internal
 
-  /** Delivered by a `messageAdapter` after PersistenceProtocol.LoadSnapshot completes. */
-  final case class SnapshotLoaded(maybeGame: Either[Throwable, Option[TicTacToe]]) extends Internal
-
   override def subscribeCommand(playerRef: ActorRef[PlayerActor.Command]): GameActor.GameCommand =
     Subscribe(playerRef)
 
@@ -56,35 +57,33 @@ object TicTacToeActor extends GameActor[TicTacToe] {
     case _                     => None
   }
 
-  /** Resolves `playerId` to `X` or `O` based on which seat they occupy; `None` if not a participant. */
-  private def markForPlayer(playerId: PlayerId, playerX: PlayerId, playerO: PlayerId): Option[Mark] =
-    if (playerId == playerX) Some(X)
-    else if (playerId == playerO) Some(O)
+  /** Resolves `playerId` to `Red` or `Yellow` based on which seat they occupy; `None` if not a participant. */
+  private def markForPlayer(playerId: PlayerId, playerRed: PlayerId, playerYellow: PlayerId): Option[Mark] =
+    if (playerId == playerRed) Some(Red)
+    else if (playerId == playerYellow) Some(Yellow)
     else None
 
-  /** Initializes a new TicTacToeActor with an empty game. */
+  /** Initializes a new ConnectFourActor with an empty game. */
   override def create(
       gameId: GameId,
       players: Seq[PlayerId],
       persist: ActorRef[PersistenceProtocol.Command],
       gameManager: ActorRef[GameManager.Command]
-  ): (TicTacToe, Behavior[Command]) = {
-    val (playerX, playerO) = (players(0), players(1))
-
-    val game = TicTacToe.empty(playerX, playerO)
+  ): (ConnectFour, Behavior[Command]) = {
+    val (playerRed, playerYellow) = (players(0), players(1))
+    val game = ConnectFour.empty(playerRed, playerYellow)
     val behavior = Behaviors.setup[Command] { context =>
       context.log.info(s"[$gameId] starting new game")
       active(game, gameId, persist, gameManager, Set.empty)
     }
-
     (game, behavior)
   }
 
-  /** Creates a TicTacToeActor from a preloaded game snapshot.
+  /** Creates a ConnectFourActor from a preloaded game snapshot.
     *
     * Used during server startup to re-hydrate in-progress games from persistent storage. If the restored game is
     * already in a terminal state (won or draw), notifies GameManager and stops immediately without spawning an active
-    * behavior. Stops the actor if the snapshot type does not match `TicTacToe`.
+    * behavior. Stops the actor if the snapshot type does not match `ConnectFour`.
     */
   override def fromSnapshot(
       gameId: GameId,
@@ -94,10 +93,10 @@ object TicTacToeActor extends GameActor[TicTacToe] {
   ): Behavior[Command] =
     Behaviors.setup { context =>
       game match {
-        case ttt: TicTacToe =>
-          ttt.gameStatus match {
+        case cf: ConnectFour =>
+          cf.gameStatus match {
             case InProgress =>
-              active(ttt, gameId, persist, gameManager, Set.empty)
+              active(cf, gameId, persist, gameManager, Set.empty)
             case Won(_) | Draw =>
               context.log.info(s"[$gameId] restored as already-completed game — notifying GameManager and stopping")
               gameManager ! GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed)
@@ -109,7 +108,7 @@ object TicTacToeActor extends GameActor[TicTacToe] {
       }
     }
 
-  /** Core recursive behavior that drives a single game from first move to completion.
+  /** Core recursive behavior that drives a single game from first drop to completion.
     *
     * Each state-changing message (MakeMove) produces a new `active` behavior with updated game and subscriber state.
     * Read-only messages (GetState, SnapshotSaved) return `Behaviors.same`. Subscribe/Unsubscribe update the subscriber
@@ -117,17 +116,17 @@ object TicTacToeActor extends GameActor[TicTacToe] {
     * confirmed.
     */
   private def active(
-      game: TicTacToe,
+      game: ConnectFour,
       gameId: GameId,
       persist: ActorRef[PersistenceProtocol.Command],
       gameManager: ActorRef[GameManager.Command],
       subscribers: Set[ActorRef[PlayerActor.Command]]
   ): Behavior[Command] = Behaviors.receive { (context, msg) =>
     msg match {
-      case MakeMove(playerId, loc, replyTo) =>
-        markForPlayer(playerId, game.playerX, game.playerO) match {
+      case MakeMove(playerId, drop, replyTo) =>
+        markForPlayer(playerId, game.playerRed, game.playerYellow) match {
           case Some(mark) if mark == game.currentPlayer =>
-            game.play(mark, loc) match {
+            game.play(mark, drop) match {
               case Right(nextState) =>
                 context.log.info(s"Game $gameId updated:\n${nextState.render}")
 
@@ -188,12 +187,6 @@ object TicTacToeActor extends GameActor[TicTacToe] {
         }
         Behaviors.same
 
-      case SnapshotLoaded(result) =>
-        result match {
-          case Left(e)  => context.log.error(s"[$gameId] snapshot load failed", e)
-          case Right(_) => context.log.debug(s"[$gameId] snapshot loaded successfully")
-        }
-        Behaviors.same
     }
   }
 }

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/GameActor.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/GameActor.scala
@@ -1,5 +1,6 @@
 package com.andy327.server.actors.core
 
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
 import org.apache.pekko.actor.typed.{ActorRef, Behavior}
 
 import com.andy327.model.core.{Game, GameId, GameType, GameTypeTag, PlayerId}
@@ -15,7 +16,26 @@ object GameActor {
   trait GameCommand
 }
 
-/** Type-class factory and helper interface implemented by every game-specific actor. */
+/** Type-class factory and behavioral contract implemented by every game-specific actor.
+  *
+  * Each game actor manages a single game instance from creation to completion. The standard lifecycle is:
+  *   - `create` spawns a fresh actor in the `active` behavior with an empty game
+  *   - `fromSnapshot` re-hydrates an actor from a persisted game; if the snapshot is already terminal the actor
+  *     notifies [[GameManager]] and stops immediately without entering `active`
+  *   - In `active`, each `MakeMove` validates the move, applies it, saves a snapshot via fire-and-forget
+  *     [[com.andy327.server.actors.persistence.PersistenceProtocol.SaveSnapshot]], fans out
+  *     [[com.andy327.server.actors.core.PlayerEvent.GameStateUpdated]] to all subscribers, and replies to the caller
+  *   - On a terminal game result (win or draw), the actor fans out
+  *     [[com.andy327.server.actors.core.PlayerEvent.GameEnded]], notifies
+  *     [[GameManager]] via `GameCompleted`, and transitions to `terminating`
+  *   - In `terminating`, all commands except `SnapshotSaved` are ignored; the actor self-stops once the final snapshot
+  *     is confirmed, so [[GameManager]] does not need to call `context.stop`
+  *
+  * Concrete implementations must define their own sealed `Command` ADT (extending [[GameActor.GameCommand]]) and
+  * wire the above steps in their `active` and `terminating` behaviors.
+  *
+  * @tparam G the concrete game model type this actor manages
+  */
 trait GameActor[G <: Game[_, _, _, _, _]] {
 
   type Command <: GameActor.GameCommand
@@ -55,4 +75,31 @@ trait GameActor[G <: Game[_, _, _, _, _]] {
 
   /** Produce the game-specific Subscribe command that registers `playerRef` for push events. */
   def subscribeCommand(playerRef: ActorRef[PlayerActor.Command]): GameActor.GameCommand
+
+  /** Extract the snapshot-save result from `cmd` if it is a `SnapshotSaved` message, otherwise `None`.
+    *
+    * Used by [[terminating]] to detect when the final snapshot has been confirmed without needing to know the
+    * concrete `SnapshotSaved` type defined in each actor's sealed `Command` ADT.
+    */
+  protected def snapshotSavedResult(cmd: Command): Option[Either[Throwable, Unit]]
+
+  /** Waits for the final snapshot confirmation after a game ends, then stops the actor.
+    *
+    * Entered after a win or draw is detected. All commands except `SnapshotSaved` are ignored — the actor is
+    * shutting down and should not process new moves or subscribe requests. The actor self-stops once the final
+    * snapshot is confirmed, so [[com.andy327.server.actors.core.GameManager]] does not need to call `context.stop`.
+    */
+  protected def terminating(gameId: GameId): Behavior[Command] =
+    Behaviors.receive { (context, msg) =>
+      snapshotSavedResult(msg) match {
+        case Some(result) =>
+          result match {
+            case Left(e)  => context.log.error(s"[$gameId] final snapshot failed", e)
+            case Right(_) => context.log.debug(s"[$gameId] final snapshot saved, stopping")
+          }
+          Behaviors.stopped
+        case None =>
+          Behaviors.same
+      }
+    }
 }

--- a/game-service-server/src/main/scala/com/andy327/server/actors/tictactoe/TicTacToeActor.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/tictactoe/TicTacToeActor.scala
@@ -45,9 +45,6 @@ object TicTacToeActor extends GameActor[TicTacToe] {
   /** Delivered by a `messageAdapter` after PersistenceProtocol.SaveSnapshot completes. */
   final case class SnapshotSaved(result: Either[Throwable, Unit]) extends Internal
 
-  /** Delivered by a `messageAdapter` after PersistenceProtocol.LoadSnapshot completes. */
-  final case class SnapshotLoaded(maybeGame: Either[Throwable, Option[TicTacToe]]) extends Internal
-
   override def subscribeCommand(playerRef: ActorRef[PlayerActor.Command]): GameActor.GameCommand =
     Subscribe(playerRef)
 
@@ -188,12 +185,6 @@ object TicTacToeActor extends GameActor[TicTacToe] {
         }
         Behaviors.same
 
-      case SnapshotLoaded(result) =>
-        result match {
-          case Left(e)  => context.log.error(s"[$gameId] snapshot load failed", e)
-          case Right(_) => context.log.debug(s"[$gameId] snapshot loaded successfully")
-        }
-        Behaviors.same
     }
   }
 }

--- a/game-service-server/src/main/scala/com/andy327/server/game/GameRegistry.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/game/GameRegistry.scala
@@ -1,9 +1,10 @@
 package com.andy327.server.game
 
 import com.andy327.model.core.{Game, GameType}
+import com.andy327.server.actors.connectfour.ConnectFourActor
 import com.andy327.server.actors.core.GameActor
 import com.andy327.server.actors.tictactoe.TicTacToeActor
-import com.andy327.server.game.modules.{GameModule, TicTacToeModule}
+import com.andy327.server.game.modules.{ConnectFourModule, GameModule, TicTacToeModule}
 import com.andy327.server.http.json.GameState
 
 /** Groups the [[com.andy327.server.game.modules.GameModule]] and [[com.andy327.server.actors.core.GameActor]] implementations for a single game type.
@@ -39,6 +40,7 @@ object GameRegistry {
     * @return the bundle containing module and actor for that game type
     */
   def forType(gameType: GameType): GameModuleBundle[_] = gameType match {
-    case GameType.TicTacToe => GameModuleBundle(TicTacToeModule, TicTacToeActor)
+    case GameType.TicTacToe   => GameModuleBundle(TicTacToeModule, TicTacToeActor)
+    case GameType.ConnectFour => GameModuleBundle(ConnectFourModule, ConnectFourActor)
   }
 }

--- a/game-service-server/src/main/scala/com/andy327/server/game/MovePayload.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/game/MovePayload.scala
@@ -15,4 +15,10 @@ object MovePayload {
     * @param col The column index (0-based)
     */
   final case class TicTacToeMove(row: Int, col: Int) extends MovePayload
+
+  /** A move for ConnectFour: drop a piece into the specified column.
+    *
+    * @param col The column index (0-based, 0–6)
+    */
+  final case class ConnectFourMove(col: Int) extends MovePayload
 }

--- a/game-service-server/src/main/scala/com/andy327/server/game/modules/ConnectFourModule.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/game/modules/ConnectFourModule.scala
@@ -1,0 +1,45 @@
+package com.andy327.server.game.modules
+
+import cats.syntax.functor._
+
+import io.circe.Decoder
+import io.circe.generic.auto._
+import org.apache.pekko.actor.typed.ActorRef
+
+import com.andy327.model.connectfour.{ConnectFour, Drop}
+import com.andy327.model.core.GameError
+import com.andy327.server.actors.connectfour.ConnectFourActor
+import com.andy327.server.actors.core.GameActor
+import com.andy327.server.game.MovePayload.ConnectFourMove
+import com.andy327.server.game.{GameOperation, MovePayload}
+import com.andy327.server.http.json.{ConnectFourState, GameState, GameStateConverters}
+
+import ConnectFourState._
+
+/** [[GameModule]] implementation for ConnectFour.
+  *
+  * Provides move decoding, operation-to-command mapping, and game serialization for ConnectFour. Enables
+  * [[com.andy327.server.actors.core.GameManager]] and the HTTP routes to handle ConnectFour games without
+  * any game-specific logic.
+  */
+object ConnectFourModule extends GameModule[ConnectFour] {
+
+  override val moveDecoder: Decoder[MovePayload] = Decoder[ConnectFourMove].widen
+
+  override def toGameCommand(
+      op: GameOperation,
+      replyTo: ActorRef[Either[GameError, GameState]]
+  ): Either[GameError, GameActor.GameCommand] = op match {
+    case GameOperation.MakeMove(playerId, MovePayload.ConnectFourMove(col)) =>
+      Right(ConnectFourActor.MakeMove(playerId, Drop(col), replyTo))
+
+    case GameOperation.MakeMove(_, otherMove) =>
+      val name = Option(otherMove).map(_.getClass.getSimpleName).getOrElse("null")
+      Left(GameError.Unknown(s"Unsupported move type for ConnectFour: $name"))
+
+    case GameOperation.GetState =>
+      Right(ConnectFourActor.GetState(replyTo))
+  }
+
+  override def serialize(game: ConnectFour): GameState = GameStateConverters.serializeGame(game)
+}

--- a/game-service-server/src/main/scala/com/andy327/server/game/modules/GameModule.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/game/modules/GameModule.scala
@@ -14,6 +14,38 @@ import com.andy327.server.http.json.GameState
   * to `serialize` matches the game type this module handles. The single cast lives in
   * [[com.andy327.server.game.GameModuleBundle]] at the DB-deserialization boundary, not here.
   *
+  * == Implementing a new game ==
+  *
+  * Create a singleton object extending `GameModule[G]` and implement the three members:
+  *
+  *  1. `moveDecoder` — a Circe `Decoder[MovePayload]` for the game's move payload subtype. The standard pattern is:
+  *     {{{
+  *       import cats.syntax.functor._
+  *       import io.circe.generic.auto._
+  *       override val moveDecoder: Decoder[MovePayload] = Decoder[MyGameMove].widen
+  *     }}}
+  *
+  *  2. `toGameCommand` — map a [[com.andy327.server.game.GameOperation]] to a game-specific actor command.
+  *     Handle three cases: the game's `MakeMove` payload (constructing the actor command), a wrong payload type
+  *     (return `Left(GameError.Unknown(...))`), and `GetState` (delegate to the actor's `GetState` command):
+  *     {{{
+  *       override def toGameCommand(op: GameOperation, replyTo: ActorRef[Either[GameError, GameState]]) = op match {
+  *         case GameOperation.MakeMove(playerId, MovePayload.MyGameMove(x, y)) =>
+  *           Right(MyGameActor.MakeMove(playerId, MyMove(x, y), replyTo))
+  *         case GameOperation.MakeMove(_, other) =>
+  *           val name = Option(other).map(_.getClass.getSimpleName).getOrElse("null")
+  *           Left(GameError.Unknown(s"Unsupported move type for MyGame: \$name"))
+  *         case GameOperation.GetState =>
+  *           Right(MyGameActor.GetState(replyTo))
+  *       }
+  *     }}}
+  *
+  *  3. `serialize` — convert the game model to its HTTP view. If a [[com.andy327.server.http.json.GameStateView]]
+  *     instance is defined in the companion object of the view type, this is always the same one-liner:
+  *     {{{
+  *       override def serialize(game: MyGame): GameState = GameStateConverters.serializeGame(game)
+  *     }}}
+  *
   * @tparam G the concrete game model type this module handles
   */
 trait GameModule[G <: Game[_, _, _, _, _]] {

--- a/game-service-server/src/main/scala/com/andy327/server/game/modules/TicTacToeModule.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/game/modules/TicTacToeModule.scala
@@ -26,12 +26,6 @@ object TicTacToeModule extends GameModule[TicTacToe] {
 
   override val moveDecoder: Decoder[MovePayload] = Decoder[TicTacToeMove].widen
 
-  /** Converts a generic [[GameOperation]] into a TicTacToe-specific actor command.
-    *
-    * @param op the game-agnostic operation from the HTTP layer
-    * @param replyTo the actor that should receive the operation result
-    * @return `Right(command)` ready to send to TicTacToeActor, or `Left(GameError)` if the payload type is wrong
-    */
   override def toGameCommand(
       op: GameOperation,
       replyTo: ActorRef[Either[GameError, GameState]]
@@ -47,8 +41,5 @@ object TicTacToeModule extends GameModule[TicTacToe] {
       Right(TicTacToeActor.GetState(replyTo))
   }
 
-  /** Serialise a `TicTacToe` game model into a [[com.andy327.server.http.json.TicTacToeState]] for HTTP/WebSocket
-    * delivery.
-    */
   override def serialize(game: TicTacToe): GameState = GameStateConverters.serializeGame(game)
 }

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/GameState.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/GameState.scala
@@ -1,7 +1,8 @@
 package com.andy327.server.http.json
 
+import com.andy327.model.connectfour.ConnectFour
 import com.andy327.model.core.Game
-import com.andy327.model.tictactoe._
+import com.andy327.model.tictactoe.TicTacToe
 
 /** Super-type for all serializable “view” representations of game state that can be sent to the client as part of an
   * HTTP response.
@@ -20,6 +21,7 @@ object TicTacToeState {
 
   /** Type class instance for serializing a TicTacToe game into a TicTacToeState. */
   implicit object TicTacToeView extends GameStateView[TicTacToe, TicTacToeState] {
+    import com.andy327.model.tictactoe.{Draw, Won}
     def fromGame(game: TicTacToe): TicTacToeState = {
       val boardStrings = game.board.map(_.map(_.map(_.toString).getOrElse(""))) // string-based representation for JSON
       val currentPlayer = game.currentPlayer.toString
@@ -29,6 +31,32 @@ object TicTacToeState {
       }
       val draw = game.gameStatus == Draw
       TicTacToeState(boardStrings, currentPlayer, winnerOpt, draw)
+    }
+  }
+}
+
+/** Serializable view of a ConnectFour game state, suitable for HTTP responses. */
+case class ConnectFourState(
+    board: Vector[Vector[String]],
+    currentPlayer: String,
+    winner: Option[String],
+    draw: Boolean
+) extends GameState
+
+object ConnectFourState {
+
+  /** Type class instance for serializing a ConnectFour game into a ConnectFourState. */
+  implicit object ConnectFourView extends GameStateView[ConnectFour, ConnectFourState] {
+    import com.andy327.model.connectfour.{Draw, Won}
+    def fromGame(game: ConnectFour): ConnectFourState = {
+      val boardStrings = game.board.map(_.map(_.map(_.toString).getOrElse("")))
+      val currentPlayer = game.currentPlayer.toString
+      val winnerOpt = game.gameStatus match {
+        case Won(mark) => Some(mark.toString)
+        case _         => None
+      }
+      val draw = game.gameStatus == Draw
+      ConnectFourState(boardStrings, currentPlayer, winnerOpt, draw)
     }
   }
 }

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -96,6 +96,13 @@ object JsonProtocol extends DefaultJsonProtocol {
 
   implicit val ticTacToeStateFormat: RootJsonFormat[TicTacToeState] = jsonFormat4(TicTacToeState.apply)
 
+  // ConnectFour
+
+  implicit val connectFourMoveRequestFormat: RootJsonFormat[ConnectFourMoveRequest] =
+    jsonFormat1(ConnectFourMoveRequest.apply)
+
+  implicit val connectFourStateFormat: RootJsonFormat[ConnectFourState] = jsonFormat4(ConnectFourState.apply)
+
   /** Write-only format for PlayerEvent — serialises server-push events to JSON for delivery over WebSocket.
     *
     * Each variant is encoded as a JSON object with a `type` discriminator field so the client can dispatch on the event
@@ -112,7 +119,8 @@ object JsonProtocol extends DefaultJsonProtocol {
         JsObject("type" -> JsString("LobbyUpdated"), "metadata" -> lobbyMetadataFormat.write(metadata))
       case PlayerEvent.GameStateUpdated(state) =>
         val stateJson = state match {
-          case s: TicTacToeState => ticTacToeStateFormat.write(s)
+          case s: TicTacToeState   => ticTacToeStateFormat.write(s)
+          case s: ConnectFourState => connectFourStateFormat.write(s)
         }
         JsObject("type" -> JsString("GameStateUpdated"), "state" -> stateJson)
       case PlayerEvent.GameEnded(result) =>
@@ -129,6 +137,9 @@ object JsonProtocol extends DefaultJsonProtocol {
       gameState match {
         case s: TicTacToeState =>
           val json = ticTacToeStateFormat.write(s).compactPrint
+          HttpResponse(entity = HttpEntity(ContentTypes.`application/json`, json))
+        case s: ConnectFourState =>
+          val json = connectFourStateFormat.write(s).compactPrint
           HttpResponse(entity = HttpEntity(ContentTypes.`application/json`, json))
       }
     }

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -51,9 +51,10 @@ object JsonProtocol extends DefaultJsonProtocol {
     def write(gt: GameType): JsValue = JsString(gt.toString)
 
     def read(json: JsValue): GameType = json match {
-      case JsString("TicTacToe") => GameType.TicTacToe
-      case JsString(other)       => deserializationError(s"Unknown GameType: $other")
-      case _                     => deserializationError("Expected GameType string")
+      case JsString("TicTacToe")   => GameType.TicTacToe
+      case JsString("ConnectFour") => GameType.ConnectFour
+      case JsString(other)         => deserializationError(s"Unknown GameType: $other")
+      case _                       => deserializationError("Expected GameType string")
     }
   }
 

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/MoveRequest.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/MoveRequest.scala
@@ -6,3 +6,10 @@ package com.andy327.server.http.json
   * converted to a domain-level MovePayload (e.g., `MovePayload.TicTacToeMove`) before being processed.
   */
 case class TicTacToeMoveRequest(row: Int, col: Int)
+
+/** Represents the JSON payload submitted by a client to make a move in a ConnectFour game.
+  *
+  * This is used exclusively for HTTP request deserialization, and is decoupled from internal game logic. It is
+  * converted to a domain-level MovePayload (e.g., `MovePayload.ConnectFourMove`) before being processed.
+  */
+case class ConnectFourMoveRequest(col: Int)

--- a/game-service-server/src/test/scala/com/andy327/server/actors/connectfour/ConnectFourActorSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/connectfour/ConnectFourActorSpec.scala
@@ -1,0 +1,292 @@
+package com.andy327.server.actors.connectfour
+
+import java.util.UUID
+
+import scala.util.control.NoStackTrace
+
+import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
+import org.apache.pekko.actor.typed.ActorRef
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import com.andy327.model.connectfour.{ConnectFour, Drop, GameError, Red, Yellow}
+import com.andy327.model.core.{Game, GameId, PlayerId}
+import com.andy327.server.actors.core.{GameManager, PlayerActor, PlayerEvent}
+import com.andy327.server.actors.persistence.PersistenceProtocol
+import com.andy327.server.http.json.{ConnectFourState, GameState}
+import com.andy327.server.lobby.GameLifecycleStatus
+
+class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
+  private val testKit = ActorTestKit()
+  import testKit._
+
+  val alice: PlayerId = UUID.randomUUID() // plays Red
+  val bob: PlayerId = UUID.randomUUID() // plays Yellow
+
+  private val dummyGameManager: ActorRef[GameManager.Command] = createTestProbe[GameManager.Command]().ref
+
+  /** Spawn a fresh game actor backed by a new persist probe. */
+  private def newActor(
+      gmRef: ActorRef[GameManager.Command] = dummyGameManager,
+      gameId: GameId = UUID.randomUUID()
+  ): (ActorRef[ConnectFourActor.Command], TestProbe[PersistenceProtocol.Command]) = {
+    val persistProbe = createTestProbe[PersistenceProtocol.Command]()
+    val (_, behavior) = ConnectFourActor.create(gameId, Seq(alice, bob), persistProbe.ref, gmRef)
+    (spawn(behavior), persistProbe)
+  }
+
+  /** Advance `game` through a sequence of (playerId, col) drops.
+    *
+    * Throws if any move is rejected — only valid test sequences should be passed here.
+    */
+  private def playMoves(game: ConnectFour, moves: Seq[(PlayerId, Int)]): ConnectFour =
+    moves.foldLeft(game) { case (g, (playerId, col)) =>
+      val mark = if (playerId == alice) Red else Yellow
+      g.play(mark, Drop(col)).getOrElse(throw new IllegalStateException(s"Unexpected invalid move: $playerId col=$col"))
+    }
+
+  /** Seven moves in which Red fills column 0 for a vertical win. */
+  private val redWinsMoves: Seq[(PlayerId, Int)] = Seq(
+    (alice, 0), // Red   row 5 col 0
+    (bob, 1), // Yellow row 5 col 1
+    (alice, 0), // Red   row 4 col 0
+    (bob, 1), // Yellow row 4 col 1
+    (alice, 0), // Red   row 3 col 0
+    (bob, 1), // Yellow row 3 col 1
+    (alice, 0) // Red   row 2 col 0 — four in a row, Red wins
+  )
+
+  "ConnectFourActor" should {
+    "return an empty 6×7 board on GetState" in {
+      val (actor, _) = newActor()
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+
+      actor ! ConnectFourActor.GetState(replyProbe.ref)
+
+      val Right(ConnectFourState(board, current, winner, draw)) = replyProbe.receiveMessage()
+      board should have size 6
+      board.head should have size 7
+      board.flatten should contain only ""
+      current shouldBe "R"
+      winner shouldBe None
+      draw shouldBe false
+    }
+
+    "restore an in-progress game state from snapshot" in {
+      val snapshot = playMoves(ConnectFour.empty(alice, bob), Seq((alice, 3)))
+
+      val persistProbe = createTestProbe[PersistenceProtocol.Command]()
+      val behavior = ConnectFourActor.fromSnapshot(UUID.randomUUID(), snapshot, persistProbe.ref, dummyGameManager)
+      val actor = spawn(behavior)
+
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      actor ! ConnectFourActor.GetState(replyProbe.ref)
+
+      val Right(ConnectFourState(board, current, winner, draw)) = replyProbe.receiveMessage()
+      board(5)(3) shouldBe "R" // Red dropped into col 3 — piece falls to bottom row
+      current shouldBe "Y"
+      winner shouldBe None
+      draw shouldBe false
+    }
+
+    "notify GameManager and stop when restored from a completed snapshot" in {
+      val gameId = UUID.randomUUID()
+      val gameManagerProbe = createTestProbe[GameManager.Command]()
+      val completedGame = playMoves(ConnectFour.empty(alice, bob), redWinsMoves)
+
+      val persistProbe = createTestProbe[PersistenceProtocol.Command]()
+      val actor = spawn(ConnectFourActor.fromSnapshot(gameId, completedGame, persistProbe.ref, gameManagerProbe.ref))
+
+      gameManagerProbe.expectMessage(GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed))
+      persistProbe.expectTerminated(actor)
+    }
+
+    "fail to restore state from snapshot with an invalid game type" in {
+      val dummyGame = new Game[Any, Any, Any, Any, Any] {
+        override def play(player: Any, move: Any): Either[Any, Any] = Left("not implemented")
+        override def currentState: Any = "dummy"
+        override def currentPlayer: Any = "dummy"
+        override def gameStatus: Any = "dummy"
+      }
+
+      val persistProbe = createTestProbe[PersistenceProtocol.Command]()
+      val behavior = ConnectFourActor.fromSnapshot(UUID.randomUUID(), dummyGame, persistProbe.ref, dummyGameManager)
+      val actor = spawn(behavior)
+
+      persistProbe.expectTerminated(actor)
+    }
+
+    "apply a valid move and switch currentPlayer" in {
+      val (actor, _) = newActor()
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+
+      actor ! ConnectFourActor.MakeMove(alice, Drop(0), replyProbe.ref)
+      val Right(ConnectFourState(board1, current1, _, _)) = replyProbe.receiveMessage()
+      board1(5)(0) shouldBe "R" // piece falls to bottom row
+      current1 shouldBe "Y"
+
+      actor ! ConnectFourActor.MakeMove(bob, Drop(1), replyProbe.ref)
+      val Right(ConnectFourState(board2, current2, _, _)) = replyProbe.receiveMessage()
+      board2(5)(0) shouldBe "R"
+      board2(5)(1) shouldBe "Y"
+      current2 shouldBe "R"
+    }
+
+    "reject a move when it is not the player's turn" in {
+      val (actor, _) = newActor()
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+
+      actor ! ConnectFourActor.MakeMove(bob, Drop(0), replyProbe.ref)
+      replyProbe.receiveMessage() shouldBe Left(GameError.InvalidTurn)
+    }
+
+    "reject a move from a player not in the game" in {
+      val eve: PlayerId = UUID.randomUUID()
+      val (actor, _) = newActor()
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+
+      actor ! ConnectFourActor.MakeMove(eve, Drop(0), replyProbe.ref)
+      replyProbe.receiveMessage() shouldBe Left(GameError.InvalidPlayer(eve))
+    }
+
+    "reject a move to an out-of-bounds column" in {
+      val (actor, _) = newActor()
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+
+      actor ! ConnectFourActor.MakeMove(alice, Drop(7), replyProbe.ref)
+      replyProbe.receiveMessage() shouldBe Left(GameError.InvalidColumn)
+    }
+
+    "log success and continue when SnapshotSaved succeeds" in {
+      val (actor, persistProbe) = newActor()
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+
+      actor ! ConnectFourActor.MakeMove(alice, Drop(0), replyProbe.ref)
+      val _ = replyProbe.receiveMessage()
+
+      val saveMsg = persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+      saveMsg.replyTo ! PersistenceProtocol.SnapshotSaved(Right(()))
+
+      actor ! ConnectFourActor.GetState(replyProbe.ref)
+      replyProbe.receiveMessage() shouldBe a[Right[_, _]]
+    }
+
+    "log error and continue when SnapshotSaved fails" in {
+      val (actor, _) = newActor()
+      val ex = new RuntimeException("artificial test failure") with NoStackTrace
+
+      actor ! ConnectFourActor.SnapshotSaved(Left(ex))
+
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      actor ! ConnectFourActor.GetState(replyProbe.ref)
+      replyProbe.receiveMessage() shouldBe a[Right[_, _]]
+    }
+
+    "push GameStateUpdated to subscribers after a valid move" in {
+      val (actor, _) = newActor()
+      val subscriberProbe = createTestProbe[PlayerActor.Command]()
+
+      actor ! ConnectFourActor.Subscribe(subscriberProbe.ref)
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial state push on subscribe
+
+      actor ! ConnectFourActor.MakeMove(alice, Drop(0), createTestProbe[Either[GameError, GameState]]().ref)
+
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe a[PlayerEvent.GameStateUpdated]
+    }
+
+    "push GameEnded to subscribers when the game completes" in {
+      val gameManagerProbe = createTestProbe[GameManager.Command]()
+      val (actor, persistProbe) = newActor(gmRef = gameManagerProbe.ref)
+      val subscriberProbe = createTestProbe[PlayerActor.Command]()
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+
+      actor ! ConnectFourActor.Subscribe(subscriberProbe.ref)
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial state push on subscribe
+
+      redWinsMoves.foreach { case (playerId, col) =>
+        actor ! ConnectFourActor.MakeMove(playerId, Drop(col), replyProbe.ref)
+        replyProbe.receiveMessage()
+        subscriberProbe.expectMessageType[PlayerActor.SendEvent] // GameStateUpdated per move
+        val _ = persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+      }
+
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe
+        PlayerEvent.GameEnded(GameLifecycleStatus.Completed)
+    }
+
+    "not push events to unsubscribed players" in {
+      val (actor, _) = newActor()
+      val subscriberProbe = createTestProbe[PlayerActor.Command]()
+
+      actor ! ConnectFourActor.Subscribe(subscriberProbe.ref)
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial state push on subscribe
+      actor ! ConnectFourActor.Unsubscribe(subscriberProbe.ref)
+      actor ! ConnectFourActor.MakeMove(alice, Drop(0), createTestProbe[Either[GameError, GameState]]().ref)
+
+      subscriberProbe.expectNoMessage()
+    }
+
+    "stop after receiving SnapshotSaved(Right) in terminating state" in {
+      val (actor, persistProbe) = newActor()
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+
+      redWinsMoves.foreach { case (playerId, col) =>
+        actor ! ConnectFourActor.MakeMove(playerId, Drop(col), replyProbe.ref)
+        replyProbe.receiveMessage()
+        persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+      }
+
+      actor ! ConnectFourActor.SnapshotSaved(Right(()))
+      persistProbe.expectTerminated(actor)
+    }
+
+    "stop after receiving SnapshotSaved(Left) in terminating state" in {
+      val (actor, persistProbe) = newActor()
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val ex = new RuntimeException("snapshot failure") with NoStackTrace
+
+      redWinsMoves.foreach { case (playerId, col) =>
+        actor ! ConnectFourActor.MakeMove(playerId, Drop(col), replyProbe.ref)
+        replyProbe.receiveMessage()
+        persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+      }
+
+      actor ! ConnectFourActor.SnapshotSaved(Left(ex))
+      persistProbe.expectTerminated(actor)
+    }
+
+    "ignore non-SnapshotSaved messages in terminating state" in {
+      val (actor, persistProbe) = newActor()
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+
+      redWinsMoves.foreach { case (playerId, col) =>
+        actor ! ConnectFourActor.MakeMove(playerId, Drop(col), replyProbe.ref)
+        replyProbe.receiveMessage()
+        persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+      }
+
+      // GetState is ignored in terminating — no reply, actor stays alive
+      actor ! ConnectFourActor.GetState(replyProbe.ref)
+      replyProbe.expectNoMessage()
+
+      // SnapshotSaved then stops the actor
+      actor ! ConnectFourActor.SnapshotSaved(Right(()))
+      persistProbe.expectTerminated(actor)
+    }
+
+    "notify the GameManager when a game completes" in {
+      val gameManagerProbe = createTestProbe[GameManager.Command]()
+      val gameId: GameId = UUID.randomUUID()
+      val (actor, persistProbe) = newActor(gmRef = gameManagerProbe.ref, gameId = gameId)
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+
+      redWinsMoves.foreach { case (playerId, col) =>
+        actor ! ConnectFourActor.MakeMove(playerId, Drop(col), replyProbe.ref)
+        replyProbe.receiveMessage() shouldBe a[Right[_, _]]
+        val _ = persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+      }
+
+      gameManagerProbe.receiveMessage() shouldBe GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed)
+    }
+  }
+}

--- a/game-service-server/src/test/scala/com/andy327/server/actors/tictactoe/TicTacToeActorSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/tictactoe/TicTacToeActorSpec.scala
@@ -196,27 +196,6 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       replyProbe.receiveMessage() shouldBe a[Right[_, _]]
     }
 
-    "log success and continue when SnapshotLoaded succeeds" in {
-      val (actor, _) = newActor()
-
-      actor ! TicTacToeActor.SnapshotLoaded(Right(None))
-
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
-      actor ! TicTacToeActor.GetState(replyProbe.ref)
-      replyProbe.receiveMessage() shouldBe a[Right[_, _]]
-    }
-
-    "log error and continue when SnapshotLoaded fails" in {
-      val (actor, _) = newActor()
-      val ex = new RuntimeException("load failed") with NoStackTrace
-
-      actor ! TicTacToeActor.SnapshotLoaded(Left(ex))
-
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
-      actor ! TicTacToeActor.GetState(replyProbe.ref)
-      replyProbe.receiveMessage() shouldBe a[Right[_, _]]
-    }
-
     "push GameStateUpdated to subscribers after a valid move" in {
       val (actor, _) = newActor()
       val subscriberProbe = createTestProbe[PlayerActor.Command]()

--- a/game-service-server/src/test/scala/com/andy327/server/game/modules/ConnectFourModuleSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/game/modules/ConnectFourModuleSpec.scala
@@ -1,0 +1,85 @@
+package com.andy327.server.game.modules
+
+import io.circe.parser.decode
+import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import com.andy327.model.connectfour.{ConnectFour, Drop}
+import com.andy327.model.core.GameError
+import com.andy327.server.actors.connectfour.ConnectFourActor
+import com.andy327.server.actors.core.PlayerActor
+import com.andy327.server.game.{GameOperation, MovePayload}
+import com.andy327.server.http.json.{ConnectFourState, GameState}
+import com.andy327.server.lobby.Player
+
+class ConnectFourModuleSpec extends AnyWordSpecLike with Matchers {
+  private val testKit = ActorTestKit()
+  import testKit._
+
+  "ConnectFourModule" should {
+    "successfully decode a valid ConnectFour move JSON" in {
+      val json = """{"col":3}"""
+      decode[MovePayload](json)(ConnectFourModule.moveDecoder) shouldBe Right(MovePayload.ConnectFourMove(3))
+    }
+
+    "fail to decode an invalid ConnectFour move JSON" in {
+      val json = """{"bad":"data"}"""
+      decode[MovePayload](json)(ConnectFourModule.moveDecoder).isLeft shouldBe true
+    }
+
+    "convert a valid GameOperation.MakeMove to a GameCommand" in {
+      val alice = Player("alice")
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val move = MovePayload.ConnectFourMove(3)
+
+      val result = ConnectFourModule.toGameCommand(GameOperation.MakeMove(alice.id, move), replyProbe.ref)
+
+      result match {
+        case Right(ConnectFourActor.MakeMove(playerId, drop, reply)) =>
+          playerId shouldBe alice.id
+          drop shouldBe Drop(3)
+          reply shouldBe replyProbe.ref
+
+        case other => fail(s"Unexpected result: $other")
+      }
+    }
+
+    "convert GetState to a GetState GameCommand" in {
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+
+      val result = ConnectFourModule.toGameCommand(GameOperation.GetState, replyProbe.ref)
+
+      result shouldBe Right(ConnectFourActor.GetState(replyProbe.ref))
+    }
+
+    "produce a Subscribe command for a given PlayerActor ref" in {
+      val playerProbe = TestProbe[PlayerActor.Command]()
+
+      val result = ConnectFourActor.subscribeCommand(playerProbe.ref)
+
+      result shouldBe ConnectFourActor.Subscribe(playerProbe.ref)
+    }
+
+    "serialize a ConnectFour game to ConnectFourState" in {
+      val alice = Player("alice")
+      val bob = Player("bob")
+      val game = ConnectFour.empty(alice.id, bob.id)
+      ConnectFourModule.serialize(game) shouldBe a[ConnectFourState]
+    }
+
+    "return error when passing unsupported MovePayload to toGameCommand" in {
+      val alice = Player("alice")
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val unsupportedMove = null.asInstanceOf[MovePayload]
+
+      val result = ConnectFourModule.toGameCommand(
+        GameOperation.MakeMove(alice.id, unsupportedMove),
+        replyProbe.ref
+      )
+
+      val Left(err) = result
+      err.message should include("Unsupported move type for ConnectFour")
+    }
+  }
+}

--- a/game-service-server/src/test/scala/com/andy327/server/game/modules/TicTacToeModuleSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/game/modules/TicTacToeModuleSpec.scala
@@ -6,11 +6,11 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.model.core.GameError
-import com.andy327.model.tictactoe.Location
+import com.andy327.model.tictactoe.{Location, TicTacToe}
 import com.andy327.server.actors.core.PlayerActor
 import com.andy327.server.actors.tictactoe.TicTacToeActor
 import com.andy327.server.game.{GameOperation, MovePayload}
-import com.andy327.server.http.json.GameState
+import com.andy327.server.http.json.{GameState, TicTacToeState}
 import com.andy327.server.lobby.Player
 
 class TicTacToeModuleSpec extends AnyWordSpecLike with Matchers {
@@ -59,6 +59,13 @@ class TicTacToeModuleSpec extends AnyWordSpecLike with Matchers {
       val result = TicTacToeActor.subscribeCommand(playerProbe.ref)
 
       result shouldBe TicTacToeActor.Subscribe(playerProbe.ref)
+    }
+
+    "serialize a TicTacToe game to TicTacToeState" in {
+      val alice = Player("alice")
+      val bob = Player("bob")
+      val game = TicTacToe.empty(alice.id, bob.id)
+      TicTacToeModule.serialize(game) shouldBe a[TicTacToeState]
     }
 
     "return error when passing unsupported MovePayload to toGameCommand" in {

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import spray.json._
 
+import com.andy327.model.connectfour.ConnectFour
 import com.andy327.model.core.GameType
 import com.andy327.model.tictactoe.TicTacToe
 import com.andy327.server.actors.core.GameManager.{
@@ -16,6 +17,7 @@ import com.andy327.server.actors.core.GameManager.{
   SubscribeAcknowledged
 }
 import com.andy327.server.actors.core.PlayerEvent
+import com.andy327.server.http.json.ConnectFourState._
 import com.andy327.server.http.json.GameStateConverters
 import com.andy327.server.http.json.TicTacToeState._
 import com.andy327.server.lobby._
@@ -186,6 +188,14 @@ class SerializationSpec extends AnyWordSpec with Matchers {
     }
   }
 
+  "ConnectFourMoveRequest JSON format" should {
+    "round-trip serialize and deserialize" in {
+      val move = ConnectFourMoveRequest(col = 3)
+      val json = move.toJson
+      json.convertTo[ConnectFourMoveRequest] shouldBe move
+    }
+  }
+
   "TicTacToeState view" should {
     "round-trip serialize and deserialize" in {
       val alice = Player("alice")
@@ -194,6 +204,17 @@ class SerializationSpec extends AnyWordSpec with Matchers {
       val view = GameStateConverters.serializeGame(game)
       val json = view.toJson
       json.convertTo[TicTacToeState] shouldBe view
+    }
+  }
+
+  "ConnectFourState view" should {
+    "round-trip serialize and deserialize" in {
+      val alice = Player("alice")
+      val bob = Player("bob")
+      val game = ConnectFour.empty(alice.id, bob.id)
+      val view = GameStateConverters.serializeGame(game)
+      val json = view.toJson
+      json.convertTo[ConnectFourState] shouldBe view
     }
   }
 
@@ -213,10 +234,21 @@ class SerializationSpec extends AnyWordSpec with Matchers {
       (json.fields should contain).key("metadata")
     }
 
-    "serialize GameStateUpdated with type discriminator and state" in {
+    "serialize GameStateUpdated with TicTacToe state" in {
       val alice = Player("alice")
       val bob = Player("bob")
       val game = TicTacToe.empty(alice.id, bob.id)
+      val state = GameStateConverters.serializeGame(game)
+      val event: PlayerEvent = PlayerEvent.GameStateUpdated(state)
+      val json = event.toJson.asJsObject
+      json.fields("type") shouldBe JsString("GameStateUpdated")
+      (json.fields should contain).key("state")
+    }
+
+    "serialize GameStateUpdated with ConnectFour state" in {
+      val alice = Player("alice")
+      val bob = Player("bob")
+      val game = ConnectFour.empty(alice.id, bob.id)
       val state = GameStateConverters.serializeGame(game)
       val event: PlayerEvent = PlayerEvent.GameStateUpdated(state)
       val json = event.toJson.asJsObject

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -57,8 +57,12 @@ class SerializationSpec extends AnyWordSpec with Matchers {
   }
 
   "GameType RootJsonFormat" should {
-    "deserialize a known game type" in {
+    "deserialize TicTacToe game type" in {
       JsString("TicTacToe").convertTo[GameType] shouldBe GameType.TicTacToe
+    }
+
+    "deserialize ConnectFour game type" in {
+      JsString("ConnectFour").convertTo[GameType] shouldBe GameType.ConnectFour
     }
 
     "fail on unknown game type string" in {

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/GameRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/GameRoutesSpec.scala
@@ -27,7 +27,7 @@ import com.andy327.model.core.GameType
 import com.andy327.server.actors.core.{GameManager, InMemRepo, PlayerActor}
 import com.andy327.server.actors.persistence.PersistenceProtocol
 import com.andy327.server.http.json.JsonProtocol._
-import com.andy327.server.http.json.{TicTacToeMoveRequest, TicTacToeState}
+import com.andy327.server.http.json.{ConnectFourMoveRequest, ConnectFourState, TicTacToeMoveRequest, TicTacToeState}
 import com.andy327.server.lobby.Player
 import com.andy327.server.testutil.AuthTestHelper.createTestToken
 
@@ -44,7 +44,8 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
 
   private val routes = concat(
     new LobbyRoutes(typedSystem).routes,
-    new GameRoutes(GameType.TicTacToe, typedSystem).routes
+    new GameRoutes(GameType.TicTacToe, typedSystem).routes,
+    new GameRoutes(GameType.ConnectFour, typedSystem).routes
   )
 
   val (aliceId, bobId, carlId) = (UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID())
@@ -243,6 +244,188 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
         }
 
         Post(s"/tictactoe/$gameId/subscribe") ~> routes ~> check {
+          status shouldBe StatusCodes.Unauthorized
+        }
+      }
+    }
+
+    "handling ConnectFour" should {
+      "submit a move to a valid game" in {
+        val gameId = Post("/lobby/create/connectfour").withHeaders(aliceHeader) ~> routes ~> check {
+          responseAs[GameManager.LobbyCreated].gameId
+        }
+
+        Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+          status shouldBe StatusCodes.OK
+        }
+
+        Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check {
+          status shouldBe StatusCodes.OK
+        }
+
+        val move = ConnectFourMoveRequest(3)
+        val moveEntity = HttpEntity(ContentTypes.`application/json`, move.toJson.compactPrint)
+
+        Post(s"/connectfour/$gameId/move", moveEntity).withHeaders(aliceHeader) ~> routes ~> check {
+          status shouldBe StatusCodes.OK
+          val gameState = responseAs[String].parseJson.convertTo[ConnectFourState]
+          gameState.board(5)(3) shouldBe "R"
+        }
+      }
+
+      "fail to move in a nonexistent game" in {
+        val fakeId = UUID.randomUUID()
+        val move = ConnectFourMoveRequest(3)
+        val moveEntity = HttpEntity(ContentTypes.`application/json`, move.toJson.compactPrint)
+        Post(s"/connectfour/$fakeId/move", moveEntity).withHeaders(aliceHeader) ~> routes ~> check {
+          status shouldBe StatusCodes.NotFound
+        }
+      }
+
+      "fetch game status" in {
+        val gameId = Post("/lobby/create/connectfour").withHeaders(aliceHeader) ~> routes ~> check {
+          responseAs[GameManager.LobbyCreated].gameId
+        }
+
+        Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+          status shouldBe StatusCodes.OK
+        }
+
+        Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check {
+          status shouldBe StatusCodes.OK
+        }
+
+        Get(s"/connectfour/$gameId/status") ~> routes ~> check {
+          status shouldBe StatusCodes.OK
+          val gameState = responseAs[String].parseJson.convertTo[ConnectFourState]
+          gameState.currentPlayer shouldBe "R"
+        }
+      }
+
+      "return 404 for status of unknown game" in {
+        val fakeId = UUID.randomUUID()
+        Get(s"/connectfour/$fakeId/status") ~> routes ~> check {
+          status shouldBe StatusCodes.NotFound
+        }
+      }
+
+      "return 400 for invalid game ID on move" in {
+        val move = ConnectFourMoveRequest(3)
+        val moveEntity = HttpEntity(ContentTypes.`application/json`, move.toJson.compactPrint)
+
+        Post("/connectfour/invalid-game-id/move", moveEntity).withHeaders(aliceHeader) ~> routes ~> check {
+          status shouldBe StatusCodes.BadRequest
+        }
+      }
+
+      "return 400 for invalid JSON structure on move" in {
+        val gameId = Post("/lobby/create/connectfour").withHeaders(aliceHeader) ~> routes ~> check {
+          responseAs[GameManager.LobbyCreated].gameId
+        }
+
+        Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+          status shouldBe StatusCodes.OK
+        }
+
+        Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check {
+          status shouldBe StatusCodes.OK
+        }
+
+        val invalidJson = """{ "row": 0, "column": 3 }"""
+        val entity = HttpEntity(ContentTypes.`application/json`, invalidJson)
+
+        Post(s"/connectfour/$gameId/move", entity).withHeaders(aliceHeader) ~> routes ~> check {
+          status shouldBe StatusCodes.BadRequest
+          responseAs[String] should include("Invalid JSON")
+        }
+      }
+
+      "return 400 for invalid game ID on status" in
+        Get("/connectfour/invalid-game-id/status") ~> routes ~> check {
+          status shouldBe StatusCodes.BadRequest
+        }
+
+      "return 500 for unexpected responses" in {
+        val fakeId = UUID.randomUUID()
+        val unexpectedBehavior = Behaviors.receiveMessage[GameManager.Command] {
+          case GameManager.RunGameOperation(_, _, replyTo) =>
+            replyTo ! GameManager.Ready
+            Behaviors.same
+
+          case GameManager.SubscribePlayerToGame(_, _, replyTo) =>
+            replyTo ! GameManager.Ready
+            Behaviors.same
+
+          case _ => Behaviors.same
+        }
+
+        val dummySystem = ActorSystem(unexpectedBehavior, "UnexpectedResponseCFSystem")
+        val errorRoutes = new GameRoutes(GameType.ConnectFour, dummySystem).routes
+
+        val move = ConnectFourMoveRequest(3)
+        val moveEntity = HttpEntity(ContentTypes.`application/json`, move.toJson.compactPrint)
+
+        val requests = Table(
+          ("description", "request"),
+          ("POST /move", Post(s"/connectfour/$fakeId/move", moveEntity).withHeaders(aliceHeader)),
+          ("GET /status", Get(s"/connectfour/$fakeId/status")),
+          ("POST /subscribe", Post(s"/connectfour/$fakeId/subscribe").withHeaders(aliceHeader))
+        )
+
+        forAll(requests) { (description, req) =>
+          withClue(s"$description should return 500 with fallback message") {
+            req ~> errorRoutes ~> check {
+              status shouldBe StatusCodes.InternalServerError
+              responseAs[String] should include("Unexpected")
+            }
+          }
+        }
+      }
+
+      "return 200 when subscribing to an active game with a WebSocket connection" in {
+        val gameId = Post("/lobby/create/connectfour").withHeaders(aliceHeader) ~> routes ~> check {
+          responseAs[GameManager.LobbyCreated].gameId
+        }
+        Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+          status shouldBe StatusCodes.OK
+        }
+        Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check {
+          status shouldBe StatusCodes.OK
+        }
+
+        val wsProbe = testKit.createTestProbe[Message]()
+        Await.result(
+          typedSystem.ask[ActorRef[PlayerActor.Command]](GameManager.RegisterPlayer(alicePlayer, wsProbe.ref, _)),
+          3.seconds
+        )
+
+        Post(s"/connectfour/$gameId/subscribe").withHeaders(aliceHeader) ~> routes ~> check {
+          status shouldBe StatusCodes.OK
+          responseAs[GameManager.SubscribeAcknowledged].gameId shouldBe gameId
+        }
+
+        typedSystem ! GameManager.PlayerDisconnected(alicePlayer.id)
+      }
+
+      "return 400 when subscribing to a game without an active WebSocket connection" in {
+        val gameId = Post("/lobby/create/connectfour").withHeaders(aliceHeader) ~> routes ~> check {
+          responseAs[GameManager.LobbyCreated].gameId
+        }
+        Post("/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check(())
+        Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check(())
+
+        Post(s"/connectfour/$gameId/subscribe").withHeaders(aliceHeader) ~> routes ~> check {
+          status shouldBe StatusCodes.BadRequest
+          responseAs[String] should include("not connected")
+        }
+      }
+
+      "return 401 when subscribing to a game without authentication" in {
+        val gameId = Post("/lobby/create/connectfour").withHeaders(aliceHeader) ~> routes ~> check {
+          responseAs[GameManager.LobbyCreated].gameId
+        }
+
+        Post(s"/connectfour/$gameId/subscribe") ~> routes ~> check {
           status shouldBe StatusCodes.Unauthorized
         }
       }

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/LobbyRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/LobbyRoutesSpec.scala
@@ -189,7 +189,7 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
       }
     }
 
-    "return metadata for a valid lobby" in {
+    "return metadata for a valid TicTacToe lobby" in {
       val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
         responseAs[GameManager.LobbyCreated].gameId
       }
@@ -239,7 +239,7 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
       }
     }
 
-    "filter lobbies by game type" in {
+    "filter lobbies by TicTacToe game type" in {
       Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
       }
@@ -248,6 +248,31 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
         status shouldBe StatusCodes.OK
         val result = responseAs[GameManager.LobbiesListed]
         result.lobbies.foreach(_.gameType shouldBe GameType.TicTacToe)
+      }
+    }
+
+    "return metadata for a valid ConnectFour lobby" in {
+      val gameId = Post("/lobby/create/connectfour").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].gameId
+      }
+
+      Get(s"/lobby/$gameId") ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+        val response = responseAs[LobbyMetadata]
+        response.gameType shouldBe GameType.ConnectFour
+        response.gameId shouldBe gameId
+      }
+    }
+
+    "filter lobbies by ConnectFour game type" in {
+      Post("/lobby/create/connectfour").withHeaders(aliceHeader) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+      }
+
+      Get("/lobby/list?gameType=connectfour") ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+        val result = responseAs[GameManager.LobbiesListed]
+        result.lobbies.foreach(_.gameType shouldBe GameType.ConnectFour)
       }
     }
 


### PR DESCRIPTION
Adds ConnectFour as a fully supported second game type alongside TicTacToe.

- Game model: 6×7 board, gravity-based drop mechanics, four-in-a-row win detection across all axes, draw detection
- Actor + module: ConnectFourActor and ConnectFourModule following the established GameActor/GameModule extension pattern
- Persistence: Circe codecs for ConnectFour mark and game state; serializeGame/deserializeGame centralized in GameTypeCodecs for both game types; gameTypeFormat.read fixed to handle ConnectFour
- Registry + routes: ConnectFour registered in GameRegistry; /connectfour routes wired into GameServer
- Shared core.Mark trait extracted; tictactoe.Mark and connectfour.Mark extend it, removing duplicated toString override
- Dead SnapshotLoaded command removed from TicTacToeActor
- Full test coverage: actor spec, module spec, codec roundtrip tests, route integration tests, lobby metadata deserialization tests