### PR TITLE
add move history persistence and replay endpoint (#21)

### DIFF
--- a/game-service-model/src/main/scala/com/andy327/model/connectfour/ConnectFour.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/connectfour/ConnectFour.scala
@@ -91,6 +91,9 @@ final case class ConnectFour(
     else if (playerId == playerYellow) Some(Yellow)
     else None
 
+  /** The number of pieces dropped so far — one per move. */
+  def moveCount: Int = board.flatten.count(_.isDefined)
+
   private def nextPlayer: Mark = currentPlayer match {
     case Red    => Yellow
     case Yellow => Red

--- a/game-service-model/src/main/scala/com/andy327/model/core/Game.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/core/Game.scala
@@ -25,6 +25,11 @@ trait Game[Move, State, Player, Status, Error] {
   /** The current status of the game (e.g., ongoing, won, draw). */
   def gameStatus: Status
 
+  /** The number of moves applied so far. Serves as the 0-based ordinal of the next move in the history log, and is
+    * derived from the game's own state so it survives a restart without consulting the move log.
+    */
+  def moveCount: Int
+
   /** Resolves an external player ID to this game's player token (e.g., a mark or seat).
     *
     * Returns None if the ID does not belong to a participant. This is the single place where platform identity

--- a/game-service-model/src/main/scala/com/andy327/model/tictactoe/TicTacToe.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/tictactoe/TicTacToe.scala
@@ -68,6 +68,9 @@ final case class TicTacToe(
     else if (playerId == playerO) Some(O)
     else None
 
+  /** The number of marks placed so far — one per move. */
+  def moveCount: Int = board.flatten.count(_.isDefined)
+
   private def nextPlayer: Mark = currentPlayer match {
     case X => O
     case O => X

--- a/game-service-persistence/src/main/scala/com/andy327/persistence/db/MoveHistoryRepository.scala
+++ b/game-service-persistence/src/main/scala/com/andy327/persistence/db/MoveHistoryRepository.scala
@@ -1,0 +1,40 @@
+package com.andy327.persistence.db
+
+import java.time.Instant
+
+import cats.effect.IO
+
+import io.circe.Json
+
+import com.andy327.model.core.{GameId, PlayerId}
+
+/** A single recorded move in a game's history.
+  *
+  * @param seq the move's ordinal within the game (0-based, gap-free), assigned by the game actor
+  * @param playerId the player who made the move
+  * @param move the move payload exactly as it crossed the wire, stored opaquely (not interpreted by this layer)
+  * @param createdAt server timestamp when the move was persisted
+  */
+final case class MoveRecord(seq: Int, playerId: PlayerId, move: Json, createdAt: Instant)
+
+/** Repository for the append-only log of moves played in each game.
+  *
+  * Distinct from [[GameRepository]], which stores a single overwritten snapshot of current state: this records the full
+  * ordered sequence of moves ("how the game got there") for history, replay, and audit. The log is purely additive — it
+  * is never read to restore in-memory game state, only on demand via the history endpoint.
+  *
+  * Moves are stored opaquely as JSON; this layer never deserializes them into game-specific move types, keeping it
+  * game-agnostic. Derived facts (whose turn, resulting board, which move won) are intentionally not stored — they are
+  * recomputed by folding the move sequence.
+  */
+trait MoveHistoryRepository {
+
+  /** Runs any needed initialization, such as creating the move-history table. */
+  def initialize(): IO[Unit]
+
+  /** Append a single move to `gameId`'s log at ordinal `seq`. Fire-and-forget from the caller's perspective. */
+  def appendMove(gameId: GameId, seq: Int, playerId: PlayerId, move: Json): IO[Unit]
+
+  /** Load all recorded moves for `gameId`, ordered by ascending `seq`. Empty if the game has no recorded moves. */
+  def loadMoves(gameId: GameId): IO[List[MoveRecord]]
+}

--- a/game-service-persistence/src/main/scala/com/andy327/persistence/db/NoOpMoveHistoryRepository.scala
+++ b/game-service-persistence/src/main/scala/com/andy327/persistence/db/NoOpMoveHistoryRepository.scala
@@ -1,0 +1,18 @@
+package com.andy327.persistence.db
+
+import cats.effect.IO
+
+import io.circe.Json
+
+import com.andy327.model.core.{GameId, PlayerId}
+
+/** A [[MoveHistoryRepository]] that records nothing and returns no history.
+  *
+  * Used as the default where move-history persistence is not wired (e.g. tests that don't exercise the feature); the
+  * real [[com.andy327.persistence.db.postgres.PostgresMoveHistoryRepository]] is supplied in production.
+  */
+object NoOpMoveHistoryRepository extends MoveHistoryRepository {
+  override def initialize(): IO[Unit] = IO.unit
+  override def appendMove(gameId: GameId, seq: Int, playerId: PlayerId, move: Json): IO[Unit] = IO.unit
+  override def loadMoves(gameId: GameId): IO[List[MoveRecord]] = IO.pure(Nil)
+}

--- a/game-service-persistence/src/main/scala/com/andy327/persistence/db/postgres/PostgresMoveHistoryRepository.scala
+++ b/game-service-persistence/src/main/scala/com/andy327/persistence/db/postgres/PostgresMoveHistoryRepository.scala
@@ -1,0 +1,76 @@
+package com.andy327.persistence.db.postgres
+
+import java.time.Instant
+import java.util.UUID
+
+import org.slf4j.LoggerFactory
+
+import cats.effect.IO
+import cats.implicits._
+
+import doobie._
+import doobie.implicits._
+import doobie.postgres.implicits._
+import io.circe.Json
+import io.circe.parser.parse
+
+import com.andy327.model.core.{GameId, PlayerId}
+import com.andy327.persistence.db.{MoveHistoryRepository, MoveRecord}
+
+/** [[MoveHistoryRepository]] backed by PostgreSQL via Doobie.
+  *
+  * Each move is one row in `game_moves`, keyed by `(game_id, seq)`. The move payload is stored as an opaque JSON
+  * string; `created_at` is stamped by the database on insert.
+  */
+class PostgresMoveHistoryRepository(xa: Transactor[IO]) extends MoveHistoryRepository {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  /** Creates the 'game_moves' table with the appropriate schema if it doesn't already exist. */
+  override def initialize(): IO[Unit] =
+    sql"""
+      CREATE TABLE IF NOT EXISTS game_moves (
+        game_id    TEXT NOT NULL,
+        seq        INTEGER NOT NULL,
+        player_id  TEXT NOT NULL,
+        move_json  TEXT NOT NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        PRIMARY KEY (game_id, seq)
+      )
+    """.update.run.transact(xa).void
+
+  /** Appends a move row. The `(game_id, seq)` primary key makes a duplicate ordinal a no-op rather than a duplicate. */
+  override def appendMove(gameId: GameId, seq: Int, playerId: PlayerId, move: Json): IO[Unit] =
+    sql"""
+      INSERT INTO game_moves (game_id, seq, player_id, move_json)
+      VALUES (${gameId.toString}, $seq, ${playerId.toString}, ${move.noSpaces})
+      ON CONFLICT (game_id, seq) DO NOTHING
+    """.update.run.transact(xa).void
+
+  /** Loads all moves for a game ordered by ascending seq. Rows that fail to parse are logged and skipped. */
+  override def loadMoves(gameId: GameId): IO[List[MoveRecord]] =
+    sql"""
+      SELECT seq, player_id, move_json, created_at
+      FROM game_moves
+      WHERE game_id = ${gameId.toString}
+      ORDER BY seq ASC
+    """
+      .query[(Int, String, String, Instant)]
+      .to[List]
+      .transact(xa)
+      .map { rows =>
+        rows.flatMap { case (seq, playerIdStr, moveJson, createdAt) =>
+          val record = for {
+            playerId <- Either.catchOnly[IllegalArgumentException](UUID.fromString(playerIdStr))
+            move <- parse(moveJson)
+          } yield MoveRecord(seq, playerId, move, createdAt)
+
+          record match {
+            case Right(rec) => List(rec)
+            case Left(err)  =>
+              logger.warn(s"Skipping unparseable move $seq for game ${gameId.toString}: ${err.getMessage}")
+              Nil
+          }
+        }
+      }
+}

--- a/game-service-persistence/src/test/scala/com/andy327/persistence/db/NoOpMoveHistoryRepositorySpec.scala
+++ b/game-service-persistence/src/test/scala/com/andy327/persistence/db/NoOpMoveHistoryRepositorySpec.scala
@@ -1,0 +1,23 @@
+package com.andy327.persistence.db
+
+import java.util.UUID
+
+import cats.effect.unsafe.implicits.global
+
+import io.circe.Json
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class NoOpMoveHistoryRepositorySpec extends AnyWordSpec with Matchers {
+
+  "NoOpMoveHistoryRepository" should {
+    "do nothing on initialize and appendMove, and return no history" in {
+      val repo = NoOpMoveHistoryRepository
+      val gameId = UUID.randomUUID()
+
+      repo.initialize().unsafeRunSync() shouldBe (())
+      repo.appendMove(gameId, 0, UUID.randomUUID(), Json.obj()).unsafeRunSync() shouldBe (())
+      repo.loadMoves(gameId).unsafeRunSync() shouldBe empty
+    }
+  }
+}

--- a/game-service-persistence/src/test/scala/com/andy327/persistence/db/postgres/PostgresMoveHistoryRepositorySpec.scala
+++ b/game-service-persistence/src/test/scala/com/andy327/persistence/db/postgres/PostgresMoveHistoryRepositorySpec.scala
@@ -1,0 +1,108 @@
+package com.andy327.persistence.db.postgres
+
+import java.util.UUID
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+
+import com.dimafeng.testcontainers.{ForAllTestContainer, PostgreSQLContainer}
+import doobie.Transactor
+import doobie.implicits._
+import io.circe.Json
+import io.circe.syntax._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import com.andy327.model.core.{GameId, PlayerId}
+
+class PostgresMoveHistoryRepositorySpec extends AnyWordSpec with Matchers with ForAllTestContainer {
+
+  /** Single PostgreSQL container spun up once per ScalaTest run. */
+  override val container: PostgreSQLContainer = PostgreSQLContainer()
+
+  private lazy val xa: Transactor[IO] = Transactor.fromDriverManager[IO](
+    driver = "org.postgresql.Driver",
+    url = container.jdbcUrl,
+    user = container.username,
+    password = container.password,
+    None
+  )
+
+  private lazy val repo = new PostgresMoveHistoryRepository(xa)
+
+  override def afterStart(): Unit =
+    repo.initialize().unsafeRunSync()
+
+  private def move(col: Int): Json = Json.obj("col" -> col.asJson)
+
+  "PostgresMoveHistoryRepository" should {
+    "append moves and load them ordered by seq" in {
+      val gameId: GameId = UUID.randomUUID()
+      val alice: PlayerId = UUID.randomUUID()
+      val bob: PlayerId = UUID.randomUUID()
+
+      repo.appendMove(gameId, 0, alice, move(3)).unsafeRunSync()
+      repo.appendMove(gameId, 1, bob, move(4)).unsafeRunSync()
+      repo.appendMove(gameId, 2, alice, move(3)).unsafeRunSync()
+
+      val moves = repo.loadMoves(gameId).unsafeRunSync()
+      moves.map(_.seq) shouldBe List(0, 1, 2)
+      moves.map(_.playerId) shouldBe List(alice, bob, alice)
+      moves.map(_.move) shouldBe List(move(3), move(4), move(3))
+      moves.foreach(_.createdAt should not be null)
+    }
+
+    "order by seq even when moves are appended out of order" in {
+      val gameId: GameId = UUID.randomUUID()
+      val player: PlayerId = UUID.randomUUID()
+
+      repo.appendMove(gameId, 2, player, move(2)).unsafeRunSync()
+      repo.appendMove(gameId, 0, player, move(0)).unsafeRunSync()
+      repo.appendMove(gameId, 1, player, move(1)).unsafeRunSync()
+
+      repo.loadMoves(gameId).unsafeRunSync().map(_.seq) shouldBe List(0, 1, 2)
+    }
+
+    "return an empty list for a game with no recorded moves" in {
+      repo.loadMoves(UUID.randomUUID()).unsafeRunSync() shouldBe empty
+    }
+
+    "ignore a duplicate (gameId, seq) rather than failing" in {
+      val gameId: GameId = UUID.randomUUID()
+      val player: PlayerId = UUID.randomUUID()
+
+      repo.appendMove(gameId, 0, player, move(1)).unsafeRunSync()
+      repo.appendMove(gameId, 0, player, move(9)).unsafeRunSync() // same seq — must not overwrite or throw
+
+      val moves = repo.loadMoves(gameId).unsafeRunSync()
+      moves.map(_.move) shouldBe List(move(1))
+    }
+
+    "skip rows whose stored move JSON cannot be parsed" in {
+      val gameId: GameId = UUID.randomUUID()
+      val player: PlayerId = UUID.randomUUID()
+
+      repo.appendMove(gameId, 0, player, move(1)).unsafeRunSync()
+      // a corrupt row inserted directly, bypassing appendMove (which always writes valid JSON)
+      sql"""
+        INSERT INTO game_moves (game_id, seq, player_id, move_json)
+        VALUES (${gameId.toString}, 1, ${player.toString}, 'not-json')
+      """.update.run.transact(xa).unsafeRunSync()
+
+      val moves = repo.loadMoves(gameId).unsafeRunSync()
+      moves.map(_.seq) shouldBe List(0) // the corrupt seq-1 row is skipped
+    }
+
+    "isolate move logs by gameId" in {
+      val game1: GameId = UUID.randomUUID()
+      val game2: GameId = UUID.randomUUID()
+      val player: PlayerId = UUID.randomUUID()
+
+      repo.appendMove(game1, 0, player, move(1)).unsafeRunSync()
+      repo.appendMove(game2, 0, player, move(2)).unsafeRunSync()
+
+      repo.loadMoves(game1).unsafeRunSync().map(_.move) shouldBe List(move(1))
+      repo.loadMoves(game2).unsafeRunSync().map(_.move) shouldBe List(move(2))
+    }
+  }
+}

--- a/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
@@ -16,9 +16,9 @@ import org.apache.pekko.http.scaladsl.Http
 import org.apache.pekko.http.scaladsl.server.Directives._
 
 import com.andy327.model.core.GameType
-import com.andy327.persistence.db.GameRepository
-import com.andy327.persistence.db.postgres.{PostgresGameRepository, PostgresTransactor}
+import com.andy327.persistence.db.postgres.{PostgresGameRepository, PostgresMoveHistoryRepository, PostgresTransactor}
 import com.andy327.persistence.db.redis.{RedisClientResource, RedisGameRepository}
+import com.andy327.persistence.db.{GameRepository, MoveHistoryRepository}
 import com.andy327.server.actors.core.GameManager
 import com.andy327.server.actors.persistence.PostgresActor
 import com.andy327.server.http.routes.{AuthRoutes, GameRoutes, LobbyRoutes, WebSocketRoutes}
@@ -56,15 +56,17 @@ object GameServer {
       val postgresRepo = new PostgresGameRepository(xa)
       val gameRepo = new RedisGameRepository(postgresRepo, redis)
       val lobbyRepo = new RedisLobbyRepository(redis)
+      val moveRepo = new PostgresMoveHistoryRepository(xa)
 
       // Ensure the schema exists before starting the server
       for {
         _ <- gameRepo.initialize()
+        _ <- moveRepo.initialize()
         subscriber <- GameEventSubscriber.create(subscribeStream)
         publisher = new RedisGameEventPublisher(publishFn)
         // Run the subscriber as a background fiber; it stays alive for the lifetime of the server
         _ <- subscriber.run.start
-        result <- startServer(host, port, gameRepo, lobbyRepo, publisher, Some(subscriber)).flatMap {
+        result <- startServer(host, port, gameRepo, lobbyRepo, moveRepo, publisher, Some(subscriber)).flatMap {
           case (system, _) =>
             IO.blocking(Await.result(system.whenTerminated, Duration.Inf))
         }
@@ -78,11 +80,12 @@ object GameServer {
       port: Int,
       gameRepo: GameRepository,
       lobbyRepo: LobbyRepository,
+      moveRepo: MoveHistoryRepository,
       publisher: GameEventPublisher = NoOpGameEventPublisher,
       subscriber: Option[GameEventSubscriber] = None
   )(implicit runtime: IORuntime): IO[(ActorSystem[GameManager.Command], Http.ServerBinding)] = IO.defer {
     val rootBehavior = Behaviors.setup[GameManager.Command] { context =>
-      val persistActor = context.spawn(PostgresActor(gameRepo), "postgres-persistence")
+      val persistActor = context.spawn(PostgresActor(gameRepo, moveRepo), "postgres-persistence")
       GameManager(persistActor, gameRepo, lobbyRepo, publisher, subscriber)
     }
 

--- a/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
@@ -86,7 +86,7 @@ object GameServer {
   )(implicit runtime: IORuntime): IO[(ActorSystem[GameManager.Command], Http.ServerBinding)] = IO.defer {
     val rootBehavior = Behaviors.setup[GameManager.Command] { context =>
       val persistActor = context.spawn(PostgresActor(gameRepo, moveRepo), "postgres-persistence")
-      GameManager(persistActor, gameRepo, lobbyRepo, publisher, subscriber)
+      GameManager(persistActor, gameRepo, lobbyRepo, moveRepo, publisher, subscriber)
     }
 
     // Pekko actor system

--- a/game-service-server/src/main/scala/com/andy327/server/actors/connectfour/ConnectFourActor.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/connectfour/ConnectFourActor.scala
@@ -1,5 +1,7 @@
 package com.andy327.server.actors.connectfour
 
+import io.circe.generic.semiauto.deriveEncoder
+
 import com.andy327.model.connectfour.{ConnectFour, Drop, Mark}
 import com.andy327.server.actors.core.TurnBasedGameActor
 import com.andy327.server.http.json.GridGameState
@@ -10,6 +12,7 @@ import com.andy327.server.http.json.GridGameState
   * order) live in the `model.connectfour.ConnectFour` model. Red is seated first and moves first, Yellow second.
   */
 object ConnectFourActor
-    extends TurnBasedGameActor[ConnectFour, Drop, Mark, GridGameState](players =>
-      ConnectFour.empty(players(0), players(1))
+    extends TurnBasedGameActor[ConnectFour, Drop, Mark, GridGameState](
+      players => ConnectFour.empty(players(0), players(1)),
+      deriveEncoder[Drop]
     )

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/GameManager.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/GameManager.scala
@@ -11,7 +11,7 @@ import org.apache.pekko.actor.typed.{ActorRef, Behavior}
 import org.apache.pekko.util.Timeout
 
 import com.andy327.model.core.{Game, GameError, GameId, GameType, PlayerId}
-import com.andy327.persistence.db.GameRepository
+import com.andy327.persistence.db.{GameRepository, MoveHistoryRepository, MoveRecord, NoOpMoveHistoryRepository}
 import com.andy327.server.actors.persistence.PersistenceProtocol
 import com.andy327.server.game.{GameOperation, GameRegistry}
 import com.andy327.server.http.json.GameState
@@ -80,6 +80,11 @@ object GameManager {
     * or [[ErrorResponse]] (internal failure).
     */
   final case class RunGameOperation(gameId: GameId, op: GameOperation, replyTo: ActorRef[GameResponse]) extends Command
+
+  /** Fetch the ordered move history for `gameId` from the move log; replies with [[MoveHistory]] (empty if none) or
+    * [[ErrorResponse]] on a storage failure. Served by a direct DB read, so it works for active and finished games.
+    */
+  final case class GetMoveHistory(gameId: GameId, replyTo: ActorRef[GameResponse]) extends Command
 
   /** Subscribe `playerRef` to game-state push events from the game actor for `gameId`. */
   final case class SubscribeToGame(gameId: GameId, playerRef: ActorRef[PlayerActor.Command]) extends Command
@@ -178,6 +183,13 @@ object GameManager {
       replyTo: ActorRef[GameResponse]
   ) extends Command
 
+  /** Carries the result of an async move-history load for a [[GetMoveHistory]] request. */
+  final private case class MoveHistoryLoaded(
+      result: Either[Throwable, List[MoveRecord]],
+      gameId: GameId,
+      replyTo: ActorRef[GameResponse]
+  ) extends Command
+
   // --- Response types (sent back to HTTP route handlers) ---
 
   sealed trait GameResponse
@@ -194,6 +206,9 @@ object GameManager {
   // Game responses
   final case class GameStarted(gameId: GameId) extends GameResponse
   final case class GameStatus(state: GameState) extends GameResponse
+
+  /** The ordered move history for a game; `moves` is empty if the game has no recorded moves. */
+  final case class MoveHistory(gameId: GameId, moves: List[MoveRecord]) extends GameResponse
 
   // Error responses
 
@@ -219,6 +234,8 @@ object GameManager {
     *
     * @param persistActor shared actor for all persistence I/O
     * @param gameRepo the repository used for the initial game restore and completed-game state lookups
+    * @param lobbyRepo the repository used to restore lobbies at startup and persist lobby changes
+    * @param moveRepo the repository read to serve move-history queries; defaults to no-op (empty history)
     * @param publisher publishes game events to Redis so remote instances can relay them; defaults to no-op
     * @param subscriber routes incoming Redis events to locally connected players watching remote games; `None` disables
     * @param onReady optional ref that receives a [[Ready]] signal once the running state is entered (used in tests)
@@ -228,6 +245,7 @@ object GameManager {
       persistActor: ActorRef[PersistenceProtocol.Command],
       gameRepo: GameRepository,
       lobbyRepo: LobbyRepository,
+      moveRepo: MoveHistoryRepository = NoOpMoveHistoryRepository,
       publisher: GameEventPublisher = NoOpGameEventPublisher,
       subscriber: Option[GameEventSubscriber] = None,
       onReady: Option[ActorRef[Ready.type]] = None
@@ -251,7 +269,17 @@ object GameManager {
             RestoreGames(Map.empty, Nil)
         }
 
-        initializing(lobbyManager, playerManager, persistActor, gameRepo, stash, publisher, subscriber, onReady)
+        initializing(
+          lobbyManager,
+          playerManager,
+          persistActor,
+          gameRepo,
+          moveRepo,
+          stash,
+          publisher,
+          subscriber,
+          onReady
+        )
       }
     }
 
@@ -265,6 +293,7 @@ object GameManager {
       playerManager: ActorRef[PlayerManager.Command],
       persistActor: ActorRef[PersistenceProtocol.Command],
       gameRepo: GameRepository,
+      moveRepo: MoveHistoryRepository,
       stash: StashBuffer[Command],
       publisher: GameEventPublisher,
       subscriber: Option[GameEventSubscriber],
@@ -290,6 +319,7 @@ object GameManager {
             playerManager,
             persistActor,
             gameRepo,
+            moveRepo,
             publisher,
             subscriber
           )(runtime)
@@ -316,6 +346,7 @@ object GameManager {
       playerManager: ActorRef[PlayerManager.Command],
       persistActor: ActorRef[PersistenceProtocol.Command],
       gameRepo: GameRepository,
+      moveRepo: MoveHistoryRepository,
       publisher: GameEventPublisher,
       subscriber: Option[GameEventSubscriber]
   )(implicit runtime: IORuntime): Behavior[Command] =
@@ -472,6 +503,7 @@ object GameManager {
               playerManager,
               persistActor,
               gameRepo,
+              moveRepo,
               publisher,
               subscriber
             )
@@ -490,6 +522,7 @@ object GameManager {
                 playerManager,
                 persistActor,
                 gameRepo,
+                moveRepo,
                 publisher,
                 subscriber
               )
@@ -540,6 +573,24 @@ object GameManager {
             case Left(ex) =>
               context.log.error("Failed to load completed game state from DB", ex)
               replyTo ! ErrorResponse("Failed to retrieve game state")
+          }
+          Behaviors.same
+
+        case GetMoveHistory(gameId, replyTo) =>
+          context.pipeToSelf(moveRepo.loadMoves(gameId).attempt.unsafeToFuture()) {
+            case Success(result) => MoveHistoryLoaded(result, gameId, replyTo)
+            // $COVERAGE-OFF$ .attempt converts IO failures to Success(Left(ex)); Failure is unreachable
+            case Failure(ex) => MoveHistoryLoaded(Left(ex), gameId, replyTo)
+            // $COVERAGE-ON$
+          }
+          Behaviors.same
+
+        case MoveHistoryLoaded(result, gameId, replyTo) =>
+          result match {
+            case Right(moves) => replyTo ! MoveHistory(gameId, moves)
+            case Left(ex)     =>
+              context.log.error(s"Failed to load move history for $gameId", ex)
+              replyTo ! ErrorResponse("Failed to retrieve move history")
           }
           Behaviors.same
 

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/TurnBasedGameActor.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/TurnBasedGameActor.scala
@@ -2,6 +2,7 @@ package com.andy327.server.actors.core
 
 import scala.reflect.ClassTag
 
+import io.circe.Encoder
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
 import org.apache.pekko.actor.typed.{ActorRef, Behavior, Terminated}
 
@@ -47,14 +48,16 @@ object TurnBasedGameActor {
   *
   * Adding a new game type therefore requires no actor code beyond a binding:
   * {{{
-  *   object MyGameActor extends TurnBasedGameActor[MyGame, MyMove, MySeat, MyGameState](players =>
-  *     MyGame.empty(players(0), players(1))
+  *   object MyGameActor extends TurnBasedGameActor[MyGame, MyMove, MySeat, MyGameState](
+  *     players => MyGame.empty(players(0), players(1)),
+  *     deriveEncoder[MyMove]
   *   )
   * }}}
   * given a `GameTypeTag[MyGame]` (model) and a `GameStateView[MyGame, MyGameState]` (http.json) instance.
   *
   * @param newGame factory producing the initial game model from the seated players; the player count has already been
   *                validated against the GameType's bounds by [[GameManager]]
+  * @param moveEncoder serializes a move to JSON for the append-only history log
   * @tparam G the concrete game model type
   * @tparam M the game's move type
   * @tparam P the game's player-token (seat) type
@@ -62,7 +65,8 @@ object TurnBasedGameActor {
   * @see [[GameActor]] for the full actor lifecycle and behavioral contract.
   */
 class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <: GameState](
-    newGame: Seq[PlayerId] => G
+    newGame: Seq[PlayerId] => G,
+    moveEncoder: Encoder[M]
 )(implicit tag: GameTypeTag[G], view: GameStateView[G, S], ct: ClassTag[G])
     extends GameActor[G] {
 
@@ -156,9 +160,13 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
                   replyTo = context.messageAdapter(_ => SnapshotSaved(Right(())))
                 )
 
+                // record the move in the append-only history log; seq is the pre-move move count (0-based ordinal)
+                persist ! PersistenceProtocol.AppendMove(gameId, game.moveCount, playerId, moveEncoder(move))
+
                 val serialized = view.fromGame(nextState)
                 replyTo ! Right(serialized)
                 val stateEvent = PlayerEvent.GameStateUpdated(serialized)
+                // fan out to locally-connected players; publisher relays to players on other server instances
                 subscribers.foreach(_ ! PlayerActor.SendEvent(stateEvent))
                 publisher.publish(gameId, stateEvent)
 

--- a/game-service-server/src/main/scala/com/andy327/server/actors/persistence/PersistActor.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/persistence/PersistActor.scala
@@ -5,10 +5,11 @@ import scala.util.{Failure, Success}
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 
+import io.circe.Json
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
 import org.apache.pekko.actor.typed.{ActorRef, Behavior}
 
-import com.andy327.model.core.{Game, GameId, GameType}
+import com.andy327.model.core.{Game, GameId, GameType, PlayerId}
 
 object PersistActor {
 
@@ -16,11 +17,14 @@ object PersistActor {
 
   /** Internal wrapper for a finished save-operation. */
   final case class Saved(replyTo: ActorRef[SnapshotSaved], result: Either[Throwable, Unit]) extends Command
+
+  /** Internal wrapper for a finished move-append; logged but never replied to (append is fire-and-forget). */
+  final case class MoveAppended(gameId: GameId, seq: Int, result: Either[Throwable, Unit]) extends Command
 }
 
-/** Base trait for persistence actors that save game snapshots on behalf of game actors.
+/** Base trait for persistence actors that save game snapshots and append move-history records on behalf of game actors.
   *
-  * Concrete implementations only need to supply the saving behavior.
+  * Concrete implementations supply the snapshot-save and move-append behavior.
   */
 trait PersistActor {
 
@@ -29,6 +33,9 @@ trait PersistActor {
 
   /** Persist the current game snapshot, overwriting any previously saved state for the same ID. */
   def saveToStore(gameId: GameId, gameType: GameType, game: Game[_, _, _, _, _]): IO[Unit]
+
+  /** Append a single move to the game's history log. */
+  def appendMoveToStore(gameId: GameId, seq: Int, playerId: PlayerId, move: Json): IO[Unit]
 
   final def behavior(implicit runtime: IORuntime): Behavior[Command] =
     Behaviors.setup { context =>
@@ -40,8 +47,19 @@ trait PersistActor {
           }
           Behaviors.same
 
+        case AppendMove(gameId, seq, playerId, move) =>
+          context.pipeToSelf(appendMoveToStore(gameId, seq, playerId, move).unsafeToFuture()) {
+            case Success(value) => MoveAppended(gameId, seq, Right(value))
+            case Failure(ex)    => MoveAppended(gameId, seq, Left(ex))
+          }
+          Behaviors.same
+
         case Saved(replyTo, result) =>
           replyTo ! SnapshotSaved(result)
+          Behaviors.same
+
+        case MoveAppended(gameId, seq, result) =>
+          result.left.foreach(ex => context.log.warn(s"Move append failed for game $gameId seq $seq: ${ex.getMessage}"))
           Behaviors.same
       }
     }

--- a/game-service-server/src/main/scala/com/andy327/server/actors/persistence/PersistenceProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/persistence/PersistenceProtocol.scala
@@ -1,14 +1,15 @@
 package com.andy327.server.actors.persistence
 
+import io.circe.Json
 import org.apache.pekko.actor.typed.ActorRef
 
-import com.andy327.model.core.{Game, GameId, GameType}
+import com.andy327.model.core.{Game, GameId, GameType, PlayerId}
 
 /** Commands and reply types for the persistence actor (e.g. [[PostgresActor]]).
   *
   * Senders fire a `SaveSnapshot` command with a typed `replyTo` ref and receive a `SnapshotSaved` reply carrying an
-  * `Either` that distinguishes success from failure. Loads do not go through the actor: startup restore and
-  * completed-game reads call the repository directly.
+  * `Either` that distinguishes success from failure. `AppendMove` is fire-and-forget (no reply). Loads do not go
+  * through the actor: startup restore and completed-game reads call the repository directly.
   */
 object PersistenceProtocol {
 
@@ -24,6 +25,15 @@ object PersistenceProtocol {
       game: Game[_, _, _, _, _],
       replyTo: ActorRef[SnapshotSaved]
   ) extends Command
+
+  /** Append one move to the game's history log at ordinal `seq`.
+    *
+    * Fire-and-forget: there is no reply and a failed append is logged but not retried. The tradeoff is that a dropped
+    * append leaves a gap in the history log while the game snapshot still reflects true current state — the game stays
+    * correct, only its recorded history is lossy. If stronger guarantees are wanted later, this is the seam to add an
+    * acknowledged, retried append (TODO: ack-and-retry; deferred while history is non-critical).
+    */
+  final case class AppendMove(gameId: GameId, seq: Int, playerId: PlayerId, move: Json) extends Command
 
   // --- Replies (sent back to the requester) ---
 

--- a/game-service-server/src/main/scala/com/andy327/server/actors/persistence/PostgresActor.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/persistence/PostgresActor.scala
@@ -3,25 +3,32 @@ package com.andy327.server.actors.persistence
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 
+import io.circe.Json
 import org.apache.pekko.actor.typed.Behavior
 
-import com.andy327.model.core.{Game, GameId, GameType}
-import com.andy327.persistence.db.GameRepository
+import com.andy327.model.core.{Game, GameId, GameType, PlayerId}
+import com.andy327.persistence.db.{GameRepository, MoveHistoryRepository}
 
-/** Concrete [[PersistActor]] that stores game snapshots in PostgreSQL via a `GameRepository`.
+/** Concrete [[PersistActor]] that stores game snapshots and move-history records in PostgreSQL.
   *
-  * Spawned once at startup by [[com.andy327.server.actors.core.GameManager]] and shared across all game actors.
+  * Spawned once at startup by [[com.andy327.server.GameServer]] and shared across all game actors.
   */
 object PostgresActor {
 
   /** @param gameRepo the repository used to read and write game snapshots
+    * @param moveRepo the repository used to append move-history records
     * @param runtime the Cats Effect runtime used to execute IO operations
     */
-  def apply(gameRepo: GameRepository)(implicit runtime: IORuntime): Behavior[PersistenceProtocol.Command] =
-    new Impl(gameRepo).behavior
+  def apply(gameRepo: GameRepository, moveRepo: MoveHistoryRepository)(implicit
+      runtime: IORuntime
+  ): Behavior[PersistenceProtocol.Command] =
+    new Impl(gameRepo, moveRepo).behavior
 
-  private class Impl(gameRepo: GameRepository) extends PersistActor {
+  private class Impl(gameRepo: GameRepository, moveRepo: MoveHistoryRepository) extends PersistActor {
     def saveToStore(gameId: GameId, gameType: GameType, game: Game[_, _, _, _, _]): IO[Unit] =
       gameRepo.saveGame(gameId, gameType, game)
+
+    def appendMoveToStore(gameId: GameId, seq: Int, playerId: PlayerId, move: Json): IO[Unit] =
+      moveRepo.appendMove(gameId, seq, playerId, move)
   }
 }

--- a/game-service-server/src/main/scala/com/andy327/server/actors/tictactoe/TicTacToeActor.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/tictactoe/TicTacToeActor.scala
@@ -1,5 +1,7 @@
 package com.andy327.server.actors.tictactoe
 
+import io.circe.generic.semiauto.deriveEncoder
+
 import com.andy327.model.tictactoe.{Location, Mark, TicTacToe}
 import com.andy327.server.actors.core.TurnBasedGameActor
 import com.andy327.server.http.json.GridGameState
@@ -10,6 +12,7 @@ import com.andy327.server.http.json.GridGameState
   * `model.tictactoe.TicTacToe` model. X is seated first, O second.
   */
 object TicTacToeActor
-    extends TurnBasedGameActor[TicTacToe, Location, Mark, GridGameState](players =>
-      TicTacToe.empty(players(0), players(1))
+    extends TurnBasedGameActor[TicTacToe, Location, Mark, GridGameState](
+      players => TicTacToe.empty(players(0), players(1)),
+      deriveEncoder[Location]
     )

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -5,6 +5,7 @@ import io.circe.syntax._
 import io.circe.{Codec, Encoder, Json}
 import org.apache.pekko.http.scaladsl.unmarshalling.FromEntityUnmarshaller
 
+import com.andy327.persistence.db.MoveRecord
 import com.andy327.server.actors.core.GameManager.{
   ErrorResponse,
   GameStarted,
@@ -12,6 +13,7 @@ import com.andy327.server.actors.core.GameManager.{
   LobbyCreated,
   LobbyJoined,
   LobbyLeft,
+  MoveHistory,
   SubscribeAcknowledged
 }
 import com.andy327.server.actors.core.PlayerEvent
@@ -50,6 +52,10 @@ object JsonProtocol extends CirceSupport {
 
   implicit val subscribeAcknowledgedCodec: Codec[SubscribeAcknowledged] = deriveCodec[SubscribeAcknowledged]
 
+  implicit val moveRecordCodec: Codec[MoveRecord] = deriveCodec[MoveRecord]
+
+  implicit val moveHistoryCodec: Codec[MoveHistory] = deriveCodec[MoveHistory]
+
   // Game state views
 
   implicit val gridGameStateCodec: Codec[GridGameState] = deriveCodec[GridGameState]
@@ -70,6 +76,7 @@ object JsonProtocol extends CirceSupport {
   implicit val lobbiesListedUnmarshaller: FromEntityUnmarshaller[LobbiesListed] = circeUnmarshaller[LobbiesListed]
   implicit val subscribeAcknowledgedUnmarshaller: FromEntityUnmarshaller[SubscribeAcknowledged] =
     circeUnmarshaller[SubscribeAcknowledged]
+  implicit val moveHistoryUnmarshaller: FromEntityUnmarshaller[MoveHistory] = circeUnmarshaller[MoveHistory]
 
   /** Write-only encoder for PlayerEvent — serialises server-push events to JSON for delivery over WebSocket.
     *

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/GameRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/GameRoutes.scala
@@ -21,6 +21,7 @@ import com.andy327.server.actors.core.GameManager.{
   GameNotFound,
   GameResponse,
   GameStatus,
+  MoveHistory,
   MoveRejected,
   SubscribeAcknowledged
 }
@@ -41,6 +42,7 @@ import com.andy327.server.http.routes.RouteDirectives._
   * Route Summary:
   *   - POST /{gameType}/{gameId}/move - Submit a move to the specified game
   *   - GET /{gameType}/{gameId}/status - Fetch the current state of a game
+  *   - GET /{gameType}/{gameId}/history - Fetch the ordered move history for a game
   */
 class GameRoutes(gameType: GameType, system: ActorSystem[Command]) {
   implicit val scheduler: Scheduler = system.scheduler
@@ -129,6 +131,25 @@ class GameRoutes(gameType: GameType, system: ActorSystem[Command]) {
               case MoveRejected(msg)  => complete(StatusCodes.Conflict -> msg)
               case ErrorResponse(msg) => complete(StatusCodes.InternalServerError -> msg)
               case unknown            => complete(StatusCodes.InternalServerError -> s"Unexpected response: $unknown")
+            }
+          }
+        } ~
+        /** Fetches the ordered move history for the specified game.
+          *
+          * Served from the move log, so it works for both active and finished games (and returns an empty list for a
+          * game with no recorded moves).
+          *
+          * - Path: `gameId` — the UUID of the game
+          * - 200: `MoveHistory` — the ordered list of moves played
+          * - 400: invalid UUID format
+          * - 500: unexpected error
+          */
+        path("history") {
+          get {
+            onSuccess(system.ask[GameResponse](GameManager.GetMoveHistory(gameId, _))) {
+              case history: MoveHistory => complete(history)
+              case ErrorResponse(msg)   => complete(StatusCodes.InternalServerError -> msg)
+              case unknown              => complete(StatusCodes.InternalServerError -> s"Unexpected response: $unknown")
             }
           }
         } ~

--- a/game-service-server/src/test/scala/com/andy327/server/GameServerSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/GameServerSpec.scala
@@ -6,6 +6,7 @@ import scala.concurrent.duration._
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 
+import io.circe.Json
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.Http
 import org.apache.pekko.http.scaladsl.model._
@@ -15,8 +16,8 @@ import org.apache.pekko.util.Timeout
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import com.andy327.model.core.{Game, GameId, GameType}
-import com.andy327.persistence.db.GameRepository
+import com.andy327.model.core.{Game, GameId, GameType, PlayerId}
+import com.andy327.persistence.db.{GameRepository, MoveHistoryRepository, MoveRecord}
 import com.andy327.server.actors.core.GameManager
 import com.andy327.server.http.json.JsonProtocol._
 import com.andy327.server.lobby.{LobbyMetadata, LobbyRepository, Player}
@@ -32,6 +33,12 @@ class GameServerSpec extends AnyWordSpec with Matchers {
     override def loadAllLobbies(): IO[List[LobbyMetadata]] = IO.pure(Nil)
   }
 
+  private val noOpMoveRepo: MoveHistoryRepository = new MoveHistoryRepository {
+    override def initialize(): IO[Unit] = IO.unit
+    override def appendMove(gameId: GameId, seq: Int, playerId: PlayerId, move: Json): IO[Unit] = IO.unit
+    override def loadMoves(gameId: GameId): IO[List[MoveRecord]] = IO.pure(Nil)
+  }
+
   "GameServer" should {
     "start and respond to /tictactoe" in {
       val dummyRepo = new GameRepository {
@@ -41,7 +48,8 @@ class GameServerSpec extends AnyWordSpec with Matchers {
         def loadAllGames(): IO[Map[GameId, (GameType, Game[_, _, _, _, _])]] = IO.pure(Map.empty)
       }
 
-      val (system, binding) = GameServer.startServer("localhost", port = 0, dummyRepo, noOpLobbyRepo).unsafeRunSync()
+      val (system, binding) =
+        GameServer.startServer("localhost", port = 0, dummyRepo, noOpLobbyRepo, noOpMoveRepo).unsafeRunSync()
       val actualPort = binding.localAddress.getPort
       implicit val classicSystem: ActorSystem = system.classicSystem
 

--- a/game-service-server/src/test/scala/com/andy327/server/actors/connectfour/ConnectFourActorSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/connectfour/ConnectFourActorSpec.scala
@@ -4,6 +4,8 @@ import java.util.UUID
 
 import scala.util.control.NoStackTrace
 
+import io.circe.Json
+import io.circe.syntax._
 import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
 import org.apache.pekko.actor.typed.ActorRef
 import org.scalatest.matchers.should.Matchers
@@ -57,6 +59,13 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
     (bob, 1), // Yellow row 3 col 1
     (alice, 0) // Red   row 2 col 0 — four in a row, Red wins
   )
+
+  /** Drains the two persistence messages emitted by one applied move: the snapshot save and the history append. */
+  private def expectMovePersisted(probe: TestProbe[PersistenceProtocol.Command]): Unit = {
+    probe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+    probe.expectMessageType[PersistenceProtocol.AppendMove]
+    ()
+  }
 
   "ConnectFourActor" should {
     "return an empty 6×7 board on GetState" in {
@@ -124,6 +133,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
         override def currentPlayer: Any = "dummy"
         override def gameStatus: Any = "dummy"
         override def playerFor(playerId: PlayerId): Option[Any] = None
+        override def moveCount: Int = 0
       }
 
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
@@ -153,6 +163,27 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
       board2(5)(0) shouldBe "R"
       board2(5)(1) shouldBe "Y"
       current2 shouldBe "R"
+    }
+
+    "append each applied move to history with an incrementing seq and the move payload" in {
+      val (actor, persistProbe) = newActor()
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+
+      actor ! TurnBasedGameActor.MakeMove(alice, Drop(0), replyProbe.ref)
+      replyProbe.receiveMessage()
+      persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+      val first = persistProbe.expectMessageType[PersistenceProtocol.AppendMove]
+      first.seq shouldBe 0
+      first.playerId shouldBe alice
+      first.move shouldBe Json.obj("col" -> 0.asJson)
+
+      actor ! TurnBasedGameActor.MakeMove(bob, Drop(1), replyProbe.ref)
+      replyProbe.receiveMessage()
+      persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+      val second = persistProbe.expectMessageType[PersistenceProtocol.AppendMove]
+      second.seq shouldBe 1
+      second.playerId shouldBe bob
+      second.move shouldBe Json.obj("col" -> 1.asJson)
     }
 
     "reject a move when it is not the player's turn" in {
@@ -230,7 +261,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
         actor ! TurnBasedGameActor.MakeMove(playerId, Drop(col), replyProbe.ref)
         replyProbe.receiveMessage()
         subscriberProbe.expectMessageType[PlayerActor.SendEvent] // GameStateUpdated per move
-        val _ = persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+        expectMovePersisted(persistProbe)
       }
 
       subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe
@@ -256,7 +287,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
       redWinsMoves.foreach { case (playerId, col) =>
         actor ! TurnBasedGameActor.MakeMove(playerId, Drop(col), replyProbe.ref)
         replyProbe.receiveMessage()
-        persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+        expectMovePersisted(persistProbe)
       }
 
       actor ! TurnBasedGameActor.SnapshotSaved(Right(()))
@@ -271,7 +302,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
       redWinsMoves.foreach { case (playerId, col) =>
         actor ! TurnBasedGameActor.MakeMove(playerId, Drop(col), replyProbe.ref)
         replyProbe.receiveMessage()
-        persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+        expectMovePersisted(persistProbe)
       }
 
       actor ! TurnBasedGameActor.SnapshotSaved(Left(ex))
@@ -285,7 +316,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
       redWinsMoves.foreach { case (playerId, col) =>
         actor ! TurnBasedGameActor.MakeMove(playerId, Drop(col), replyProbe.ref)
         replyProbe.receiveMessage()
-        persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+        expectMovePersisted(persistProbe)
       }
 
       // GetState is ignored in terminating — no reply, actor stays alive
@@ -306,7 +337,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
       redWinsMoves.foreach { case (playerId, col) =>
         actor ! TurnBasedGameActor.MakeMove(playerId, Drop(col), replyProbe.ref)
         replyProbe.receiveMessage() shouldBe a[Right[_, _]]
-        val _ = persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+        expectMovePersisted(persistProbe)
       }
 
       gameManagerProbe.receiveMessage() shouldBe GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed)

--- a/game-service-server/src/test/scala/com/andy327/server/actors/core/GameManagerSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/core/GameManagerSpec.scala
@@ -1,5 +1,6 @@
 package com.andy327.server.actors.core
 
+import java.time.Instant
 import java.util.UUID
 
 import scala.concurrent.duration._
@@ -10,6 +11,8 @@ import cats.effect.std.Queue
 import cats.effect.unsafe.IORuntime
 
 import fs2.Stream
+import io.circe.Json
+import io.circe.syntax._
 import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
 import org.apache.pekko.actor.typed.ActorRef
 import org.apache.pekko.http.scaladsl.model.ws.TextMessage
@@ -18,7 +21,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.model.core.{Game, GameId, GameType, PlayerId}
 import com.andy327.model.tictactoe.TicTacToe
-import com.andy327.persistence.db.GameRepository
+import com.andy327.persistence.db.{GameRepository, MoveHistoryRepository, MoveRecord}
 import com.andy327.server.actors.core.{PlayerActor, PlayerEvent}
 import com.andy327.server.actors.persistence.PersistenceProtocol
 import com.andy327.server.game.{GameOperation, MovePayload}
@@ -40,6 +43,21 @@ class InMemRepo(initialGames: Map[GameId, (GameType, Game[_, _, _, _, _])] = Map
 
   def loadAllGames(): IO[Map[GameId, (GameType, Game[_, _, _, _, _])]] =
     IO(db.toMap)
+}
+
+/** In-memory MoveHistoryRepository for unit tests; `loadFails` forces loadMoves to raise. */
+class InMemMoveRepo(initial: Map[GameId, List[MoveRecord]] = Map.empty, loadFails: Boolean = false)
+    extends MoveHistoryRepository {
+  private val db = scala.collection.concurrent.TrieMap(initial.toSeq: _*)
+
+  def initialize(): IO[Unit] = IO.unit
+
+  def appendMove(gameId: GameId, seq: Int, playerId: PlayerId, move: Json): IO[Unit] =
+    IO(db.update(gameId, db.getOrElse(gameId, Nil) :+ MoveRecord(seq, playerId, move, Instant.EPOCH)))
+
+  def loadMoves(gameId: GameId): IO[List[MoveRecord]] =
+    if (loadFails) IO.raiseError(new RuntimeException("move load failure") with NoStackTrace)
+    else IO.pure(db.getOrElse(gameId, Nil))
 }
 
 class GameManagerSpec extends AnyWordSpecLike with Matchers {
@@ -360,6 +378,45 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
       gm ! GameManager.ListLobbies(None, 1, 20, responseProbe.ref)
       val response = responseProbe.expectMessageType[GameManager.LobbiesListed]
       response.lobbies.map(_.gameId) should contain only (gameId2, gameId3)
+    }
+
+    "return the recorded move history for a game" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameId: GameId = UUID.randomUUID()
+      val moves = List(
+        MoveRecord(0, alice, Json.obj("col" -> 3.asJson), Instant.EPOCH),
+        MoveRecord(1, bob, Json.obj("col" -> 4.asJson), Instant.EPOCH)
+      )
+      val moveRepo = new InMemMoveRepo(Map(gameId -> moves))
+      val gm = spawn(GameManager(persistProbe.ref, new InMemRepo, noOpLobbyRepo, moveRepo = moveRepo))
+
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+      gm ! GameManager.GetMoveHistory(gameId, responseProbe.ref)
+
+      responseProbe.expectMessage(GameManager.MoveHistory(gameId, moves))
+    }
+
+    "return an empty move history for a game with no recorded moves" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameId: GameId = UUID.randomUUID()
+      val gm = spawn(GameManager(persistProbe.ref, new InMemRepo, noOpLobbyRepo, moveRepo = new InMemMoveRepo))
+
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+      gm ! GameManager.GetMoveHistory(gameId, responseProbe.ref)
+
+      responseProbe.expectMessage(GameManager.MoveHistory(gameId, Nil))
+    }
+
+    "return an error when the move history load fails" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val moveRepo = new InMemMoveRepo(loadFails = true)
+      val gm = spawn(GameManager(persistProbe.ref, new InMemRepo, noOpLobbyRepo, moveRepo = moveRepo))
+
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+      gm ! GameManager.GetMoveHistory(UUID.randomUUID(), responseProbe.ref)
+
+      val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
+      error.message should include("Failed to retrieve move history")
     }
 
     "mark game as completed when receiving GameCompleted message" in {

--- a/game-service-server/src/test/scala/com/andy327/server/actors/persistence/PostgresActorSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/persistence/PostgresActorSpec.scala
@@ -1,19 +1,22 @@
 package com.andy327.server.actors.persistence
 
 import java.util.UUID
+import java.util.concurrent.ConcurrentLinkedQueue
 
 import scala.util.control.NoStackTrace
 
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 
+import io.circe.Json
+import io.circe.syntax._
 import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.model.core.{Game, GameId, GameType, PlayerId}
 import com.andy327.model.tictactoe.TicTacToe
-import com.andy327.persistence.db.GameRepository
+import com.andy327.persistence.db.{GameRepository, MoveHistoryRepository, MoveRecord}
 
 class PostgresActorSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with Matchers {
   implicit val runtime: IORuntime = IORuntime.global
@@ -25,7 +28,17 @@ class PostgresActorSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike w
     def loadAllGames(): IO[Map[GameId, (GameType, Game[_, _, _, _, _])]] = IO.pure(Map.empty)
   }
 
+  /** Records each appended move; `appendResult` lets a test force the append IO to fail. */
+  class RecordingMoveRepo(appendResult: Either[Throwable, Unit] = Right(())) extends MoveHistoryRepository {
+    val appended = new ConcurrentLinkedQueue[(GameId, Int, PlayerId, Json)]()
+    def initialize(): IO[Unit] = IO.unit
+    def appendMove(gameId: GameId, seq: Int, playerId: PlayerId, move: Json): IO[Unit] =
+      IO(appended.add((gameId, seq, playerId, move))) *> IO.fromEither(appendResult)
+    def loadMoves(gameId: GameId): IO[List[MoveRecord]] = IO.pure(Nil)
+  }
+
   val saveError: RuntimeException with NoStackTrace = new RuntimeException("saving failure") with NoStackTrace
+  val appendError: RuntimeException with NoStackTrace = new RuntimeException("append failure") with NoStackTrace
 
   val alice: PlayerId = UUID.randomUUID()
   val bob: PlayerId = UUID.randomUUID()
@@ -33,8 +46,7 @@ class PostgresActorSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike w
 
   "PostgresActor" should {
     "reply with SnapshotSaved on successful SaveSnapshot" in {
-      val gameRepo = new DummyRepo(saveResult = Right(()))
-      val persistActor = spawn(PostgresActor(gameRepo))
+      val persistActor = spawn(PostgresActor(new DummyRepo(saveResult = Right(())), new RecordingMoveRepo))
 
       val replyProbe = createTestProbe[PersistenceProtocol.SnapshotSaved]()
       persistActor ! PersistenceProtocol.SaveSnapshot(UUID.randomUUID(), GameType.TicTacToe, freshGame, replyProbe.ref)
@@ -43,8 +55,7 @@ class PostgresActorSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike w
     }
 
     "reply with SnapshotSaved on failed SaveSnapshot when GameRepository raises an error" in {
-      val gameRepo = new DummyRepo(saveResult = Left(saveError))
-      val persistActor = spawn(PostgresActor(gameRepo))
+      val persistActor = spawn(PostgresActor(new DummyRepo(saveResult = Left(saveError)), new RecordingMoveRepo))
 
       val replyProbe = createTestProbe[PersistenceProtocol.SnapshotSaved]()
       persistActor ! PersistenceProtocol.SaveSnapshot(UUID.randomUUID(), GameType.TicTacToe, freshGame, replyProbe.ref)
@@ -53,5 +64,27 @@ class PostgresActorSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike w
       err shouldBe saveError
     }
 
+    "append a move to the move repository on AppendMove" in {
+      val moveRepo = new RecordingMoveRepo
+      val persistActor = spawn(PostgresActor(new DummyRepo(), moveRepo))
+      val gameId = UUID.randomUUID()
+      val move = Json.obj("col" -> 3.asJson)
+
+      persistActor ! PersistenceProtocol.AppendMove(gameId, 0, alice, move)
+
+      createTestProbe().awaitAssert(moveRepo.appended should have size 1)
+      moveRepo.appended.peek() shouldBe ((gameId, 0, alice, move))
+    }
+
+    "stay alive when a move append fails" in {
+      val persistActor = spawn(PostgresActor(new DummyRepo(), new RecordingMoveRepo(appendResult = Left(appendError))))
+
+      persistActor ! PersistenceProtocol.AppendMove(UUID.randomUUID(), 0, alice, Json.obj())
+
+      // a failed append must not crash the actor — a subsequent snapshot still gets a reply
+      val replyProbe = createTestProbe[PersistenceProtocol.SnapshotSaved]()
+      persistActor ! PersistenceProtocol.SaveSnapshot(UUID.randomUUID(), GameType.TicTacToe, freshGame, replyProbe.ref)
+      replyProbe.expectMessage(PersistenceProtocol.SnapshotSaved(Right(())))
+    }
   }
 }

--- a/game-service-server/src/test/scala/com/andy327/server/actors/tictactoe/TicTacToeActorSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/tictactoe/TicTacToeActorSpec.scala
@@ -5,6 +5,8 @@ import java.util.UUID
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
+import io.circe.Json
+import io.circe.syntax._
 import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
 import org.apache.pekko.actor.typed.ActorRef
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
@@ -48,6 +50,13 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
     (bob, Location(1, 1)),
     (alice, Location(0, 2))
   )
+
+  /** Drains the two persistence messages emitted by one applied move: the snapshot save and the history append. */
+  private def expectMovePersisted(probe: TestProbe[PersistenceProtocol.Command]): Unit = {
+    probe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+    probe.expectMessageType[PersistenceProtocol.AppendMove]
+    ()
+  }
 
   "TicTacToeActor" should {
     "return an empty 3×3 board on GetState" in {
@@ -136,6 +145,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
         override def currentPlayer: Any = "dummy"
         override def gameStatus: Any = "dummy"
         override def playerFor(playerId: PlayerId): Option[Any] = None
+        override def moveCount: Int = 0
       }
 
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
@@ -165,6 +175,27 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       board2(0)(0) shouldBe "X"
       board2(1)(1) shouldBe "O"
       current2 shouldBe "X"
+    }
+
+    "append each applied move to history with an incrementing seq and the move payload" in {
+      val (actor, persistProbe) = newActor()
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+
+      actor ! TurnBasedGameActor.MakeMove(alice, Location(0, 0), replyProbe.ref)
+      replyProbe.receiveMessage()
+      persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+      val first = persistProbe.expectMessageType[PersistenceProtocol.AppendMove]
+      first.seq shouldBe 0
+      first.playerId shouldBe alice
+      first.move shouldBe Json.obj("row" -> 0.asJson, "col" -> 0.asJson)
+
+      actor ! TurnBasedGameActor.MakeMove(bob, Location(1, 1), replyProbe.ref)
+      replyProbe.receiveMessage()
+      persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+      val second = persistProbe.expectMessageType[PersistenceProtocol.AppendMove]
+      second.seq shouldBe 1
+      second.playerId shouldBe bob
+      second.move shouldBe Json.obj("row" -> 1.asJson, "col" -> 1.asJson)
     }
 
     "reject a move when it is not the player's turn" in {
@@ -243,7 +274,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
         actor ! TurnBasedGameActor.MakeMove(player, loc, replyProbe.ref)
         replyProbe.receiveMessage()
         subscriberProbe.expectMessageType[PlayerActor.SendEvent] // GameStateUpdated per move
-        val _ = persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+        expectMovePersisted(persistProbe)
       }
 
       subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe
@@ -283,7 +314,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       xWinsMoves.foreach { case (player, loc) =>
         actor ! TurnBasedGameActor.MakeMove(player, loc, replyProbe.ref)
         replyProbe.receiveMessage()
-        persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+        expectMovePersisted(persistProbe)
       }
 
       actor ! TurnBasedGameActor.SnapshotSaved(Right(()))
@@ -298,7 +329,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       xWinsMoves.foreach { case (player, loc) =>
         actor ! TurnBasedGameActor.MakeMove(player, loc, replyProbe.ref)
         replyProbe.receiveMessage()
-        persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+        expectMovePersisted(persistProbe)
       }
 
       actor ! TurnBasedGameActor.SnapshotSaved(Left(ex))
@@ -312,7 +343,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       xWinsMoves.foreach { case (player, loc) =>
         actor ! TurnBasedGameActor.MakeMove(player, loc, replyProbe.ref)
         replyProbe.receiveMessage()
-        persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+        expectMovePersisted(persistProbe)
       }
 
       // GetState is ignored in terminating — no reply, actor stays alive
@@ -336,7 +367,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       xWinsMoves.foreach { case (player, loc) =>
         actor ! TurnBasedGameActor.MakeMove(player, loc, replyProbe.ref)
         replyProbe.receiveMessage()
-        persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+        expectMovePersisted(persistProbe)
       }
 
       // the watched subscriber dies mid-shutdown; without the Terminated handler this is a DeathPactException
@@ -358,7 +389,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       xWinsMoves.foreach { case (player, loc) =>
         actor ! TurnBasedGameActor.MakeMove(player, loc, replyProbe.ref)
         replyProbe.receiveMessage() shouldBe a[Right[_, _]]
-        val _ = persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+        expectMovePersisted(persistProbe)
       }
 
       gameManagerProbe.receiveMessage() shouldBe GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed)

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -1,7 +1,9 @@
 package com.andy327.server.http.json
 
+import java.time.Instant
 import java.util.UUID
 
+import io.circe.Json
 import io.circe.syntax._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -9,11 +11,13 @@ import org.scalatest.wordspec.AnyWordSpec
 import com.andy327.model.connectfour.ConnectFour
 import com.andy327.model.core.GameType
 import com.andy327.model.tictactoe.TicTacToe
+import com.andy327.persistence.db.MoveRecord
 import com.andy327.server.actors.core.GameManager.{
   ErrorResponse,
   LobbyCreated,
   LobbyJoined,
   LobbyLeft,
+  MoveHistory,
   SubscribeAcknowledged
 }
 import com.andy327.server.actors.core.PlayerEvent
@@ -71,6 +75,24 @@ class SerializationSpec extends AnyWordSpec with Matchers {
     "round-trip serialize and deserialize" in {
       val ack = SubscribeAcknowledged(UUID.randomUUID())
       ack.asJson.as[SubscribeAcknowledged] shouldBe Right(ack)
+    }
+  }
+
+  "MoveHistory codec" should {
+    "round-trip serialize and deserialize, preserving move payload and timestamp" in {
+      val history = MoveHistory(
+        UUID.randomUUID(),
+        List(
+          MoveRecord(0, UUID.randomUUID(), Json.obj("col" -> 3.asJson), Instant.parse("2026-06-14T12:00:00Z")),
+          MoveRecord(1, UUID.randomUUID(), Json.obj("row" -> 1.asJson, "col" -> 2.asJson), Instant.EPOCH)
+        )
+      )
+      history.asJson.as[MoveHistory] shouldBe Right(history)
+    }
+
+    "round-trip an empty history" in {
+      val history = MoveHistory(UUID.randomUUID(), Nil)
+      history.asJson.as[MoveHistory] shouldBe Right(history)
     }
   }
 

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/GameRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/GameRoutesSpec.scala
@@ -1,5 +1,6 @@
 package com.andy327.server.http.routes
 
+import java.time.Instant
 import java.util.UUID
 
 import scala.concurrent.Await
@@ -8,6 +9,8 @@ import scala.concurrent.duration._
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 
+import io.circe.Json
+import io.circe.syntax._
 import org.apache.pekko.actor.testkit.typed.scaladsl.ActorTestKit
 import org.apache.pekko.actor.typed.scaladsl.AskPattern._
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
@@ -22,7 +25,8 @@ import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.wordspec.AnyWordSpec
 
 import com.andy327.model.core.{GameId, GameType}
-import com.andy327.server.actors.core.{GameManager, InMemRepo, PlayerActor}
+import com.andy327.persistence.db.MoveRecord
+import com.andy327.server.actors.core.{GameManager, InMemMoveRepo, InMemRepo, PlayerActor}
 import com.andy327.server.actors.persistence.PersistenceProtocol
 import com.andy327.server.http.json.GridGameState
 import com.andy327.server.http.json.JsonProtocol._
@@ -145,6 +149,40 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
         }
       }
 
+      "return the recorded move history" in {
+        val gameId = UUID.randomUUID()
+        val moves = List(
+          MoveRecord(0, aliceId, Json.obj("row" -> 0.asJson, "col" -> 0.asJson), Instant.EPOCH),
+          MoveRecord(1, bobId, Json.obj("row" -> 1.asJson, "col" -> 1.asJson), Instant.EPOCH)
+        )
+        val histSystem = ActorSystem(
+          GameManager(
+            persistProbe.ref,
+            new InMemRepo,
+            noOpLobbyRepo,
+            moveRepo = new InMemMoveRepo(Map(gameId -> moves))
+          ),
+          "GameRoutesHistorySystem"
+        )
+        val histRoutes = new GameRoutes(GameType.TicTacToe, histSystem).routes
+
+        Get(s"/tictactoe/$gameId/history") ~> histRoutes ~> check {
+          status shouldBe StatusCodes.OK
+          val history = responseAs[GameManager.MoveHistory]
+          history.gameId shouldBe gameId
+          history.moves.map(_.seq) shouldBe List(0, 1)
+          history.moves.map(_.move) shouldBe moves.map(_.move)
+        }
+      }
+
+      "return an empty move history for a game with no moves" in {
+        val gameId = UUID.randomUUID()
+        Get(s"/tictactoe/$gameId/history") ~> routes ~> check {
+          status shouldBe StatusCodes.OK
+          responseAs[GameManager.MoveHistory].moves shouldBe empty
+        }
+      }
+
       "return 400 for invalid game ID on move" in {
         val moveEntity = HttpEntity(ContentTypes.`application/json`, """{"row":0,"col":0}""")
 
@@ -198,6 +236,10 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
             replyTo ! GameManager.Ready // triggers /subscribe fallback
             Behaviors.same
 
+          case GameManager.GetMoveHistory(_, replyTo) =>
+            replyTo ! GameManager.Ready // triggers /history fallback
+            Behaviors.same
+
           case _ => Behaviors.same
         }
 
@@ -210,7 +252,8 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
           ("description", "request"),
           ("POST /move", Post(s"/tictactoe/$fakeId/move", moveEntity).withHeaders(aliceHeader)),
           ("GET /status", Get(s"/tictactoe/$fakeId/status")),
-          ("POST /subscribe", Post(s"/tictactoe/$fakeId/subscribe").withHeaders(aliceHeader))
+          ("POST /subscribe", Post(s"/tictactoe/$fakeId/subscribe").withHeaders(aliceHeader)),
+          ("GET /history", Get(s"/tictactoe/$fakeId/history"))
         )
 
         forAll(requests) { (description, req) =>
@@ -231,6 +274,9 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
           ActorSystem(
             Behaviors.receiveMessage[GameManager.Command] {
               case GameManager.RunGameOperation(_, _, replyTo) =>
+                replyTo ! response
+                Behaviors.same
+              case GameManager.GetMoveHistory(_, replyTo) =>
                 replyTo ! response
                 Behaviors.same
               case _ => Behaviors.same
@@ -256,6 +302,11 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
         }
         Get(s"/tictactoe/$fakeId/status") ~> errorRoutes ~> check {
           status shouldBe StatusCodes.InternalServerError
+        }
+        // /history maps a storage ErrorResponse to 500 as well
+        Get(s"/tictactoe/$fakeId/history") ~> errorRoutes ~> check {
+          status shouldBe StatusCodes.InternalServerError
+          responseAs[String] should include("boom")
         }
       }
 


### PR DESCRIPTION
Adds an append-only log of every move played in a game, persisted to Postgres and exposed over HTTP for history and replay. Distinct from the existing game-state snapshot (a single overwritten row): this records the full ordered move sequence and is game-agnostic, storing each move as opaque JSON.

Model (game-service-model):
- Game.moveCount added — the number of moves applied so far, serving as the 0-based ordinal of the next move; implemented by TicTacToe and ConnectFour as the count of placed pieces, so the ordinal is derived from game state and survives a restart

Persistence (game-service-persistence):
- MoveHistoryRepository trait and MoveRecord; PostgresMoveHistoryRepository backed by a new game_moves table keyed (game_id, seq), storing each move as opaque JSON with a DB-stamped timestamp
- appendMove uses ON CONFLICT (game_id, seq) DO NOTHING so a duplicate ordinal is a safe no-op; loadMoves returns moves ordered by seq and skips unparseable rows
- NoOpMoveHistoryRepository for contexts where history persistence is not wired

Server (game-service-server):
- PersistenceProtocol.AppendMove added (fire-and-forget: no reply, failures logged, not retried); PostgresActor now handles both snapshot saves and move appends
- TurnBasedGameActor emits AppendMove on each applied move with seq taken from Game.moveCount; per-game bindings supply a Circe encoder for their move type
- GameManager.GetMoveHistory serves the move log via a direct DB read, so it works for active, finished, and unknown games (the last returns an empty list); moveRepo threaded through and defaulting to no-op
- GET /{gameType}/{gameId}/history route added; MoveHistory and MoveRecord Circe codecs

Tests:
- Testcontainers repository spec (ordering, per-game isolation, duplicate-seq no-op, corrupt-row skip)
- Actor specs assert AppendMove emission with incrementing seq and the move payload
- GameManager and route specs for the history endpoint (recorded, empty, and error paths); MoveHistory JSON round-trip; NoOpMoveHistoryRepository spec

Closes #21