### PR TITLE
Support leaving/forfeiting an in-progress game

### DIFF
--- a/game-service-model/src/main/scala/com/andy327/model/battleship/Battleship.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/battleship/Battleship.scala
@@ -141,6 +141,18 @@ final case class Battleship(
       }
     }
 
+  /** Forfeits the game on behalf of the leaving player: the opponent is declared the winner.
+    *
+    * Rejects with [[core.GameError.InvalidPlayer]] if `playerId` is not a participant, or [[core.GameError.GameOver]]
+    * if the game has already ended. The full state is retained, so the fog-of-war view layer is unaffected.
+    */
+  override def playerLeft(playerId: PlayerId): Either[GameError, Battleship] =
+    playerFor(playerId) match {
+      case None                                => Left(GameError.InvalidPlayer(playerId))
+      case Some(_) if gameStatus != InProgress => Left(GameOver)
+      case Some(leaver)                        => Right(copy(winner = Some(opponent(leaver))))
+    }
+
   /** Renders both players' boards for logging: `S` ship, `X` hit, `o` miss, `.` empty water. */
   def render: String = {
     def renderBoard(b: PlayerBoard): String = {

--- a/game-service-model/src/main/scala/com/andy327/model/connectfour/ConnectFour.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/connectfour/ConnectFour.scala
@@ -129,6 +129,18 @@ final case class ConnectFour(
           )
       }
 
+  /** Forfeits the game on behalf of the leaving player: the opponent is declared the winner.
+    *
+    * Rejects with [[core.GameError.InvalidPlayer]] if `playerId` is not a participant, or [[core.GameError.GameOver]]
+    * if the game has already ended.
+    */
+  override def playerLeft(playerId: PlayerId): Either[GameError, ConnectFour] =
+    playerFor(playerId) match {
+      case None                                => Left(GameError.InvalidPlayer(playerId))
+      case Some(_) if gameStatus != InProgress => Left(GameOver)
+      case Some(leaver)                        => Right(copy(winner = Some(if (leaver == Red) Yellow else Red)))
+    }
+
   /** Returns a human-readable representation of the board for logging. */
   def render: String = {
     val border = "-" * (Cols * 2 + 1)

--- a/game-service-model/src/main/scala/com/andy327/model/core/Game.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/core/Game.scala
@@ -46,4 +46,18 @@ trait Game[Move, State, Player, Status, Error] {
     *   - Return either a new game state or an error
     */
   def play(player: Player, move: Move): Either[Error, State]
+
+  /** Applies the effect of `playerId` leaving an in-progress game.
+    *
+    * The returned state's [[gameStatus]] drives what happens next, exactly as for a move: a terminal status (won or
+    * draw) runs the game's normal completion machinery, while an `InProgress` status means the game continues with the
+    * remaining players (the fold-out case for games with more than two players). A `Left` rejects the leave and leaves
+    * the game untouched.
+    *
+    * Each game defines its own leave semantics: two-player games forfeit — the leaver loses and the opponent wins — so
+    * the implementation should reject a non-participant and an already-finished game, then transition to a win for the
+    * remaining player. Returns a core [[GameError]] rather than the game-specific `Error` type because leaving never
+    * produces a game-rule error.
+    */
+  def playerLeft(playerId: PlayerId): Either[GameError, State]
 }

--- a/game-service-model/src/main/scala/com/andy327/model/tictactoe/TicTacToe.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/tictactoe/TicTacToe.scala
@@ -110,6 +110,18 @@ final case class TicTacToe(
       )
     }
 
+  /** Forfeits the game on behalf of the leaving player: the opponent is declared the winner.
+    *
+    * Rejects with [[core.GameError.InvalidPlayer]] if `playerId` is not a participant, or [[core.GameError.GameOver]]
+    * if the game has already ended.
+    */
+  override def playerLeft(playerId: PlayerId): Either[GameError, TicTacToe] =
+    playerFor(playerId) match {
+      case None                                => Left(GameError.InvalidPlayer(playerId))
+      case Some(_) if gameStatus != InProgress => Left(GameOver)
+      case Some(leaver)                        => Right(copy(winner = Some(if (leaver == X) O else X)))
+    }
+
   def render: String = {
     val border = "-" * 7
     val rows = board.map { row =>

--- a/game-service-model/src/test/scala/com/andy327/model/battleship/BattleshipSpec.scala
+++ b/game-service-model/src/test/scala/com/andy327/model/battleship/BattleshipSpec.scala
@@ -105,6 +105,24 @@ class BattleshipSpec extends AnyWordSpec with Matchers {
     }
   }
 
+  "A leaving player" should {
+    "forfeit to the opponent" in {
+      val game = gameWith(board(Set(Coord(0, 0))), board(Set(Coord(0, 0))))
+      game.playerLeft(alice).map(_.gameStatus) shouldBe Right(Won(Player2))
+      game.playerLeft(bob).map(_.gameStatus) shouldBe Right(Won(Player1))
+    }
+
+    "be rejected for a non-participant" in {
+      val game = gameWith(board(Set(Coord(0, 0))), board(Set(Coord(0, 0))))
+      game.playerLeft(UUID.randomUUID()) shouldBe a[Left[_, _]]
+    }
+
+    "be rejected once the game is already over" in {
+      val game = gameWith(board(Set(Coord(0, 0))), board(Set(Coord(0, 0))), winner = Some(Player1))
+      game.playerLeft(bob) shouldBe Left(GameOver)
+    }
+  }
+
   "Battleship.random" should {
     "start a fresh game with Player1 to move, no winner, and no shots fired" in {
       val game = Battleship.random(alice, bob, new Random(7))

--- a/game-service-model/src/test/scala/com/andy327/model/connectfour/ConnectFourSpec.scala
+++ b/game-service-model/src/test/scala/com/andy327/model/connectfour/ConnectFourSpec.scala
@@ -134,6 +134,30 @@ class ConnectFourSpec extends AnyWordSpec with Matchers {
       won.play(Yellow, Drop(0)) shouldBe Left(GameError.GameOver)
     }
 
+    "forfeit to the opponent when a player leaves" in {
+      val game = ConnectFour.empty(alice, bob)
+      game.playerLeft(alice).map(_.gameStatus) shouldBe Right(Won(Yellow))
+      game.playerLeft(bob).map(_.gameStatus) shouldBe Right(Won(Red))
+    }
+
+    "reject a leave from a non-participant" in {
+      ConnectFour.empty(alice, bob).playerLeft(UUID.randomUUID()) shouldBe a[Left[_, _]]
+    }
+
+    "reject a leave once the game is already over" in {
+      val won = ConnectFour.empty(alice, bob)
+        .play(Red, Drop(0)).toOption.get
+        .play(Yellow, Drop(1)).toOption.get
+        .play(Red, Drop(0)).toOption.get
+        .play(Yellow, Drop(1)).toOption.get
+        .play(Red, Drop(0)).toOption.get
+        .play(Yellow, Drop(1)).toOption.get
+        .play(Red, Drop(0)).toOption.get // Red connects four vertically in column 0
+
+      won.gameStatus shouldBe Won(Red)
+      won.playerLeft(bob) shouldBe Left(GameError.GameOver)
+    }
+
     "render the board as a human-readable string" in {
       val game = ConnectFour.empty(alice, bob)
         .play(Red, Drop(0)).toOption.get // Red  (5,0)

--- a/game-service-model/src/test/scala/com/andy327/model/tictactoe/TicTacToeSpec.scala
+++ b/game-service-model/src/test/scala/com/andy327/model/tictactoe/TicTacToeSpec.scala
@@ -91,6 +91,34 @@ class TicTacToeSpec extends AnyWordSpec with Matchers {
       result shouldBe Left(GameError.GameOver)
     }
 
+    "forfeit to the opponent when a player leaves" in {
+      val game = TicTacToe.empty(alice, bob).play(X, Location(0, 0)).toOption.get
+      val Right(forfeited) = game.playerLeft(bob) // O leaves
+      forfeited.gameStatus shouldBe Won(X)
+    }
+
+    "let either seat forfeit to the other" in {
+      val game = TicTacToe.empty(alice, bob)
+      game.playerLeft(alice).map(_.gameStatus) shouldBe Right(Won(O))
+      game.playerLeft(bob).map(_.gameStatus) shouldBe Right(Won(X))
+    }
+
+    "reject a leave from a non-participant" in {
+      val game = TicTacToe.empty(alice, bob)
+      game.playerLeft(UUID.randomUUID()) shouldBe a[Left[_, _]]
+    }
+
+    "reject a leave once the game is already over" in {
+      val game = TicTacToe.empty(alice, bob)
+        .play(X, Location(0, 0)).toOption.get
+        .play(O, Location(1, 0)).toOption.get
+        .play(X, Location(0, 1)).toOption.get
+        .play(O, Location(1, 1)).toOption.get
+        .play(X, Location(0, 2)).toOption.get // X wins
+
+      game.playerLeft(bob) shouldBe Left(GameError.GameOver)
+    }
+
     "properly render a game board" in {
       val game = TicTacToe.empty(alice, bob)
         .play(X, Location(0, 0)).toOption.get

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/GameActor.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/GameActor.scala
@@ -3,8 +3,9 @@ package com.andy327.server.actors.core
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
 import org.apache.pekko.actor.typed.{ActorRef, Behavior, Terminated}
 
-import com.andy327.model.core.{Game, GameId, GameType, GameTypeTag, PlayerId}
+import com.andy327.model.core.{Game, GameError, GameId, GameType, GameTypeTag, PlayerId}
 import com.andy327.server.actors.persistence.PersistenceProtocol
+import com.andy327.server.http.json.GameState
 import com.andy327.server.pubsub.GameEventPublisher
 
 object GameActor {
@@ -86,6 +87,12 @@ trait GameActor[G <: Game[_, _, _, _, _]] {
 
   /** Produce the game-specific command that fans `event` out to all of the game's subscribers (e.g. a chat message). */
   def broadcastCommand(event: PlayerEvent): GameActor.GameCommand
+
+  /** Produce the game-specific command that applies `playerId` leaving the game (a forfeit for two-player games),
+    * replying to `replyTo` with the leaver's view of the resulting state or a `GameError` if the leave is rejected.
+    * Lets GameManager trigger a forfeit without knowing the game's concrete move/command types.
+    */
+  def forfeitCommand(playerId: PlayerId, replyTo: ActorRef[Either[GameError, GameState]]): GameActor.GameCommand
 
   /** Extract the snapshot-save result from `cmd` if it is a `SnapshotSaved` message, otherwise `None`.
     *

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/GameManager.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/GameManager.scala
@@ -152,6 +152,15 @@ object GameManager {
   final private case class WrappedGameResponse(response: Either[GameError, GameState], replyTo: ActorRef[GameResponse])
       extends Command
 
+  /** Adapter wrapper — converts a game actor's forfeit reply (from a `LeaveLobby` on an in-progress game) into a
+    * [[GameForfeited]] on success or a [[MoveRejected]] if the model rejected the leave.
+    */
+  final private case class WrappedForfeitResponse(
+      response: Either[GameError, GameState],
+      gameId: GameId,
+      replyTo: ActorRef[GameResponse]
+  ) extends Command
+
   /** Adapter wrapper — converts [[LobbyManager.LobbiesListed]] into a [[GameResponse]] for the HTTP caller. */
   final private case class WrappedLobbiesListed(listed: LobbyManager.LobbiesListed, replyTo: ActorRef[GameResponse])
       extends Command
@@ -229,6 +238,9 @@ object GameManager {
   // Game responses
   final case class GameStarted(gameId: GameId) extends GameResponse
   final case class GameStatus(state: GameState) extends GameResponse
+
+  /** A player left an in-progress game and thereby forfeited it; `state` is the leaver's view of the finished game. */
+  final case class GameForfeited(gameId: GameId, state: GameState) extends GameResponse
 
   /** The ordered move history for a game; `moves` is empty if the game has no recorded moves. */
   final case class MoveHistory(gameId: GameId, moves: List[MoveRecord]) extends GameResponse
@@ -395,7 +407,17 @@ object GameManager {
           Behaviors.same
 
         case LeaveLobby(gameId, player, replyTo) =>
-          lobbyManager ! LobbyManager.LeaveLobby(gameId, player, replyTo)
+          activeGames.get(gameId) match {
+            // game in progress: leaving it is a forfeit, handled by the game actor (which then self-completes and
+            // triggers GameCompleted -> MarkCompleted, moving the lobby to Completed)
+            case Some((gameType, gameActor)) =>
+              val adaptedRef: ActorRef[Either[GameError, GameState]] =
+                context.messageAdapter(response => WrappedForfeitResponse(response, gameId, replyTo))
+              gameActor ! GameRegistry.forType(gameType).actor.forfeitCommand(player.id, adaptedRef)
+            // pre-game (or unknown) lobby: ordinary leave / host-cancel handled by LobbyManager as before
+            case None =>
+              lobbyManager ! LobbyManager.LeaveLobby(gameId, player, replyTo)
+          }
           Behaviors.same
 
         case StartGame(gameId, playerId, replyTo) =>
@@ -671,6 +693,13 @@ object GameManager {
         case WrappedGameResponse(response, replyTo) =>
           response match {
             case Right(state) => replyTo ! GameStatus(state)
+            case Left(error)  => replyTo ! MoveRejected(error.message)
+          }
+          Behaviors.same
+
+        case WrappedForfeitResponse(response, gameId, replyTo) =>
+          response match {
+            case Right(state) => replyTo ! GameForfeited(gameId, state)
             case Left(error)  => replyTo ! MoveRejected(error.message)
           }
           Behaviors.same

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/LobbyManager.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/LobbyManager.scala
@@ -202,9 +202,9 @@ object LobbyManager {
 
       case LeaveLobby(gameId, player, replyTo) =>
         lobbies.get(gameId) match {
-          // TODO(#28): leaving an in-progress game should eventually mean forfeiting it (or folding out of
-          // multiplayer games); until that exists, reject the request so the lobby cannot revert to a joinable
-          // status while its game actor is still running.
+          // Leaving an in-progress game is a forfeit, handled by the game actor; GameManager routes those directly and
+          // never forwards them here. This branch only guards the edge case where a lobby still shows InProgress but no
+          // live game actor exists (e.g. mid-restore) — reject so the lobby cannot revert to a joinable status.
           case Some(metadata) if metadata.status == GameLifecycleStatus.InProgress =>
             replyTo ! GameManager.LobbyErrorResponse(LobbyError.GameInProgress(gameId))
             Behaviors.same

--- a/game-service-server/src/main/scala/com/andy327/server/actors/core/TurnBasedGameActor.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/actors/core/TurnBasedGameActor.scala
@@ -3,7 +3,7 @@ package com.andy327.server.actors.core
 import scala.reflect.ClassTag
 
 import io.circe.Encoder
-import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko.actor.typed.scaladsl.{ActorContext, Behaviors}
 import org.apache.pekko.actor.typed.{ActorRef, Behavior, Terminated}
 
 import com.andy327.model.core.{Draw, Game, GameError, GameId, GameStatus, GameTypeTag, InProgress, PlayerId, Won}
@@ -24,6 +24,12 @@ object TurnBasedGameActor {
   /** Attempt to apply `move` on behalf of `playerId`. */
   final case class MakeMove[M](playerId: PlayerId, move: M, replyTo: ActorRef[Either[GameError, GameState]])
       extends Command[M]
+
+  /** Apply the effect of `playerId` leaving the game (a forfeit for two-player games). Replies with the leaver's view
+    * of the resulting state, or a `GameError` if the model rejects the leave (e.g. not a participant, or unsupported).
+    */
+  final case class PlayerLeft(playerId: PlayerId, replyTo: ActorRef[Either[GameError, GameState]])
+      extends Command[Nothing]
 
   /** Return the current serialized game state without mutating it. */
   final case class GetState(replyTo: ActorRef[Either[GameError, GameState]]) extends Command[Nothing]
@@ -85,6 +91,12 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
   override def broadcastCommand(event: PlayerEvent): GameActor.GameCommand =
     Broadcast(event)
 
+  override def forfeitCommand(
+      playerId: PlayerId,
+      replyTo: ActorRef[Either[GameError, GameState]]
+  ): GameActor.GameCommand =
+    PlayerLeft(playerId, replyTo)
+
   override protected def snapshotSavedResult(cmd: Command): Option[Either[Throwable, Unit]] = cmd match {
     case SnapshotSaved(result) => Some(result)
     case _                     => None
@@ -137,6 +149,63 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
       }
     }
 
+  /** Persists, fans out, and completes a successful state transition — shared by `MakeMove` and `PlayerLeft`.
+    *
+    * Saves a snapshot, replies to the acting player with their own view, fans a per-viewer view out to every
+    * subscriber, and publishes the public view for other instances. The resulting `gameStatus` then decides the next
+    * behavior: a terminal status emits `GameEnded`, notifies GameManager, and transitions to [[terminating]]; an
+    * `InProgress` status returns to [[active]] with the new state.
+    *
+    * @param viewerId the acting player (mover or leaver), used to render the reply sent back to them
+    * @param appendMove run immediately after the snapshot save — a move appends to the history log here, whereas a
+    *                   forfeit passes the default no-op (the winning result is derived, not a recorded move)
+    */
+  private def applyTransition(
+      context: ActorContext[Command],
+      nextState: G,
+      viewerId: PlayerId,
+      gameId: GameId,
+      persist: ActorRef[PersistenceProtocol.Command],
+      gameManager: ActorRef[GameManager.Command],
+      subscribers: Map[ActorRef[PlayerActor.Command], PlayerId],
+      publisher: GameEventPublisher,
+      replyTo: ActorRef[Either[GameError, GameState]]
+  )(appendMove: => Unit = ()): Behavior[Command] = {
+    context.log.info(s"Game $gameId updated:\n$nextState")
+
+    persist ! PersistenceProtocol.SaveSnapshot(
+      gameId = gameId,
+      gameType = gameType,
+      game = nextState,
+      // pass the real save outcome through so a failed snapshot is logged by the SnapshotSaved handler
+      replyTo = context.messageAdapter(saved => SnapshotSaved(saved.result))
+    )
+
+    appendMove
+
+    // reply to the acting player with their own view; fan out a per-viewer view to each subscriber
+    replyTo ! Right(view.fromGame(nextState, Some(viewerId)))
+    subscribers.foreach { case (ref, subscriberId) =>
+      ref ! PlayerActor.SendEvent(PlayerEvent.GameStateUpdated(view.fromGame(nextState, Some(subscriberId))))
+    }
+    // publisher relays to other instances; carries the public view (per-viewer multi-instance is deferred)
+    publisher.publish(gameId, PlayerEvent.GameStateUpdated(view.fromGame(nextState, None)))
+
+    nextState.gameStatus match {
+      case Won(_) | Draw =>
+        context.log.info(s"[$gameId] game completed with status: ${nextState.gameStatus}")
+        val endEvent = PlayerEvent.GameEnded(GameLifecycleStatus.Completed)
+        // GameEnded carries no board, so it is identical for every viewer
+        subscribers.foreach { case (ref, _) => ref ! PlayerActor.SendEvent(endEvent) }
+        publisher.publish(gameId, endEvent)
+        gameManager ! GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed)
+        terminating(gameId)
+
+      case InProgress =>
+        active(nextState, gameId, persist, gameManager, subscribers, publisher)
+    }
+  }
+
   /** Core recursive behavior that drives a single game from first move to completion.
     *
     * Each state-changing message (MakeMove) produces a new `active` behavior with updated game and subscriber state.
@@ -159,39 +228,19 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
           case Some(player) =>
             game.play(player, move) match {
               case Right(nextState) =>
-                context.log.info(s"Game $gameId updated:\n$nextState")
-
-                persist ! PersistenceProtocol.SaveSnapshot(
-                  gameId = gameId,
-                  gameType = gameType,
-                  game = nextState,
-                  // pass the real save outcome through so a failed snapshot is logged by the SnapshotSaved handler
-                  replyTo = context.messageAdapter(saved => SnapshotSaved(saved.result))
-                )
-
-                // record the move in the append-only history log; seq is the pre-move move count (0-based ordinal)
-                persist ! PersistenceProtocol.AppendMove(gameId, game.moveCount, playerId, moveEncoder(move))
-
-                // reply to the mover with their own view; fan out a per-viewer view to each subscriber
-                replyTo ! Right(view.fromGame(nextState, Some(playerId)))
-                subscribers.foreach { case (ref, viewerId) =>
-                  ref ! PlayerActor.SendEvent(PlayerEvent.GameStateUpdated(view.fromGame(nextState, Some(viewerId))))
-                }
-                // publisher relays to other instances; carries the public view (per-viewer multi-instance is deferred)
-                publisher.publish(gameId, PlayerEvent.GameStateUpdated(view.fromGame(nextState, None)))
-
-                nextState.gameStatus match {
-                  case Won(_) | Draw =>
-                    context.log.info(s"[$gameId] game completed with status: ${nextState.gameStatus}")
-                    val endEvent = PlayerEvent.GameEnded(GameLifecycleStatus.Completed)
-                    // GameEnded carries no board, so it is identical for every viewer
-                    subscribers.foreach { case (ref, _) => ref ! PlayerActor.SendEvent(endEvent) }
-                    publisher.publish(gameId, endEvent)
-                    gameManager ! GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed)
-                    terminating(gameId)
-
-                  case InProgress =>
-                    active(nextState, gameId, persist, gameManager, subscribers, publisher)
+                applyTransition(
+                  context,
+                  nextState,
+                  playerId,
+                  gameId,
+                  persist,
+                  gameManager,
+                  subscribers,
+                  publisher,
+                  replyTo
+                ) {
+                  // record the move in the append-only history log; seq is the pre-move count (0-based ordinal)
+                  persist ! PersistenceProtocol.AppendMove(gameId, game.moveCount, playerId, moveEncoder(move))
                 }
 
               case Left(err) =>
@@ -203,6 +252,29 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
           case None =>
             context.log.warn(s"[$gameId] Player ID '$playerId' is not part of this game.")
             replyTo ! Left(GameError.InvalidPlayer(playerId))
+            Behaviors.same
+        }
+
+      case PlayerLeft(playerId, replyTo) =>
+        // forfeit/fold-out semantics live in the model; the resulting status drives completion exactly like a move
+        game.playerLeft(playerId) match {
+          case Right(nextState) =>
+            context.log.info(s"[$gameId] player $playerId left the game")
+            applyTransition(
+              context,
+              nextState,
+              playerId,
+              gameId,
+              persist,
+              gameManager,
+              subscribers,
+              publisher,
+              replyTo
+            )()
+
+          case Left(err) =>
+            context.log.warn(s"[$gameId] leave rejected: $err")
+            replyTo ! Left(err)
             Behaviors.same
         }
 

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/LobbyRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/LobbyRoutes.scala
@@ -13,6 +13,7 @@ import com.andy327.model.core.GameType
 import com.andy327.server.actors.core.GameManager
 import com.andy327.server.actors.core.GameManager.{
   ErrorResponse,
+  GameForfeited,
   GameResponse,
   GameStarted,
   LobbiesListed,
@@ -21,6 +22,7 @@ import com.andy327.server.actors.core.GameManager.{
   LobbyInfo,
   LobbyJoined,
   LobbyLeft,
+  MoveRejected,
   SubscribeAcknowledged
 }
 import com.andy327.server.http.auth.JwtPlayerDirectives._
@@ -148,11 +150,12 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
           *
           * - Auth: Bearer token required
           * - Path: `gameId` — the UUID of the lobby to leave
-          * - 200: `LobbyLeft` with the game ID and a status message
+          * - 200: `LobbyLeft` (pre-game leave) with the game ID and a status message, or the leaver's final game
+          *   state if the game was in progress (leaving forfeits it — the opponent wins)
           * - 400: invalid UUID format
           * - 401: missing or invalid token
           * - 404: lobby not found
-          * - 409: game is in progress; leaving a started game is not supported
+          * - 409: the caller is not a participant in the in-progress game, or the game type does not support leaving
           * - 500: unexpected error
           */
         path("leave") {
@@ -160,6 +163,8 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
             authenticatePlayer { player =>
               onSuccess(system.ask[GameResponse](replyTo => GameManager.LeaveLobby(gameId, player, replyTo))) {
                 case left @ LobbyLeft(_, _)    => complete(left)
+                case GameForfeited(_, state)   => complete(state)
+                case MoveRejected(msg)         => complete(StatusCodes.Conflict -> msg)
                 case LobbyErrorResponse(error) => complete(statusFor(error) -> error.message)
                 case other => complete(StatusCodes.InternalServerError -> s"Unexpected response: $other")
               }

--- a/game-service-server/src/test/scala/com/andy327/server/actors/connectfour/ConnectFourActorSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/connectfour/ConnectFourActorSpec.scala
@@ -134,6 +134,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
         override def gameStatus: Any = "dummy"
         override def playerFor(playerId: PlayerId): Option[Any] = None
         override def moveCount: Int = 0
+        override def playerLeft(playerId: PlayerId): Either[GameError, Any] = Left(GameError.Unknown("not implemented"))
       }
 
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()

--- a/game-service-server/src/test/scala/com/andy327/server/actors/core/GameManagerSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/core/GameManagerSpec.scala
@@ -16,6 +16,7 @@ import io.circe.syntax._
 import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
 import org.apache.pekko.actor.typed.ActorRef
 import org.apache.pekko.http.scaladsl.model.ws.TextMessage
+import org.scalatest.concurrent.Eventually
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -74,7 +75,7 @@ class InMemChatRepo(initial: Map[GameId, List[PlayerEvent.ChatMessage]] = Map.em
     else IO.pure(db.getOrElse(gameId, Nil))
 }
 
-class GameManagerSpec extends AnyWordSpecLike with Matchers {
+class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
   private val testKit = ActorTestKit()
   import testKit._
 
@@ -655,6 +656,59 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers {
       gm ! GameManager.LeaveLobby(gameId, alice, responseProbe.ref)
       val aliceLeft = responseProbe.expectMessageType[GameManager.LobbyLeft]
       aliceLeft.message should include("host left")
+    }
+
+    "forfeit an in-progress game when a player leaves" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+      val alice = Player("alice")
+      val bob = Player("bob")
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      val GameManager.LobbyCreated(gameId, host) = responseProbe.receiveMessage()
+      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbyJoined]
+      gm ! GameManager.StartGame(gameId, host.id, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.GameStarted]
+
+      // Bob (O) leaves the in-progress game — Alice (X) wins by forfeit
+      gm ! GameManager.LeaveLobby(gameId, bob, responseProbe.ref)
+      val forfeited = responseProbe.expectMessageType[GameManager.GameForfeited]
+      forfeited.state.asInstanceOf[GridGameState].winner shouldBe Some("X")
+
+      // the lobby has been moved to Completed by the GameCompleted -> MarkCompleted flow
+      eventually {
+        gm ! GameManager.GetLobbyInfo(gameId, responseProbe.ref)
+        responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.status shouldBe GameLifecycleStatus.Completed
+      }
+    }
+
+    "reject a forfeit from a non-participant of an in-progress game" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+      val alice = Player("alice")
+      val bob = Player("bob")
+      val carol = Player("carol")
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      val GameManager.LobbyCreated(gameId, host) = responseProbe.receiveMessage()
+      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbyJoined]
+      gm ! GameManager.StartGame(gameId, host.id, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.GameStarted]
+
+      // Carol is not seated in the game; her leave is rejected and the game stays live
+      gm ! GameManager.LeaveLobby(gameId, carol, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.MoveRejected]
+
+      gm ! GameManager.GetLobbyInfo(gameId, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.status shouldBe GameLifecycleStatus.InProgress
     }
 
     "handle a player trying to leave a nonexistent lobby" in {

--- a/game-service-server/src/test/scala/com/andy327/server/actors/tictactoe/TicTacToeActorSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/actors/tictactoe/TicTacToeActorSpec.scala
@@ -147,6 +147,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
         override def gameStatus: Any = "dummy"
         override def playerFor(playerId: PlayerId): Option[Any] = None
         override def moveCount: Int = 0
+        override def playerLeft(playerId: PlayerId): Either[GameError, Any] = Left(GameError.Unknown("not implemented"))
       }
 
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
@@ -406,6 +407,41 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       }
 
       gameManagerProbe.receiveMessage() shouldBe GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed)
+    }
+
+    "forfeit the game to the opponent when a player leaves, appending no move" in {
+      val gameManagerProbe = createTestProbe[GameManager.Command]()
+      val gameId: GameId = UUID.randomUUID()
+      val (actor, persistProbe) = newActor(gmRef = gameManagerProbe.ref, gameId = gameId)
+      val subscriberProbe = createTestProbe[PlayerActor.Command]()
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+
+      actor ! TurnBasedGameActor.Subscribe(subscriberProbe.ref, alice)
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial state push on subscribe
+
+      // Bob (O) leaves the in-progress game → Alice (X) wins by forfeit
+      actor ! TurnBasedGameActor.PlayerLeft(bob, replyProbe.ref)
+      val Right(GridGameState(_, _, winner, _)) = replyProbe.receiveMessage()
+      winner shouldBe Some("X")
+
+      // a forfeit saves a final snapshot but, unlike a move, appends nothing to the history log
+      persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+      persistProbe.expectNoMessage()
+
+      // the subscriber sees the finished state then the game-ended event; GameManager is notified
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe a[PlayerEvent.GameStateUpdated]
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe
+        PlayerEvent.GameEnded(GameLifecycleStatus.Completed)
+      gameManagerProbe.receiveMessage() shouldBe GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed)
+    }
+
+    "reject a leave from a player not in the game" in {
+      val eve: PlayerId = UUID.randomUUID()
+      val (actor, _) = newActor()
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+
+      actor ! TurnBasedGameActor.PlayerLeft(eve, replyProbe.ref)
+      replyProbe.receiveMessage() shouldBe Left(GameError.InvalidPlayer(eve))
     }
   }
 }

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/LobbyRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/LobbyRoutesSpec.scala
@@ -144,6 +144,41 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
       }
     }
 
+    "forfeit an in-progress game when a player leaves it" in {
+      val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].gameId
+      }
+      Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+      }
+      Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+      }
+
+      // Bob (O) leaves the live game: 200 with the finished game state, Alice (X) the winner
+      Post(s"/lobby/$gameId/leave").withHeaders(bobHeader) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+        responseAs[String] should include(""""winner":"X"""")
+      }
+    }
+
+    "reject a forfeit from a non-participant of an in-progress game" in {
+      val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].gameId
+      }
+      Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+      }
+      Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+      }
+
+      // Carl is not seated in the game; leaving is rejected with 409 and the game stays live
+      Post(s"/lobby/$gameId/leave").withHeaders(carlHeader) ~> routes ~> check {
+        status shouldBe StatusCodes.Conflict
+      }
+    }
+
     "reject leaving a lobby if the lobby does not exist" in {
       val fakeId = UUID.randomUUID()
 


### PR DESCRIPTION
Closes #28.

Leaving a game that has already started is now a supported action instead of being rejected with `409 GameInProgress`. For the three current (two-player) games, leaving means **forfeiting**: the leaver loses, the opponent wins, and the game transitions to `Won(opponent)` and runs through the existing completion machinery (final snapshot → `GameEnded` fan-out → `GameCompleted` → `MarkCompleted`) exactly as if it had ended by play. Because the right behavior is per-game-type (forfeit for two-player games; fold-out for future >2-player games), the transition lives in the `Game` model rather than as a special case in `LobbyManager`.

## Changes

- **Model:** added an abstract `Game.playerLeft(playerId): Either[GameError, State]`. Each game defines its own leave semantics; TicTacToe, ConnectFour, and Battleship implement it as a forfeit (rejecting a non-participant or an already-finished game). The returned state's `gameStatus` drives what happens next, so a terminal status completes the game and an `InProgress` status would continue it — the fold-out path is already supported for when a >2-player game arrives.
- **Actor:** added a `PlayerLeft` command to `TurnBasedGameActor` and a `forfeitCommand` to the `GameActor` trait. The forfeit reuses the same post-move completion path (snapshot, per-viewer `GameStateUpdated` fan-out, publish, completion) — but appends no move to the history log, since the winning result is derived rather than played.
- **Routing:** `GameManager.LeaveLobby` now routes to the game actor when the game is active (returning a new `GameForfeited` response) and forwards to `LobbyManager` otherwise, so pre-game leaves and host-cancels are unchanged. The lobby is moved to `Completed` by the normal `GameCompleted` → `MarkCompleted` flow.
- **HTTP:** `POST /lobby/{gameId}/leave` returns the leaver's final game state (`200`) on forfeit — distinct from the pre-game `LobbyLeft` — or `409` if the caller is not a participant.

## Testing

- New model tests cover the forfeit transition and its rejections (non-participant, already-finished) for all three games.
- New actor/manager/route tests cover the forfeit end to end: the opponent wins, subscribers receive `GameStateUpdated` then `GameEnded`, no move is appended, the lobby reaches `Completed`, and a non-participant's leave is rejected.
- Full suite green: model + server + persistence; `scalafmtCheckAll` clean.

## Deferred (tracked separately)

- Disconnect → forfeit with a reconnect grace period (would reuse `Game.playerLeft`).
- Host-boot/kick (needs an authorization and anti-walkover policy; pairs with the disconnect work).
- >2-player fold-out — the actor already handles a `Right(InProgress)` return, but no such game exists yet.
- "What am I in now" participation lookups (#36) and durable player identity / game history (#37).
