### PR TITLE
Add match chat over WebSockets

### DIFF
--- a/game-service-server/src/main/resources/application.conf
+++ b/game-service-server/src/main/resources/application.conf
@@ -19,6 +19,12 @@ pekko-game-service {
     uri = "redis://localhost:6379"
     uri = ${?REDIS_URI}
   }
+
+  chat {
+    # Most recent messages retained per match for backscroll (GET /chat); older messages are evicted.
+    max-messages = 100
+    max-messages = ${?CHAT_MAX_MESSAGES}
+  }
 }
 
 jwt {

--- a/game-service-server/src/main/resources/reference.conf
+++ b/game-service-server/src/main/resources/reference.conf
@@ -3,4 +3,8 @@ pekko-game-service {
     host = "0.0.0.0"
     port = 8080
   }
+
+  chat {
+    max-messages = 100
+  }
 }

--- a/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
@@ -21,6 +21,7 @@ import com.andy327.persistence.db.redis.{RedisClientResource, RedisGameRepositor
 import com.andy327.persistence.db.{GameRepository, MoveHistoryRepository}
 import com.andy327.server.actors.core.GameManager
 import com.andy327.server.actors.persistence.PostgresActor
+import com.andy327.server.chat.{ChatRepository, NoOpChatRepository, RedisChatRepository}
 import com.andy327.server.http.routes.{AuthRoutes, GameRoutes, LobbyRoutes, WebSocketRoutes}
 import com.andy327.server.lobby.{LobbyRepository, RedisLobbyRepository}
 import com.andy327.server.pubsub.{
@@ -57,6 +58,7 @@ object GameServer {
       val gameRepo = new RedisGameRepository(postgresRepo, redis)
       val lobbyRepo = new RedisLobbyRepository(redis)
       val moveRepo = new PostgresMoveHistoryRepository(xa)
+      val chatRepo = new RedisChatRepository(redis)
 
       // Ensure the schema exists before starting the server
       for {
@@ -66,9 +68,17 @@ object GameServer {
         publisher = new RedisGameEventPublisher(publishFn)
         // Run the subscriber as a background fiber; it stays alive for the lifetime of the server
         _ <- subscriber.run.start
-        result <- startServer(host, port, gameRepo, lobbyRepo, moveRepo, publisher, Some(subscriber)).flatMap {
-          case (system, _) =>
-            IO.blocking(Await.result(system.whenTerminated, Duration.Inf))
+        result <- startServer(
+          host,
+          port,
+          gameRepo,
+          lobbyRepo,
+          moveRepo,
+          chatRepo,
+          publisher,
+          Some(subscriber)
+        ).flatMap { case (system, _) =>
+          IO.blocking(Await.result(system.whenTerminated, Duration.Inf))
         }
       } yield result
     }.unsafeRunSync()
@@ -81,12 +91,13 @@ object GameServer {
       gameRepo: GameRepository,
       lobbyRepo: LobbyRepository,
       moveRepo: MoveHistoryRepository,
+      chatRepo: ChatRepository = NoOpChatRepository,
       publisher: GameEventPublisher = NoOpGameEventPublisher,
       subscriber: Option[GameEventSubscriber] = None
   )(implicit runtime: IORuntime): IO[(ActorSystem[GameManager.Command], Http.ServerBinding)] = IO.defer {
     val rootBehavior = Behaviors.setup[GameManager.Command] { context =>
       val persistActor = context.spawn(PostgresActor(gameRepo, moveRepo), "postgres-persistence")
-      GameManager(persistActor, gameRepo, lobbyRepo, moveRepo, publisher, subscriber)
+      GameManager(persistActor, gameRepo, lobbyRepo, moveRepo, chatRepo, publisher, subscriber)
     }
 
     // Pekko actor system

--- a/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
@@ -58,7 +58,7 @@ object GameServer {
       val gameRepo = new RedisGameRepository(postgresRepo, redis)
       val lobbyRepo = new RedisLobbyRepository(redis)
       val moveRepo = new PostgresMoveHistoryRepository(xa)
-      val chatRepo = new RedisChatRepository(redis)
+      val chatRepo = new RedisChatRepository(redis, config.getInt("pekko-game-service.chat.max-messages"))
 
       // Ensure the schema exists before starting the server
       for {

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/GameActor.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/GameActor.scala
@@ -81,6 +81,9 @@ trait GameActor[G <: Game[_, _, _, _, _]] {
   /** Produce the game-specific Subscribe command that registers `playerRef` for push events. */
   def subscribeCommand(playerRef: ActorRef[PlayerActor.Command]): GameActor.GameCommand
 
+  /** Produce the game-specific command that fans `event` out to all of the game's subscribers (e.g. a chat message). */
+  def broadcastCommand(event: PlayerEvent): GameActor.GameCommand
+
   /** Extract the snapshot-save result from `cmd` if it is a `SnapshotSaved` message, otherwise `None`.
     *
     * Used by [[terminating]] to detect when the final snapshot has been confirmed without needing to know the

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/GameManager.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/GameManager.scala
@@ -15,6 +15,7 @@ import org.apache.pekko.util.Timeout
 import com.andy327.model.core.{Game, GameError, GameId, GameType, PlayerId}
 import com.andy327.persistence.db.{GameRepository, MoveHistoryRepository, MoveRecord, NoOpMoveHistoryRepository}
 import com.andy327.server.actors.persistence.PersistenceProtocol
+import com.andy327.server.chat.{ChatRepository, NoOpChatRepository}
 import com.andy327.server.game.{GameOperation, GameRegistry}
 import com.andy327.server.http.json.GameState
 import com.andy327.server.lobby.{GameLifecycleStatus, LobbyError, LobbyMetadata, LobbyRepository, Player}
@@ -87,6 +88,12 @@ object GameManager {
     * [[ErrorResponse]] on a storage failure. Served by a direct DB read, so it works for active and finished games.
     */
   final case class GetMoveHistory(gameId: GameId, replyTo: ActorRef[GameResponse]) extends Command
+
+  /** Fetch the recent chat history for `gameId` (backscroll) from the chat store; replies with [[ChatHistory]] (empty
+    * if none) or [[ErrorResponse]] on a storage failure. Served by a direct read, so it works for active and finished
+    * games; live messages continue to arrive over the WebSocket.
+    */
+  final case class GetChatHistory(gameId: GameId, replyTo: ActorRef[GameResponse]) extends Command
 
   /** Subscribe `playerRef` to game-state push events from the game actor for `gameId`. */
   final case class SubscribeToGame(gameId: GameId, playerRef: ActorRef[PlayerActor.Command]) extends Command
@@ -197,6 +204,13 @@ object GameManager {
       replyTo: ActorRef[GameResponse]
   ) extends Command
 
+  /** Carries the result of an async chat-history load for a [[GetChatHistory]] request. */
+  final private case class ChatHistoryLoaded(
+      result: Either[Throwable, List[PlayerEvent.ChatMessage]],
+      gameId: GameId,
+      replyTo: ActorRef[GameResponse]
+  ) extends Command
+
   // --- Response types (sent back to HTTP route handlers) ---
 
   sealed trait GameResponse
@@ -216,6 +230,9 @@ object GameManager {
 
   /** The ordered move history for a game; `moves` is empty if the game has no recorded moves. */
   final case class MoveHistory(gameId: GameId, moves: List[MoveRecord]) extends GameResponse
+
+  /** The recent chat history for a game, oldest first; `messages` is empty if the game has no recorded messages. */
+  final case class ChatHistory(gameId: GameId, messages: List[PlayerEvent.ChatMessage]) extends GameResponse
 
   // Error responses
 
@@ -243,6 +260,7 @@ object GameManager {
     * @param gameRepo the repository used for the initial game restore and completed-game state lookups
     * @param lobbyRepo the repository used to restore lobbies at startup and persist lobby changes
     * @param moveRepo the repository read to serve move-history queries; defaults to no-op (empty history)
+    * @param chatRepo the repository written on each chat message and read to serve backscroll; defaults to no-op
     * @param publisher publishes game events to Redis so remote instances can relay them; defaults to no-op
     * @param subscriber routes incoming Redis events to locally connected players watching remote games; `None` disables
     * @param onReady optional ref that receives a [[Ready]] signal once the running state is entered (used in tests)
@@ -253,6 +271,7 @@ object GameManager {
       gameRepo: GameRepository,
       lobbyRepo: LobbyRepository,
       moveRepo: MoveHistoryRepository = NoOpMoveHistoryRepository,
+      chatRepo: ChatRepository = NoOpChatRepository,
       publisher: GameEventPublisher = NoOpGameEventPublisher,
       subscriber: Option[GameEventSubscriber] = None,
       onReady: Option[ActorRef[Ready.type]] = None
@@ -282,6 +301,7 @@ object GameManager {
           persistActor,
           gameRepo,
           moveRepo,
+          chatRepo,
           stash,
           publisher,
           subscriber,
@@ -301,6 +321,7 @@ object GameManager {
       persistActor: ActorRef[PersistenceProtocol.Command],
       gameRepo: GameRepository,
       moveRepo: MoveHistoryRepository,
+      chatRepo: ChatRepository,
       stash: StashBuffer[Command],
       publisher: GameEventPublisher,
       subscriber: Option[GameEventSubscriber],
@@ -327,6 +348,7 @@ object GameManager {
             persistActor,
             gameRepo,
             moveRepo,
+            chatRepo,
             publisher,
             subscriber
           )(runtime)
@@ -354,6 +376,7 @@ object GameManager {
       persistActor: ActorRef[PersistenceProtocol.Command],
       gameRepo: GameRepository,
       moveRepo: MoveHistoryRepository,
+      chatRepo: ChatRepository,
       publisher: GameEventPublisher,
       subscriber: Option[GameEventSubscriber]
   )(implicit runtime: IORuntime): Behavior[Command] =
@@ -455,6 +478,11 @@ object GameManager {
           }
           // relay to watchers on other instances; local watchers are reached by the fan-out above
           publisher.publish(gameId, event)
+          // record to the bounded chat history so late joiners can backscroll; best-effort, never blocks the send
+          chatRepo.append(event).unsafeRunAsync {
+            case Left(ex) => context.log.warn(s"Failed to persist chat message for $gameId", ex)
+            case Right(_) => ()
+          }
           Behaviors.same
 
         case SubscribePlayerToGame(gameId, playerId, replyTo) =>
@@ -524,6 +552,7 @@ object GameManager {
               persistActor,
               gameRepo,
               moveRepo,
+              chatRepo,
               publisher,
               subscriber
             )
@@ -543,6 +572,7 @@ object GameManager {
                 persistActor,
                 gameRepo,
                 moveRepo,
+                chatRepo,
                 publisher,
                 subscriber
               )
@@ -611,6 +641,24 @@ object GameManager {
             case Left(ex)     =>
               context.log.error(s"Failed to load move history for $gameId", ex)
               replyTo ! ErrorResponse("Failed to retrieve move history")
+          }
+          Behaviors.same
+
+        case GetChatHistory(gameId, replyTo) =>
+          context.pipeToSelf(chatRepo.recent(gameId).attempt.unsafeToFuture()) {
+            case Success(result) => ChatHistoryLoaded(result, gameId, replyTo)
+            // $COVERAGE-OFF$ .attempt converts IO failures to Success(Left(ex)); Failure is unreachable
+            case Failure(ex) => ChatHistoryLoaded(Left(ex), gameId, replyTo)
+            // $COVERAGE-ON$
+          }
+          Behaviors.same
+
+        case ChatHistoryLoaded(result, gameId, replyTo) =>
+          result match {
+            case Right(messages) => replyTo ! ChatHistory(gameId, messages)
+            case Left(ex)        =>
+              context.log.error(s"Failed to load chat history for $gameId", ex)
+              replyTo ! ErrorResponse("Failed to retrieve chat history")
           }
           Behaviors.same
 

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/GameManager.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/GameManager.scala
@@ -1,5 +1,7 @@
 package com.andy327.server.actors.core
 
+import java.time.Instant
+
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
@@ -88,6 +90,11 @@ object GameManager {
 
   /** Subscribe `playerRef` to game-state push events from the game actor for `gameId`. */
   final case class SubscribeToGame(gameId: GameId, playerRef: ActorRef[PlayerActor.Command]) extends Command
+
+  /** Post a chat message to a match: fans it out to the match's subscribers (the game actor's while in progress, the
+    * lobby's otherwise) and publishes it so other instances relay it to their watchers.
+    */
+  final case class SendChat(gameId: GameId, sender: Player, text: String) extends Command
 
   /** Subscribe the authenticated player to game push events as a spectator; replies with [[SubscribeAcknowledged]] or
     * [[ErrorResponse]].
@@ -435,6 +442,19 @@ object GameManager {
                   context.log.warn(s"SubscribeToGame: no active game found for $gameId")
               }
           }
+          Behaviors.same
+
+        case SendChat(gameId, sender, text) =>
+          val event = PlayerEvent.ChatMessage(gameId, sender.id, sender.name, text, Instant.now())
+          activeGames.get(gameId) match {
+            case Some((gameType, gameActor)) =>
+              gameActor ! GameRegistry.forType(gameType).actor.broadcastCommand(event)
+            case None =>
+              // not in progress (or unknown): fan out via the lobby; a bogus gameId is a harmless no-op there
+              lobbyManager ! LobbyManager.BroadcastChat(gameId, event)
+          }
+          // relay to watchers on other instances; local watchers are reached by the fan-out above
+          publisher.publish(gameId, event)
           Behaviors.same
 
         case SubscribePlayerToGame(gameId, playerId, replyTo) =>

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/LobbyManager.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/LobbyManager.scala
@@ -97,6 +97,9 @@ object LobbyManager {
   /** Replace the in-memory lobby map with lobbies restored from Redis at startup. */
   final private[core] case class RestoreLobbies(lobbies: List[LobbyMetadata]) extends Command
 
+  /** Fan `event` (a chat message) out to the lobby's subscribers, used while the match is still in its lobby phase. */
+  final private[core] case class BroadcastChat(gameId: GameId, event: PlayerEvent) extends Command
+
   // --- Response type owned by LobbyManager ---
 
   /** Paginated lobby-list result; adapted into [[GameManager.LobbiesListed]] by a GameManager message adapter. */
@@ -155,6 +158,10 @@ object LobbyManager {
         val restoredMap = restored.map(m => m.gameId -> m).toMap
         context.log.info(s"Restoring ${restoredMap.size} lobbies from Redis")
         running(restoredMap, recentlyEnded, subscribers, gameManager, lobbyRepo)
+
+      case BroadcastChat(gameId, event) =>
+        fanOut(subscribers, gameId, event)
+        Behaviors.same
 
       case CreateLobby(gameType, host, replyTo) =>
         context.log.info(s"Creating new lobby for game type $gameType with host ${host.name}")

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/PlayerEvent.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/PlayerEvent.scala
@@ -1,5 +1,8 @@
 package com.andy327.server.actors.core
 
+import java.time.Instant
+
+import com.andy327.model.core.{GameId, PlayerId}
 import com.andy327.server.http.json.GameState
 import com.andy327.server.lobby.{GameLifecycleStatus, LobbyMetadata}
 
@@ -17,6 +20,20 @@ object PlayerEvent {
   /** The game state changed after a move — carries the full updated board state. */
   final case class GameStateUpdated(state: GameState) extends PlayerEvent
 
-  /** The game has ended. @param result Completed (someone won) or Cancelled (host left before the game started). */
+  /** The game has ended.
+    *
+    * @param result Completed (someone won) or Cancelled (host left before the game started).
+    */
   final case class GameEnded(result: GameLifecycleStatus.GameEnded) extends PlayerEvent
+
+  /** A chat message in a match's thread, pushed to everyone watching that game (in lobby or in progress).
+    *
+    * @param gameId the match the message belongs to
+    * @param senderId the authenticated player who sent it
+    * @param senderName the sender's display name, denormalized so clients can render without a lookup
+    * @param text the message body
+    * @param sentAt server timestamp when the message was accepted
+    */
+  final case class ChatMessage(gameId: GameId, senderId: PlayerId, senderName: String, text: String, sentAt: Instant)
+      extends PlayerEvent
 }

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/TurnBasedGameActor.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/TurnBasedGameActor.scala
@@ -34,6 +34,9 @@ object TurnBasedGameActor {
   /** Deregister a previously subscribed PlayerActor. */
   final case class Unsubscribe(playerRef: ActorRef[PlayerActor.Command]) extends Command[Nothing]
 
+  /** Fan an already-built event (e.g. a chat message) out to the game's current subscribers. */
+  final case class Broadcast(event: PlayerEvent) extends Command[Nothing]
+
   /** Delivered by a `messageAdapter` after PersistenceProtocol.SaveSnapshot completes; logged but never causes a
     * state change while the game is active.
     */
@@ -76,6 +79,9 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
 
   override def subscribeCommand(playerRef: ActorRef[PlayerActor.Command]): GameActor.GameCommand =
     Subscribe(playerRef)
+
+  override def broadcastCommand(event: PlayerEvent): GameActor.GameCommand =
+    Broadcast(event)
 
   override protected def snapshotSavedResult(cmd: Command): Option[Either[Throwable, Unit]] = cmd match {
     case SnapshotSaved(result) => Some(result)
@@ -209,6 +215,10 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
       case Unsubscribe(playerRef) =>
         context.unwatch(playerRef)
         active(game, gameId, persist, gameManager, subscribers - playerRef, publisher)
+
+      case Broadcast(event) =>
+        subscribers.foreach(_ ! PlayerActor.SendEvent(event))
+        Behaviors.same
 
       case SnapshotSaved(result) =>
         result match {

--- a/game-service-server/src/main/scala/com/andy327/server/chat/ChatCodecs.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/chat/ChatCodecs.scala
@@ -1,0 +1,29 @@
+package com.andy327.server.chat
+
+import io.circe.Codec
+import io.circe.generic.semiauto.deriveCodec
+import io.circe.parser.decode
+import io.circe.syntax._
+
+import com.andy327.server.actors.core.PlayerEvent
+
+/** Circe codec for chat messages, used by [[RedisChatRepository]] to store and reload
+  * [[actors.core.PlayerEvent.ChatMessage]]s as JSON in Redis, and re-exported by the HTTP layer to encode the
+  * `GET /chat` history response.
+  *
+  * This is the plain record form — the chat fields with no envelope. It is intentionally distinct from the tagged
+  * `{"type":"ChatMessage", ...}` form that [[com.andy327.server.http.json.JsonProtocol.playerEventEncoder]] uses for
+  * live WebSocket push: the live event is one variant of a discriminated `PlayerEvent` stream, whereas a
+  * stored/returned history record is always a chat message and needs no discriminator. Both carry the same fields.
+  */
+object ChatCodecs {
+
+  implicit val chatMessageCodec: Codec[PlayerEvent.ChatMessage] = deriveCodec[PlayerEvent.ChatMessage]
+
+  /** Serializes a chat message to a compact JSON string for Redis storage. */
+  def serialize(message: PlayerEvent.ChatMessage): String = message.asJson.noSpaces
+
+  /** Deserializes a JSON string back into a chat message. */
+  def deserialize(json: String): Either[Throwable, PlayerEvent.ChatMessage] =
+    decode[PlayerEvent.ChatMessage](json).left.map(err => new Exception(err.getMessage))
+}

--- a/game-service-server/src/main/scala/com/andy327/server/chat/ChatRepository.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/chat/ChatRepository.scala
@@ -1,0 +1,22 @@
+package com.andy327.server.chat
+
+import cats.effect.IO
+
+import com.andy327.model.core.GameId
+import com.andy327.server.actors.core.PlayerEvent
+
+/** Repository for a bounded, recent-message history of each match's chat thread.
+  *
+  * Backed by a ring buffer (see [[RedisChatRepository]]): only the most recent N messages per game are retained, which
+  * is all "backscroll" needs — a client opening a chat fetches recent context, while live messages continue to arrive
+  * over the WebSocket. Writes are fire-and-forget from the caller's perspective; [[recent]] is served on demand by the
+  * `GET /chat` endpoint and works for active and finished games alike.
+  */
+trait ChatRepository {
+
+  /** Append a chat message to its game's history, evicting the oldest once the buffer is full. */
+  def append(message: PlayerEvent.ChatMessage): IO[Unit]
+
+  /** Load the recent chat history for `gameId`, oldest first. Empty if the game has no recorded messages. */
+  def recent(gameId: GameId): IO[List[PlayerEvent.ChatMessage]]
+}

--- a/game-service-server/src/main/scala/com/andy327/server/chat/NoOpChatRepository.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/chat/NoOpChatRepository.scala
@@ -1,0 +1,16 @@
+package com.andy327.server.chat
+
+import cats.effect.IO
+
+import com.andy327.model.core.GameId
+import com.andy327.server.actors.core.PlayerEvent
+
+/** A [[ChatRepository]] that records nothing and returns no history.
+  *
+  * Used as the default where chat persistence is not wired (e.g. tests that don't exercise backscroll); the real
+  * [[RedisChatRepository]] is supplied in production.
+  */
+object NoOpChatRepository extends ChatRepository {
+  override def append(message: PlayerEvent.ChatMessage): IO[Unit] = IO.unit
+  override def recent(gameId: GameId): IO[List[PlayerEvent.ChatMessage]] = IO.pure(Nil)
+}

--- a/game-service-server/src/main/scala/com/andy327/server/chat/RedisChatRepository.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/chat/RedisChatRepository.scala
@@ -1,0 +1,44 @@
+package com.andy327.server.chat
+
+import org.slf4j.LoggerFactory
+
+import cats.effect.IO
+
+import dev.profunktor.redis4cats.RedisCommands
+
+import com.andy327.model.core.GameId
+import com.andy327.server.actors.core.PlayerEvent
+
+/** A [[ChatRepository]] backed by a per-game Redis list used as a fixed-size ring buffer.
+  *
+  * Each message is `LPUSH`ed onto the head of `chat:{gameId}` and the list is immediately `LTRIM`med to the newest
+  * `maxMessages` entries, so storage per game is bounded regardless of how chatty a match gets. [[recent]] reads the
+  * buffer with `LRANGE` and reverses it to oldest-first display order. Corrupt entries are skipped with a warning
+  * rather than failing the whole read.
+  *
+  * @param redis Redis commands handle used for all reads and writes
+  * @param maxMessages the most recent messages retained per game
+  */
+class RedisChatRepository(redis: RedisCommands[IO, String, String], maxMessages: Int = 100) extends ChatRepository {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private def chatKey(gameId: GameId): String = s"chat:$gameId"
+
+  override def append(message: PlayerEvent.ChatMessage): IO[Unit] = {
+    val key = chatKey(message.gameId)
+    redis.lPush(key, ChatCodecs.serialize(message)) *> redis.lTrim(key, 0, maxMessages - 1L)
+  }
+
+  override def recent(gameId: GameId): IO[List[PlayerEvent.ChatMessage]] =
+    redis.lRange(chatKey(gameId), 0, maxMessages - 1L).map { raw =>
+      raw.reverse.flatMap { json =>
+        ChatCodecs.deserialize(json) match {
+          case Right(message) => Some(message)
+          case Left(err)      =>
+            logger.warn(s"Skipping corrupt chat message for $gameId: ${err.getMessage}")
+            None
+        }
+      }
+    }
+}

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/ClientMessage.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/ClientMessage.scala
@@ -1,0 +1,31 @@
+package com.andy327.server.http.json
+
+import io.circe.{Decoder, DecodingFailure}
+
+import com.andy327.model.core.GameId
+
+/** A message a connected client sends to the server over the WebSocket.
+  *
+  * Inbound counterpart to the server-push [[com.andy327.server.actors.core.PlayerEvent]]: decoded from JSON frames and
+  * dispatched on a `type` discriminator field, so new client-initiated actions slot in as additional variants.
+  */
+sealed trait ClientMessage
+
+object ClientMessage {
+
+  /** Post `text` to the chat thread of the match identified by `gameId`. */
+  final case class ChatSend(gameId: GameId, text: String) extends ClientMessage
+
+  /** Decodes a client frame by its `type` field; fails for unknown or malformed frames. */
+  implicit val decoder: Decoder[ClientMessage] = Decoder.instance { cursor =>
+    cursor.get[String]("type").flatMap {
+      case "ChatSend" =>
+        for {
+          gameId <- cursor.get[GameId]("gameId")
+          text <- cursor.get[String]("text")
+        } yield ChatSend(gameId, text)
+      case other =>
+        Left(DecodingFailure(s"Unknown client message type: $other", cursor.history))
+    }
+  }
+}

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -7,6 +7,7 @@ import org.apache.pekko.http.scaladsl.unmarshalling.FromEntityUnmarshaller
 
 import com.andy327.persistence.db.MoveRecord
 import com.andy327.server.actors.core.GameManager.{
+  ChatHistory,
   ErrorResponse,
   GameStarted,
   LobbiesListed,
@@ -17,6 +18,7 @@ import com.andy327.server.actors.core.GameManager.{
   SubscribeAcknowledged
 }
 import com.andy327.server.actors.core.PlayerEvent
+import com.andy327.server.chat.ChatCodecs
 import com.andy327.server.http.auth.PlayerRequest
 import com.andy327.server.lobby.{GameLifecycleStatus, LobbyCodecs, LobbyMetadata, Player}
 
@@ -56,6 +58,12 @@ object JsonProtocol extends CirceSupport {
 
   implicit val moveHistoryCodec: Codec[MoveHistory] = deriveCodec[MoveHistory]
 
+  // Chat history records use the plain (untagged) chat-message form from ChatCodecs — see its scaladoc for how this
+  // differs from the tagged ChatMessage envelope that playerEventEncoder emits for live WebSocket push.
+  implicit val chatMessageCodec: Codec[PlayerEvent.ChatMessage] = ChatCodecs.chatMessageCodec
+
+  implicit val chatHistoryCodec: Codec[ChatHistory] = deriveCodec[ChatHistory]
+
   // Game state views
 
   implicit val gridGameStateCodec: Codec[GridGameState] = deriveCodec[GridGameState]
@@ -77,6 +85,7 @@ object JsonProtocol extends CirceSupport {
   implicit val subscribeAcknowledgedUnmarshaller: FromEntityUnmarshaller[SubscribeAcknowledged] =
     circeUnmarshaller[SubscribeAcknowledged]
   implicit val moveHistoryUnmarshaller: FromEntityUnmarshaller[MoveHistory] = circeUnmarshaller[MoveHistory]
+  implicit val chatHistoryUnmarshaller: FromEntityUnmarshaller[ChatHistory] = circeUnmarshaller[ChatHistory]
 
   /** Write-only encoder for PlayerEvent — serialises server-push events to JSON for delivery over WebSocket.
     *

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -82,9 +82,10 @@ object JsonProtocol extends CirceSupport {
     *
     * Each variant is encoded as a JSON object with a `type` discriminator field so the client can dispatch on the event
     * kind without additional out-of-band information:
-    *   - `{"type":"LobbyUpdated",    "metadata":{...}}`
-    *   - `{"type":"GameStateUpdated","state":{...}}`
-    *   - `{"type":"GameEnded",       "result":"Completed"}`
+    *   - `{"type":"LobbyUpdated",     "metadata":{...}}`
+    *   - `{"type":"GameStateUpdated", "state":{...}}`
+    *   - `{"type":"GameEnded",        "result":"Completed"}`
+    *   - `{"type":"ChatMessage",      "gameId":..., "senderId":..., "senderName":..., "text":..., "sentAt":...}`
     */
   implicit val playerEventEncoder: Encoder[PlayerEvent] = Encoder.instance {
     case PlayerEvent.LobbyUpdated(metadata) =>
@@ -93,5 +94,14 @@ object JsonProtocol extends CirceSupport {
       Json.obj("type" -> "GameStateUpdated".asJson, "state" -> state.asJson)
     case PlayerEvent.GameEnded(result) =>
       Json.obj("type" -> "GameEnded".asJson, "result" -> (result: GameLifecycleStatus).asJson)
+    case PlayerEvent.ChatMessage(gameId, senderId, senderName, text, sentAt) =>
+      Json.obj(
+        "type" -> "ChatMessage".asJson,
+        "gameId" -> gameId.asJson,
+        "senderId" -> senderId.asJson,
+        "senderName" -> senderName.asJson,
+        "text" -> text.asJson,
+        "sentAt" -> sentAt.asJson
+      )
   }
 }

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/GameRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/GameRoutes.scala
@@ -16,6 +16,7 @@ import org.apache.pekko.util.Timeout
 import com.andy327.model.core.GameType
 import com.andy327.server.actors.core.GameManager
 import com.andy327.server.actors.core.GameManager.{
+  ChatHistory,
   Command,
   ErrorResponse,
   GameNotFound,
@@ -43,6 +44,7 @@ import com.andy327.server.http.routes.RouteDirectives._
   *   - POST /{gameType}/{gameId}/move - Submit a move to the specified game
   *   - GET /{gameType}/{gameId}/status - Fetch the current state of a game
   *   - GET /{gameType}/{gameId}/history - Fetch the ordered move history for a game
+  *   - GET /{gameType}/{gameId}/chat - Fetch the recent chat history (backscroll) for a game
   */
 class GameRoutes(gameType: GameType, system: ActorSystem[Command]) {
   implicit val scheduler: Scheduler = system.scheduler
@@ -148,6 +150,25 @@ class GameRoutes(gameType: GameType, system: ActorSystem[Command]) {
           get {
             onSuccess(system.ask[GameResponse](GameManager.GetMoveHistory(gameId, _))) {
               case history: MoveHistory => complete(history)
+              case ErrorResponse(msg)   => complete(StatusCodes.InternalServerError -> msg)
+              case unknown              => complete(StatusCodes.InternalServerError -> s"Unexpected response: $unknown")
+            }
+          }
+        } ~
+        /** Fetches the recent chat history (backscroll) for the specified game.
+          *
+          * Served from the chat store, so it works for both active and finished games (and returns an empty list for a
+          * game with no recorded messages). Live chat continues to arrive over the WebSocket.
+          *
+          * - Path: `gameId` — the UUID of the game
+          * - 200: `ChatHistory` — the recent messages, oldest first
+          * - 400: invalid UUID format
+          * - 500: unexpected error
+          */
+        path("chat") {
+          get {
+            onSuccess(system.ask[GameResponse](GameManager.GetChatHistory(gameId, _))) {
+              case history: ChatHistory => complete(history)
               case ErrorResponse(msg)   => complete(StatusCodes.InternalServerError -> msg)
               case unknown              => complete(StatusCodes.InternalServerError -> s"Unexpected response: $unknown")
             }

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/WebSocketRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/WebSocketRoutes.scala
@@ -2,38 +2,46 @@ package com.andy327.server.http.routes
 
 import scala.concurrent.duration._
 
+import org.slf4j.LoggerFactory
+
+import io.circe.parser.decode
 import org.apache.pekko.actor.typed.scaladsl.AskPattern._
 import org.apache.pekko.actor.typed.{ActorRef, ActorSystem}
-import org.apache.pekko.http.scaladsl.model.ws.Message
+import org.apache.pekko.http.scaladsl.model.ws.{Message, TextMessage}
 import org.apache.pekko.http.scaladsl.server.Directives._
 import org.apache.pekko.http.scaladsl.server.Route
-import org.apache.pekko.stream.OverflowStrategy
 import org.apache.pekko.stream.scaladsl.{Flow, Sink}
 import org.apache.pekko.stream.typed.scaladsl.ActorSource
+import org.apache.pekko.stream.{Materializer, OverflowStrategy}
 import org.apache.pekko.util.Timeout
 
 import com.andy327.server.actors.core.{GameManager, PlayerActor}
 import com.andy327.server.http.auth.JwtPlayerDirectives._
+import com.andy327.server.http.json.ClientMessage
 import com.andy327.server.lobby.Player
 
 /** HTTP route that upgrades connections to WebSocket sessions.
   *
   * On connect the client must supply a valid Bearer token (obtained via POST /auth/token). The server materializes an
   * ActorSource-backed stream, spawns a PlayerActor wired to it via GameManager.RegisterPlayer, and begins forwarding
-  * push events (lobby updates, game state, game-end notifications) as JSON TextMessages. Inbound client messages are
-  * currently discarded. When the WebSocket closes, PlayerDisconnected is sent to GameManager so that the associated
-  * PlayerActor is stopped; conversely, when the PlayerActor stops (explicit disconnect or replacement on reconnect),
-  * it completes the stream via `PlayerActor.WsComplete`, closing the WebSocket from the server side.
+  * push events (lobby updates, game state, game-end notifications, chat) as JSON TextMessages. Inbound client frames
+  * are decoded as [[json.ClientMessage]] and routed to GameManager (e.g. a `ChatSend` becomes `GameManager.SendChat`);
+  * unparseable frames are logged and dropped. When the WebSocket closes, PlayerDisconnected is sent to GameManager so
+  * the associated PlayerActor is stopped; conversely, when the PlayerActor stops (explicit disconnect or replacement on
+  * reconnect), it completes the stream via `PlayerActor.WsComplete`, closing the WebSocket from the server side.
   *
   * Route: GET /ws (Auth: Bearer token required)
   *
   * Actor relationships:
-  *   - Sends to: `GameManager` (`RegisterPlayer` on connect, `PlayerDisconnected` on close)
+  *   - Sends to: `GameManager` (`RegisterPlayer` on connect, `SendChat` on an inbound chat frame, `PlayerDisconnected`
+  *     on close)
   */
 class WebSocketRoutes(gameManager: ActorSystem[GameManager.Command]) {
   implicit private val system: ActorSystem[GameManager.Command] = gameManager
   implicit private val timeout: Timeout = Timeout(5.seconds)
+  implicit private val mat: Materializer = Materializer(system)
   private val ec = system.executionContext
+  private val logger = LoggerFactory.getLogger(getClass)
 
   val routes: Route = path("ws") {
     authenticatePlayer { player =>
@@ -41,14 +49,23 @@ class WebSocketRoutes(gameManager: ActorSystem[GameManager.Command]) {
     }
   }
 
+  /** Decode one inbound client frame and act on it; malformed frames are logged and ignored. */
+  private def handleInbound(player: Player)(text: String): Unit =
+    decode[ClientMessage](text) match {
+      case Right(ClientMessage.ChatSend(gameId, body)) =>
+        gameManager ! GameManager.SendChat(gameId, player, body)
+      case Left(err) =>
+        logger.warn(s"Ignoring unparseable client message from ${player.id}: ${err.getMessage}")
+    }
+
   /** Builds a WebSocket Flow for the given authenticated player.
     *
     * Pre-materializes an ActorSource over [[PlayerActor.WsOutput]] to obtain a `wsOut` ref before the stream starts,
-    * then asks GameManager to register the player (which spawns a PlayerActor bound to that ref). The outbound side of
-    * the flow carries server-push events; the inbound side is drained with Sink.ignore. The stream completes when the
-    * PlayerActor emits [[PlayerActor.WsComplete]]. When the stream terminates (WebSocket closed by either side),
-    * PlayerDisconnected — carrying this session's PlayerActor ref — is sent to GameManager so a stale close cannot
-    * tear down a newer session for the same player.
+    * then asks GameManager to register the player (which spawns a PlayerActor bound to that ref). The inbound side
+    * decodes each text frame into a [[ClientMessage]] and routes it; the outbound side carries server-push events. The
+    * stream completes when the PlayerActor emits [[PlayerActor.WsComplete]]. When the stream terminates (WebSocket
+    * closed by either side), PlayerDisconnected — carrying this session's PlayerActor ref — is sent to GameManager so a
+    * stale close cannot tear down a newer session for the same player.
     */
   private def buildFlow(player: Player): Flow[Message, Message, Any] = {
     // Materialize the ActorRef up front so we can pass it to RegisterPlayer before the stream runs
@@ -66,6 +83,13 @@ class WebSocketRoutes(gameManager: ActorSystem[GameManager.Command]) {
       GameManager.RegisterPlayer(player, wsOut, replyTo)
     )
 
+    // Inbound: decode each text frame and route it (binary frames are ignored)
+    val inbound: Sink[Message, Any] =
+      Flow[Message]
+        .collect { case tm: TextMessage => tm }
+        .mapAsync(1)(_.toStrict(timeout.duration).map(_.text)(ec))
+        .to(Sink.foreach(handleInbound(player)))
+
     // On WebSocket close (either side), stop this session's PlayerActor via GameManager
     val outbound = source
       .collect { case PlayerActor.WsMessage(message) => message }
@@ -75,6 +99,6 @@ class WebSocketRoutes(gameManager: ActorSystem[GameManager.Command]) {
         }(ec)
       }
 
-    Flow.fromSinkAndSource(Sink.ignore, outbound)
+    Flow.fromSinkAndSource(inbound, outbound)
   }
 }

--- a/game-service-server/src/test/scala/com/andy327/server/actors/core/GameManagerSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/core/GameManagerSpec.scala
@@ -24,6 +24,7 @@ import com.andy327.model.tictactoe.TicTacToe
 import com.andy327.persistence.db.{GameRepository, MoveHistoryRepository, MoveRecord}
 import com.andy327.server.actors.core.{PlayerActor, PlayerEvent}
 import com.andy327.server.actors.persistence.PersistenceProtocol
+import com.andy327.server.chat.ChatRepository
 import com.andy327.server.game.{GameOperation, MovePayload}
 import com.andy327.server.http.json.{GameStateConverters, GridGameState}
 import com.andy327.server.lobby.{GameLifecycleStatus, LobbyError, LobbyMetadata, LobbyRepository, Player}
@@ -57,6 +58,19 @@ class InMemMoveRepo(initial: Map[GameId, List[MoveRecord]] = Map.empty, loadFail
 
   def loadMoves(gameId: GameId): IO[List[MoveRecord]] =
     if (loadFails) IO.raiseError(new RuntimeException("move load failure") with NoStackTrace)
+    else IO.pure(db.getOrElse(gameId, Nil))
+}
+
+/** In-memory ChatRepository for unit tests; records appends and `loadFails` forces recent to raise. */
+class InMemChatRepo(initial: Map[GameId, List[PlayerEvent.ChatMessage]] = Map.empty, loadFails: Boolean = false)
+    extends ChatRepository {
+  private val db = scala.collection.concurrent.TrieMap(initial.toSeq: _*)
+
+  def append(message: PlayerEvent.ChatMessage): IO[Unit] =
+    IO(db.update(message.gameId, db.getOrElse(message.gameId, Nil) :+ message))
+
+  def recent(gameId: GameId): IO[List[PlayerEvent.ChatMessage]] =
+    if (loadFails) IO.raiseError(new RuntimeException("chat load failure") with NoStackTrace)
     else IO.pure(db.getOrElse(gameId, Nil))
 }
 
@@ -1030,6 +1044,51 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
       val frame = wsProbe.expectMessageType[PlayerActor.WsMessage].message.asInstanceOf[TextMessage.Strict].text
       frame should include("ChatMessage")
       frame should include("hello")
+    }
+
+    "persist each chat message to the chat repository on SendChat" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val chatRepo = new InMemChatRepo()
+      val gm = spawn(GameManager(persistProbe.ref, new InMemRepo, noOpLobbyRepo, chatRepo = chatRepo))
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+      val gameId: GameId = UUID.randomUUID()
+      val sender = Player("alice")
+
+      gm ! GameManager.SendChat(gameId, sender, "hello all")
+
+      // append is fire-and-forget, so poll the history until the message lands
+      responseProbe.awaitAssert {
+        gm ! GameManager.GetChatHistory(gameId, responseProbe.ref)
+        val history = responseProbe.expectMessageType[GameManager.ChatHistory]
+        history.messages.map(_.text) shouldBe List("hello all")
+      }
+    }
+
+    "return the recorded chat history on GetChatHistory" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameId: GameId = UUID.randomUUID()
+      val seeded = List(
+        PlayerEvent.ChatMessage(gameId, alice, "alice", "hi", Instant.EPOCH),
+        PlayerEvent.ChatMessage(gameId, bob, "bob", "hey", Instant.EPOCH)
+      )
+      val chatRepo = new InMemChatRepo(Map(gameId -> seeded))
+      val gm = spawn(GameManager(persistProbe.ref, new InMemRepo, noOpLobbyRepo, chatRepo = chatRepo))
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+
+      gm ! GameManager.GetChatHistory(gameId, responseProbe.ref)
+      val history = responseProbe.expectMessageType[GameManager.ChatHistory]
+      history.gameId shouldBe gameId
+      history.messages shouldBe seeded
+    }
+
+    "reply with an error when the chat history load fails" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val chatRepo = new InMemChatRepo(loadFails = true)
+      val gm = spawn(GameManager(persistProbe.ref, new InMemRepo, noOpLobbyRepo, chatRepo = chatRepo))
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+
+      gm ! GameManager.GetChatHistory(UUID.randomUUID(), responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.ErrorResponse]
     }
 
     "forward SubscribeToGame so the subscriber receives events after a move" in {

--- a/game-service-server/src/test/scala/com/andy327/server/actors/core/GameManagerSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/core/GameManagerSpec.scala
@@ -27,7 +27,7 @@ import com.andy327.server.actors.persistence.PersistenceProtocol
 import com.andy327.server.game.{GameOperation, MovePayload}
 import com.andy327.server.http.json.{GameStateConverters, GridGameState}
 import com.andy327.server.lobby.{GameLifecycleStatus, LobbyError, LobbyMetadata, LobbyRepository, Player}
-import com.andy327.server.pubsub.GameEventSubscriber
+import com.andy327.server.pubsub.{GameEventPublisher, GameEventSubscriber}
 
 /** In-memory GameRepository for unit tests */
 class InMemRepo(initialGames: Map[GameId, (GameType, Game[_, _, _, _, _])] = Map.empty) extends GameRepository {
@@ -970,6 +970,66 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
 
       // subscriber receives initial lobby state immediately via WebSocket
       wsProbe.expectMessageType[PlayerActor.WsMessage]
+    }
+
+    "broadcast a chat message to an active game's subscribers and publish it on SendChat" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val host = Player("alice")
+      val guest = Player("bob")
+      val published = new java.util.concurrent.ConcurrentLinkedQueue[(GameId, PlayerEvent)]()
+      val recordingPublisher = new GameEventPublisher {
+        def publish(gameId: GameId, event: PlayerEvent): Unit = { published.add((gameId, event)); () }
+      }
+      val gm = spawn(GameManager(persistProbe.ref, new InMemRepo, noOpLobbyRepo, publisher = recordingPublisher))
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, host, responseProbe.ref)
+      val GameManager.LobbyCreated(gameId, _) = responseProbe.receiveMessage()
+      gm ! GameManager.JoinLobby(gameId, guest, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbyJoined]
+      gm ! GameManager.StartGame(gameId, host.id, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.GameStarted]
+
+      val subscriberProbe = createTestProbe[PlayerActor.Command]()
+      gm ! GameManager.SubscribeToGame(gameId, subscriberProbe.ref)
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial game state on subscribe
+
+      gm ! GameManager.SendChat(gameId, host, "gg")
+
+      val Some(chat) = subscriberProbe.expectMessageType[PlayerActor.SendEvent].event match {
+        case c: PlayerEvent.ChatMessage => Some(c)
+        case _                          => None
+      }
+      chat.gameId shouldBe gameId
+      chat.senderId shouldBe host.id
+      chat.senderName shouldBe "alice"
+      chat.text shouldBe "gg"
+
+      // also relayed to other instances via the publisher
+      subscriberProbe.awaitAssert(published.size shouldBe 1)
+      published.peek()._2 shouldBe a[PlayerEvent.ChatMessage]
+    }
+
+    "broadcast a chat message to lobby subscribers on SendChat before the game starts" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val alice = Player("alice")
+      val gm = spawn(GameManager(persistProbe.ref, new InMemRepo, noOpLobbyRepo))
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+
+      // connect alice so CreateLobby auto-subscribes her to the new lobby
+      val wsProbe = TestProbe[PlayerActor.WsOutput]()
+      val playerRefProbe = TestProbe[ActorRef[PlayerActor.Command]]()
+      gm ! GameManager.RegisterPlayer(alice, wsProbe.ref, playerRefProbe.ref)
+      playerRefProbe.expectMessageType[ActorRef[PlayerActor.Command]]
+
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      val GameManager.LobbyCreated(gameId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
+      wsProbe.expectMessageType[PlayerActor.WsMessage] // initial lobby state from the auto-subscribe
+
+      gm ! GameManager.SendChat(gameId, alice, "hello")
+      val frame = wsProbe.expectMessageType[PlayerActor.WsMessage].message.asInstanceOf[TextMessage.Strict].text
+      frame should include("ChatMessage")
+      frame should include("hello")
     }
 
     "forward SubscribeToGame so the subscriber receives events after a move" in {

--- a/game-service-server/src/test/scala/com/andy327/server/actors/core/LobbyManagerSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/core/LobbyManagerSpec.scala
@@ -1,5 +1,6 @@
 package com.andy327.server.actors.core
 
+import java.time.Instant
 import java.util.UUID
 
 import cats.effect.IO
@@ -168,6 +169,22 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       f.responseProbe.expectMessageType[GameManager.LobbyJoined]
 
       subscriberProbe.expectNoMessage()
+    }
+
+    "fan a chat message out to lobby subscribers on BroadcastChat" in {
+      val f = newLobby()
+      val subscriberProbe = TestProbe[PlayerActor.Command]()
+
+      f.lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, f.responseProbe.ref)
+      val GameManager.LobbyCreated(gameId, _) = f.responseProbe.expectMessageType[GameManager.LobbyCreated]
+
+      f.lm ! LobbyManager.SubscribeToLobby(gameId, alice.id, subscriberProbe.ref, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.SubscribeAcknowledged]
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial lobby state on subscribe
+
+      val chat = PlayerEvent.ChatMessage(gameId, alice.id, "alice", "hi", Instant.EPOCH)
+      f.lm ! LobbyManager.BroadcastChat(gameId, chat)
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe chat
     }
 
     "push LobbyUpdated to a subscriber when a player joins" in {

--- a/game-service-server/src/test/scala/com/andy327/server/actors/tictactoe/TicTacToeActorSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/tictactoe/TicTacToeActorSpec.scala
@@ -1,5 +1,6 @@
 package com.andy327.server.actors.tictactoe
 
+import java.time.Instant
 import java.util.UUID
 
 import scala.concurrent.duration._
@@ -279,6 +280,18 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
       subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe
         PlayerEvent.GameEnded(GameLifecycleStatus.Completed)
+    }
+
+    "fan a Broadcast event out to all subscribers" in {
+      val (actor, _) = newActor()
+      val subscriberProbe = createTestProbe[PlayerActor.Command]()
+
+      actor ! TurnBasedGameActor.Subscribe(subscriberProbe.ref)
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial state push on subscribe
+
+      val chat = PlayerEvent.ChatMessage(UUID.randomUUID(), alice, "alice", "gg", Instant.EPOCH)
+      actor ! TurnBasedGameActor.Broadcast(chat)
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe chat
     }
 
     "not push events to unsubscribed players" in {

--- a/game-service-server/src/test/scala/com/andy327/server/chat/RedisChatRepositorySpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/chat/RedisChatRepositorySpec.scala
@@ -1,0 +1,101 @@
+package com.andy327.server.chat
+
+import java.time.Instant
+import java.util.UUID
+
+import com.typesafe.config.ConfigFactory
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.implicits._
+
+import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.testcontainers.containers.wait.strategy.Wait
+
+import com.andy327.model.core.GameId
+import com.andy327.persistence.db.redis.RedisClientResource
+import com.andy327.server.actors.core.PlayerEvent
+
+class RedisChatRepositorySpec extends AnyWordSpec with Matchers with ForAllTestContainer {
+
+  private val RedisPort = 6379
+
+  /** Single Redis container spun up once per ScalaTest run. */
+  override val container: GenericContainer = GenericContainer(
+    dockerImage = "redis:7-alpine",
+    exposedPorts = Seq(RedisPort),
+    waitStrategy = Wait.forListeningPort()
+  )
+
+  private def redisConfig = ConfigFactory.parseString(s"""
+    pekko-game-service.redis {
+      uri = "redis://${container.containerIpAddress}:${container.mappedPort(RedisPort)}"
+    }
+  """)
+
+  /** Runs `f` against a freshly flushed Redis with a chat repo bounded to `maxMessages`. */
+  private def withRepo[A](maxMessages: Int = 100)(f: RedisChatRepository => IO[A]): A =
+    RedisClientResource(redisConfig).use { redis =>
+      redis.flushAll *> f(new RedisChatRepository(redis, maxMessages))
+    }.unsafeRunSync()
+
+  private def message(gameId: GameId, text: String): PlayerEvent.ChatMessage =
+    PlayerEvent.ChatMessage(gameId, UUID.randomUUID(), "alice", text, Instant.now())
+
+  "RedisChatRepository.recent" should {
+    "return appended messages in oldest-first order" in {
+      val gameId = UUID.randomUUID()
+      withRepo() { repo =>
+        for {
+          _ <- repo.append(message(gameId, "first"))
+          _ <- repo.append(message(gameId, "second"))
+          _ <- repo.append(message(gameId, "third"))
+          recent <- repo.recent(gameId)
+        } yield recent.map(_.text) shouldBe List("first", "second", "third")
+      }
+    }
+
+    "return an empty list for a game with no messages" in
+      withRepo() { repo =>
+        repo.recent(UUID.randomUUID()).map(_ shouldBe empty)
+      }
+
+    "isolate messages by game" in {
+      val gameA = UUID.randomUUID()
+      val gameB = UUID.randomUUID()
+      withRepo() { repo =>
+        for {
+          _ <- repo.append(message(gameA, "for-a"))
+          _ <- repo.append(message(gameB, "for-b"))
+          recentA <- repo.recent(gameA)
+        } yield recentA.map(_.text) shouldBe List("for-a")
+      }
+    }
+
+    "skip corrupt entries rather than failing the whole read" in {
+      val gameId = UUID.randomUUID()
+      RedisClientResource(redisConfig).use { redis =>
+        val repo = new RedisChatRepository(redis)
+        redis.flushAll *> (for {
+          _ <- repo.append(message(gameId, "good"))
+          _ <- redis.lPush(s"chat:$gameId", "{not valid json") // a non-JSON entry slipped into the buffer
+          recent <- repo.recent(gameId)
+        } yield recent.map(_.text) shouldBe List("good"))
+      }.unsafeRunSync()
+    }
+  }
+
+  "RedisChatRepository.append" should {
+    "retain only the most recent messages once the buffer is full" in {
+      val gameId = UUID.randomUUID()
+      withRepo(maxMessages = 3) { repo =>
+        for {
+          _ <- List("m1", "m2", "m3", "m4", "m5").traverse_(t => repo.append(message(gameId, t)))
+          recent <- repo.recent(gameId)
+        } yield recent.map(_.text) shouldBe List("m3", "m4", "m5")
+      }
+    }
+  }
+}

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -140,5 +140,38 @@ class SerializationSpec extends AnyWordSpec with Matchers {
       json.hcursor.get[String]("type") shouldBe Right("GameEnded")
       json.hcursor.get[String]("result") shouldBe Right("Completed")
     }
+
+    "encode ChatMessage with a type discriminator and fields" in {
+      val event: PlayerEvent =
+        PlayerEvent.ChatMessage(
+          UUID.randomUUID(),
+          UUID.randomUUID(),
+          "alice",
+          "gg",
+          Instant.parse("2026-06-15T12:00:00Z")
+        )
+      val json = event.asJson
+      json.hcursor.get[String]("type") shouldBe Right("ChatMessage")
+      json.hcursor.get[String]("senderName") shouldBe Right("alice")
+      json.hcursor.get[String]("text") shouldBe Right("gg")
+      json.hcursor.get[String]("sentAt") shouldBe Right("2026-06-15T12:00:00Z")
+    }
+  }
+
+  "ClientMessage decoder" should {
+    "decode a ChatSend frame" in {
+      val gameId = UUID.randomUUID()
+      val json = s"""{"type":"ChatSend","gameId":"$gameId","text":"hello"}"""
+      io.circe.parser.decode[ClientMessage](json) shouldBe Right(ClientMessage.ChatSend(gameId, "hello"))
+    }
+
+    "reject an unknown message type with an explanatory error" in {
+      val error = io.circe.parser.decode[ClientMessage]("""{"type":"Nope"}""").swap.map(_.getMessage).getOrElse("")
+      error should include("Unknown client message type: Nope")
+    }
+
+    "reject a frame missing the type discriminator" in {
+      io.circe.parser.decode[ClientMessage]("""{"text":"no type"}""").isLeft shouldBe true
+    }
   }
 }

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/GameRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/GameRoutesSpec.scala
@@ -26,7 +26,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 import com.andy327.model.core.{GameId, GameType}
 import com.andy327.persistence.db.MoveRecord
-import com.andy327.server.actors.core.{GameManager, InMemMoveRepo, InMemRepo, PlayerActor}
+import com.andy327.server.actors.core.{GameManager, InMemChatRepo, InMemMoveRepo, InMemRepo, PlayerActor, PlayerEvent}
 import com.andy327.server.actors.persistence.PersistenceProtocol
 import com.andy327.server.http.json.GridGameState
 import com.andy327.server.http.json.JsonProtocol._
@@ -183,6 +183,40 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
         }
       }
 
+      "return the recorded chat history" in {
+        val gameId = UUID.randomUUID()
+        val messages = List(
+          PlayerEvent.ChatMessage(gameId, aliceId, "alice", "hi", Instant.EPOCH),
+          PlayerEvent.ChatMessage(gameId, bobId, "bob", "hey", Instant.EPOCH)
+        )
+        val chatSystem = ActorSystem(
+          GameManager(
+            persistProbe.ref,
+            new InMemRepo,
+            noOpLobbyRepo,
+            chatRepo = new InMemChatRepo(Map(gameId -> messages))
+          ),
+          "GameRoutesChatSystem"
+        )
+        val chatRoutes = new GameRoutes(GameType.TicTacToe, chatSystem).routes
+
+        Get(s"/tictactoe/$gameId/chat") ~> chatRoutes ~> check {
+          status shouldBe StatusCodes.OK
+          val history = responseAs[GameManager.ChatHistory]
+          history.gameId shouldBe gameId
+          history.messages.map(_.text) shouldBe List("hi", "hey")
+          history.messages.map(_.senderName) shouldBe List("alice", "bob")
+        }
+      }
+
+      "return an empty chat history for a game with no messages" in {
+        val gameId = UUID.randomUUID()
+        Get(s"/tictactoe/$gameId/chat") ~> routes ~> check {
+          status shouldBe StatusCodes.OK
+          responseAs[GameManager.ChatHistory].messages shouldBe empty
+        }
+      }
+
       "return 400 for invalid game ID on move" in {
         val moveEntity = HttpEntity(ContentTypes.`application/json`, """{"row":0,"col":0}""")
 
@@ -240,6 +274,10 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
             replyTo ! GameManager.Ready // triggers /history fallback
             Behaviors.same
 
+          case GameManager.GetChatHistory(_, replyTo) =>
+            replyTo ! GameManager.Ready // triggers /chat fallback
+            Behaviors.same
+
           case _ => Behaviors.same
         }
 
@@ -253,7 +291,8 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
           ("POST /move", Post(s"/tictactoe/$fakeId/move", moveEntity).withHeaders(aliceHeader)),
           ("GET /status", Get(s"/tictactoe/$fakeId/status")),
           ("POST /subscribe", Post(s"/tictactoe/$fakeId/subscribe").withHeaders(aliceHeader)),
-          ("GET /history", Get(s"/tictactoe/$fakeId/history"))
+          ("GET /history", Get(s"/tictactoe/$fakeId/history")),
+          ("GET /chat", Get(s"/tictactoe/$fakeId/chat"))
         )
 
         forAll(requests) { (description, req) =>
@@ -277,6 +316,9 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
                 replyTo ! response
                 Behaviors.same
               case GameManager.GetMoveHistory(_, replyTo) =>
+                replyTo ! response
+                Behaviors.same
+              case GameManager.GetChatHistory(_, replyTo) =>
                 replyTo ! response
                 Behaviors.same
               case _ => Behaviors.same
@@ -305,6 +347,11 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
         }
         // /history maps a storage ErrorResponse to 500 as well
         Get(s"/tictactoe/$fakeId/history") ~> errorRoutes ~> check {
+          status shouldBe StatusCodes.InternalServerError
+          responseAs[String] should include("boom")
+        }
+        // /chat maps a storage ErrorResponse to 500 as well
+        Get(s"/tictactoe/$fakeId/chat") ~> errorRoutes ~> check {
           status shouldBe StatusCodes.InternalServerError
           responseAs[String] should include("boom")
         }

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/WebSocketRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/WebSocketRoutesSpec.scala
@@ -91,5 +91,35 @@ class WebSocketRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteT
         wsClient.expectCompletion()
       }
     }
+
+    "drop a malformed inbound frame and still route a valid ChatSend back to the match's subscribers" in {
+      val alice = Player("alice")
+      val token = createTestToken(alice)
+      val responseProbe = typedKit.createTestProbe[GameManager.GameResponse]()
+
+      typedSystem ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      val gameId = responseProbe.expectMessageType[GameManager.LobbyCreated].gameId
+
+      val wsClient = WSProbe()
+      WS("/ws", wsClient.flow) ~> addHeader(RawHeader("Authorization", s"Bearer $token")) ~> routes ~> check {
+        isWebSocketUpgrade shouldBe true
+
+        // subscribe alice to the lobby once her session is registered (registration is async)
+        responseProbe.awaitAssert {
+          typedSystem ! GameManager.SubscribePlayerToLobby(gameId, alice.id, responseProbe.ref)
+          responseProbe.receiveMessage() shouldBe a[GameManager.SubscribeAcknowledged]
+        }
+        wsClient.expectMessage().asTextMessage.getStrictText should include("LobbyUpdated") // initial state
+
+        // a malformed frame is logged and dropped without tearing down the connection
+        wsClient.sendMessage("not even json")
+
+        // the next valid chat frame is still routed: inbound decode -> SendChat -> lobby fan-out -> back to her socket
+        wsClient.sendMessage(s"""{"type":"ChatSend","gameId":"$gameId","text":"hello all"}""")
+        val frame = wsClient.expectMessage().asTextMessage.getStrictText
+        frame should include("ChatMessage")
+        frame should include("hello all")
+      }
+    }
   }
 }


### PR DESCRIPTION
Adds real-time text chat scoped to a match, delivered over each player's existing
WebSocket connection, with persisted recent history for backscroll.

## What's included
- **Protocol** — a `ChatMessage` server-push event and an inbound `ClientMessage.ChatSend`
  frame, both Circe-encoded with a `type` discriminator.
- **Delivery** — inbound WS frames are decoded and routed to `GameManager.SendChat`, which
  fans the message out to the match's subscribers (the game actor while in progress, the
  lobby otherwise) and publishes it to Redis so other instances relay it to their watchers.
  Malformed inbound frames are logged and dropped without tearing down the connection.
- **History** — each message is recorded in a per-game Redis ring buffer (`LPUSH`/`LTRIM`,
  newest N retained), exposed via `GET /{gameType}/{gameId}/chat` (oldest-first), mirroring
  the existing move-history endpoint. Works for active and finished games.
- **Config** — retention size is configurable via `pekko-game-service.chat.max-messages`
  (default 100, `CHAT_MAX_MESSAGES` override).

## Wire formats
- Inbound: `{"type":"ChatSend","gameId":"…","text":"…"}`
- Outbound: `{"type":"ChatMessage","gameId":…,"senderId":…,"senderName":…,"text":…,"sentAt":…}`
- `GET …/chat`: `{"gameId":…,"messages":[{plain chat record}, …]}`

## Testing
- `sbt scalafixAll scalafmtAll test` green (model 23, persistence 30, server 256); `sbt doc` clean.
- Manual end-to-end smoke test over WebSockets (lobby + in-progress chat, backscroll, restart persistence).

## Known limitations / follow-ups
- **No live post-game chat.** Messages sent after a game completes are still persisted and
  published, but not delivered live — the game actor (which holds the subscribers) has
  terminated and the lobby dropped them at start. Worth a follow-up (hand subscribers back to
  the recently-ended lobby cache).
- **No participant validation or rate-limiting** on `SendChat` yet — any connected player can
  post to any `gameId`. Ties to auth (#29); a token-bucket + length cap is a natural follow-up.
- The Redis pub/sub `publishFn` re-creates a channel listener per publish (pre-existing, not
  chat-specific) — a separate cleanup.

Closes #18