### PR TITLE
Add a browser UI for playing the games

### DIFF
--- a/game-service-server/src/main/resources/web/app.js
+++ b/game-service-server/src/main/resources/web/app.js
@@ -17,10 +17,11 @@ const session = {
   game: null // { gameId, gameType, isHost }
 };
 
-// Per-game-type knowledge the rest of the client stays agnostic to: display label and how a clicked cell becomes a move.
+// Per-game-type knowledge the rest of the client stays agnostic to: display label, how a click becomes a move, and
+// whether moves are made by picking a column (Connect Four) rather than an individual cell.
 const GAMES = {
   tictactoe: { label: "Tic-Tac-Toe", move: (row, col) => ({ row, col }) },
-  connectfour: { label: "Connect Four", move: (row, col) => ({ col }) }
+  connectfour: { label: "Connect Four", move: (row, col) => ({ col }), columns: true }
 };
 
 const $ = (id) => document.getElementById(id);
@@ -173,6 +174,7 @@ async function enterGame({ gameId, gameType, isHost }) {
   session.game = { gameId, gameType, isHost };
   $("game-title").textContent = GAMES[gameType].label;
   $("board").innerHTML = "";
+  $("column-controls").innerHTML = "";
   setError("game-error", "");
   $("start-game").classList.add("hidden");
   $("start-game").disabled = true;
@@ -267,7 +269,8 @@ function sendChat(text) {
 
 // --- Board rendering -------------------------------------------------------------------------------------------------
 // Renders any grid game-state view: board is rows of cell tokens (mark symbol or "" when empty). Clicks are optimistic —
-// the server validates turn/legality and rejects with a plain-text message we surface.
+// the server validates turn/legality and rejects with a plain-text message we surface. Column-based games (Connect Four)
+// are played via drop buttons above the board rather than by clicking individual cells.
 function renderBoard(state) {
   const board = $("board");
   $("start-game").classList.add("hidden"); // a live board means the game has started; Start no longer applies
@@ -277,13 +280,18 @@ function renderBoard(state) {
   board.innerHTML = "";
 
   const over = Boolean(state.winner) || state.draw === true;
+  const columnMode = Boolean(session.game && GAMES[session.game.gameType] && GAMES[session.game.gameType].columns);
+
+  renderColumnControls(columnMode ? cols : 0, rows, over);
 
   rows.forEach((cells, r) => {
     cells.forEach((mark, c) => {
       const cell = document.createElement("div");
-      cell.className = "cell" + (mark ? ` mark-${mark}` : "") + (over ? " disabled" : " clickable");
+      // In column mode the cells are display-only; you drop via the buttons above the board.
+      const clickable = !over && !columnMode;
+      cell.className = "cell" + (mark ? ` mark-${mark}` : "") + (clickable ? " clickable" : " disabled");
       cell.textContent = mark;
-      if (!over) cell.onclick = () => submitMove(r, c);
+      if (clickable) cell.onclick = () => submitMove(r, c);
       board.appendChild(cell);
     });
   });
@@ -291,6 +299,23 @@ function renderBoard(state) {
   if (state.winner) setStatus(`${state.winner} wins!`);
   else if (state.draw) setStatus("Draw.");
   else setStatus(`Turn: ${state.currentPlayer}`);
+}
+
+// Render one drop button per column above the board (for column-based games). Pass cols=0 to clear the controls for
+// cell-click games. A column whose top cell is filled is full, so its button is disabled.
+function renderColumnControls(cols, rows, over) {
+  const controls = $("column-controls");
+  controls.innerHTML = "";
+  if (cols === 0) return;
+  controls.style.setProperty("--cols", cols);
+  for (let c = 0; c < cols; c++) {
+    const btn = document.createElement("button");
+    btn.className = "col-btn";
+    btn.textContent = "▼";
+    btn.disabled = over || (rows[0] && rows[0][c] !== ""); // column full when its top cell is occupied
+    btn.onclick = () => submitMove(0, c); // row is ignored for column moves
+    controls.appendChild(btn);
+  }
 }
 
 async function submitMove(row, col) {

--- a/game-service-server/src/main/resources/web/app.js
+++ b/game-service-server/src/main/resources/web/app.js
@@ -106,7 +106,7 @@ function handleEvent(msg) {
       onGameEnded(msg.result);
       break;
     case "ChatMessage":
-      // Chat UI is a follow-up; ignore for now.
+      appendChat(msg);
       break;
     default:
       break;
@@ -147,11 +147,15 @@ async function refreshLobbies() {
   for (const lobby of lobbies) {
     const type = lobby.gameType.toLowerCase();
     const count = Object.keys(lobby.players).length;
+    const host = lobby.players[lobby.hostId]; // the host is always present in the players map
+    const hostName = host ? host.name : "unknown";
+    const mine = session.me && lobby.hostId === session.me.id;
     const li = document.createElement("li");
 
     const meta = document.createElement("span");
     meta.className = "meta";
-    meta.textContent = `${GAMES[type].label} — ${count}/2 players`;
+    meta.textContent =
+      `${GAMES[type].label} — hosted by ${hostName}${mine ? " (you)" : ""} — ${count}/2 players`;
 
     const join = document.createElement("button");
     join.textContent = "Join";
@@ -171,25 +175,34 @@ async function enterGame({ gameId, gameType, isHost }) {
   $("start-game").classList.add("hidden");
   $("start-game").disabled = true;
   setStatus(isHost ? "Waiting for an opponent to join…" : "Joined. Waiting for the host to start…");
+  $("chat-log").innerHTML = "";
   showPanel("game");
 
   const res = await api(`/lobby/${gameId}/subscribe`, { method: "POST", body: {} });
   if (!res.ok) setError("game-error", res.data?.error || res.data || "Could not subscribe to the lobby");
+  loadChatHistory(gameId, gameType);
 }
 
-// A pre-game lobby changed: refresh the player count and, for the host, enable Start once the lobby is ready.
+// A pre-game lobby changed: refresh the player count, surface the host, and (for the host) enable Start when ready.
 function onLobbyUpdated(metadata) {
   if (!session.game || metadata.gameId !== session.game.gameId) return;
-  const count = Object.keys(metadata.players).length;
   if (metadata.status === "InProgress") return; // game state pushes take over from here
 
-  if (session.game.isHost) {
+  const count = Object.keys(metadata.players).length;
+  const host = metadata.players[metadata.hostId];
+  const hostName = host ? host.name : "the host";
+  // The host role can migrate if the original host leaves a pre-game lobby, so re-derive it on every update.
+  const youHost = Boolean(session.me) && metadata.hostId === session.me.id;
+  session.game.isHost = youHost;
+
+  if (youHost) {
     const ready = metadata.status === "ReadyToStart";
     $("start-game").classList.remove("hidden");
     $("start-game").disabled = !ready;
-    setStatus(ready ? "Opponent joined — press Start." : `Waiting for an opponent… (${count}/2)`);
+    setStatus(ready ? "Opponent joined — press Start." : `You're hosting — waiting for an opponent… (${count}/2)`);
   } else {
-    setStatus("Waiting for the host to start…");
+    $("start-game").classList.add("hidden");
+    setStatus(`Hosted by ${hostName} — waiting for them to start… (${count}/2)`);
   }
 }
 
@@ -211,6 +224,40 @@ async function leaveGame() {
   session.game = null;
   showPanel("lobby");
   refreshLobbies();
+}
+
+// --- Chat ------------------------------------------------------------------------------------------------------------
+// Chat rides the same one-per-player WebSocket. Outbound messages are ClientMessage.ChatSend frames; the server fans
+// the resulting ChatMessage back to every subscriber (including the sender), so — like the board — we render purely
+// from received events rather than echoing locally.
+function appendChat(m) {
+  const log = $("chat-log");
+  const li = document.createElement("li");
+  li.className = "chat-msg" + (session.me && m.senderId === session.me.id ? " own" : "");
+
+  const who = document.createElement("span");
+  who.className = "chat-who";
+  who.textContent = m.senderName + ":";
+
+  const text = document.createElement("span");
+  text.className = "chat-text";
+  text.textContent = m.text; // textContent, never innerHTML, so message bodies can't inject markup
+
+  li.append(who, text);
+  log.appendChild(li);
+  log.scrollTop = log.scrollHeight; // keep the latest message in view
+}
+
+// Load the recent backscroll (oldest first) for a game/lobby; best-effort, so an empty or failed load is harmless.
+async function loadChatHistory(gameId, gameType) {
+  const res = await api(`/${gameType}/${gameId}/chat`);
+  if (res.ok && res.data && Array.isArray(res.data.messages)) res.data.messages.forEach(appendChat);
+}
+
+// Send a chat frame over the WebSocket. Requires an open socket and an active game/lobby context.
+function sendChat(text) {
+  if (!session.ws || session.ws.readyState !== WebSocket.OPEN || !session.game) return;
+  session.ws.send(JSON.stringify({ type: "ChatSend", gameId: session.game.gameId, text }));
 }
 
 // --- Board rendering -------------------------------------------------------------------------------------------------
@@ -291,3 +338,12 @@ for (const button of document.querySelectorAll("[data-gametype]")) {
 $("refresh-lobbies").addEventListener("click", refreshLobbies);
 $("start-game").addEventListener("click", startGame);
 $("leave-game").addEventListener("click", leaveGame);
+
+$("chat-form").addEventListener("submit", (e) => {
+  e.preventDefault();
+  const input = $("chat-input");
+  const text = input.value.trim();
+  if (!text) return;
+  sendChat(text);
+  input.value = "";
+});

--- a/game-service-server/src/main/resources/web/app.js
+++ b/game-service-server/src/main/resources/web/app.js
@@ -1,0 +1,293 @@
+"use strict";
+
+/*
+ * Minimal client for the Pekko game service. Plain JS, no build step, served same-origin with the API.
+ *
+ * Flow: authenticate() -> open one WebSocket -> create or join a lobby and subscribe to it -> the host starts the game.
+ * Lobby subscribers are carried over to the game actor on start, so each player begins receiving GameStateUpdated
+ * pushes automatically; this client never re-subscribes once a game begins. Moves are fired optimistically over REST
+ * and the board is redrawn purely from the WebSocket pushes, with the server as the sole authority on legality.
+ */
+
+// In-memory session state only; nothing is persisted to localStorage, so a refresh is a fresh session.
+const session = {
+  token: null,
+  me: null, // { id, name }
+  ws: null,
+  game: null // { gameId, gameType, isHost }
+};
+
+// Per-game-type knowledge the rest of the client stays agnostic to: display label and how a clicked cell becomes a move.
+const GAMES = {
+  tictactoe: { label: "Tic-Tac-Toe", move: (row, col) => ({ row, col }) },
+  connectfour: { label: "Connect Four", move: (row, col) => ({ col }) }
+};
+
+const $ = (id) => document.getElementById(id);
+
+// --- Auth seam -------------------------------------------------------------------------------------------------------
+// authenticate() is the single point that knows how a token is obtained. Today it registers a throwaway account so the
+// user only types a name; swapping in real email/password login later changes only this function and the login markup.
+async function authenticate(name) {
+  const suffix = (crypto.randomUUID && crypto.randomUUID()) || String(Date.now()) + Math.random();
+  const body = {
+    username: name,
+    email: `guest-${suffix}@example.invalid`,
+    password: `pw-${suffix}` // satisfies the 8–128 char rule; throwaway, never shown to the user
+  };
+  const res = await api("/auth/register", { method: "POST", body, auth: false });
+  if (!res.ok) throw new Error(res.data?.error || `Registration failed (${res.status})`);
+  session.token = res.data.token;
+
+  const who = await api("/auth/whoami");
+  if (!who.ok) throw new Error("Could not load profile");
+  session.me = who.data;
+}
+
+// --- HTTP helper -----------------------------------------------------------------------------------------------------
+// Returns { ok, status, data } where data is parsed JSON when the response is JSON, otherwise the raw text (the API
+// returns plain-text bodies for move rejections and other errors).
+async function api(path, opts = {}) {
+  const { method = "GET", body, auth = true } = opts;
+  const headers = {};
+  if (body !== undefined) headers["Content-Type"] = "application/json";
+  if (auth && session.token) headers["Authorization"] = `Bearer ${session.token}`;
+
+  const res = await fetch(path, { method, headers, body: body !== undefined ? JSON.stringify(body) : undefined });
+  const text = await res.text();
+  const isJson = (res.headers.get("content-type") || "").includes("application/json");
+  let data = text;
+  if (isJson && text) {
+    try {
+      data = JSON.parse(text);
+    } catch (_) {
+      data = text;
+    }
+  }
+  return { ok: res.ok, status: res.status, data };
+}
+
+// --- WebSocket -------------------------------------------------------------------------------------------------------
+// One socket per player. The browser WebSocket API cannot set headers, so the JWT travels as the access_token query
+// parameter (the server accepts it there for /ws only). Resolves once the socket is open so subscribe calls — which
+// require a registered PlayerActor — never race ahead of the connection.
+function connectWs() {
+  return new Promise((resolve, reject) => {
+    const proto = location.protocol === "https:" ? "wss" : "ws";
+    const ws = new WebSocket(`${proto}://${location.host}/ws?access_token=${encodeURIComponent(session.token)}`);
+    session.ws = ws;
+    ws.onopen = () => resolve();
+    ws.onerror = (e) => reject(e);
+    ws.onclose = () => {
+      session.ws = null;
+    };
+    ws.onmessage = (ev) => {
+      let msg;
+      try {
+        msg = JSON.parse(ev.data);
+      } catch (_) {
+        return;
+      }
+      handleEvent(msg);
+    };
+  });
+}
+
+// Dispatch a server push by its tagged type. Only events relevant to the single active game/lobby are acted on.
+function handleEvent(msg) {
+  switch (msg.type) {
+    case "LobbyUpdated":
+      onLobbyUpdated(msg.metadata);
+      break;
+    case "GameStateUpdated":
+      renderBoard(msg.state);
+      break;
+    case "GameEnded":
+      onGameEnded(msg.result);
+      break;
+    case "ChatMessage":
+      // Chat UI is a follow-up; ignore for now.
+      break;
+    default:
+      break;
+  }
+}
+
+// --- Lobby -----------------------------------------------------------------------------------------------------------
+async function createGame(gameType) {
+  setError("lobby-error", "");
+  const res = await api(`/lobby/create/${gameType}`, { method: "POST", body: {} });
+  if (!res.ok) return setError("lobby-error", res.data?.error || res.data || "Could not create game");
+  await enterGame({ gameId: res.data.gameId, gameType, isHost: true });
+}
+
+async function joinGame(gameId, gameType) {
+  setError("lobby-error", "");
+  const res = await api(`/lobby/${gameId}/join`, { method: "POST", body: {} });
+  if (!res.ok) return setError("lobby-error", res.data?.error || res.data || "Could not join game");
+  await enterGame({ gameId, gameType, isHost: false });
+}
+
+async function refreshLobbies() {
+  setError("lobby-error", "");
+  const res = await api("/lobby/list");
+  const list = $("lobby-list");
+  list.innerHTML = "";
+  if (!res.ok) return setError("lobby-error", "Could not list lobbies");
+
+  const lobbies = (res.data.lobbies || []).filter((l) => GAMES[l.gameType.toLowerCase()]);
+  if (lobbies.length === 0) {
+    const li = document.createElement("li");
+    li.className = "meta";
+    li.textContent = "No open lobbies. Create one above.";
+    list.appendChild(li);
+    return;
+  }
+
+  for (const lobby of lobbies) {
+    const type = lobby.gameType.toLowerCase();
+    const count = Object.keys(lobby.players).length;
+    const li = document.createElement("li");
+
+    const meta = document.createElement("span");
+    meta.className = "meta";
+    meta.textContent = `${GAMES[type].label} — ${count}/2 players`;
+
+    const join = document.createElement("button");
+    join.textContent = "Join";
+    join.onclick = () => joinGame(lobby.gameId, type);
+
+    li.append(meta, join);
+    list.appendChild(li);
+  }
+}
+
+// Enter the game view for a lobby we just created or joined, then subscribe so we receive its push events.
+async function enterGame({ gameId, gameType, isHost }) {
+  session.game = { gameId, gameType, isHost };
+  $("game-title").textContent = GAMES[gameType].label;
+  $("board").innerHTML = "";
+  setError("game-error", "");
+  $("start-game").classList.add("hidden");
+  $("start-game").disabled = true;
+  setStatus(isHost ? "Waiting for an opponent to join…" : "Joined. Waiting for the host to start…");
+  showPanel("game");
+
+  const res = await api(`/lobby/${gameId}/subscribe`, { method: "POST", body: {} });
+  if (!res.ok) setError("game-error", res.data?.error || res.data || "Could not subscribe to the lobby");
+}
+
+// A pre-game lobby changed: refresh the player count and, for the host, enable Start once the lobby is ready.
+function onLobbyUpdated(metadata) {
+  if (!session.game || metadata.gameId !== session.game.gameId) return;
+  const count = Object.keys(metadata.players).length;
+  if (metadata.status === "InProgress") return; // game state pushes take over from here
+
+  if (session.game.isHost) {
+    const ready = metadata.status === "ReadyToStart";
+    $("start-game").classList.remove("hidden");
+    $("start-game").disabled = !ready;
+    setStatus(ready ? "Opponent joined — press Start." : `Waiting for an opponent… (${count}/2)`);
+  } else {
+    setStatus("Waiting for the host to start…");
+  }
+}
+
+async function startGame() {
+  setError("game-error", "");
+  const res = await api(`/lobby/${session.game.gameId}/start`, { method: "POST", body: {} });
+  if (!res.ok) setError("game-error", res.data?.error || res.data || "Could not start the game");
+  // On success the game-state push arrives over the WebSocket and renders the board.
+}
+
+function onGameEnded(result) {
+  if (result === "Cancelled") setStatus("Game cancelled.");
+  // A "Completed" end is already reflected by the final GameStateUpdated (winner/draw), so leave that status in place.
+}
+
+async function leaveGame() {
+  const game = session.game;
+  if (game) await api(`/lobby/${game.gameId}/leave`, { method: "POST", body: {} });
+  session.game = null;
+  showPanel("lobby");
+  refreshLobbies();
+}
+
+// --- Board rendering -------------------------------------------------------------------------------------------------
+// Renders any grid game-state view: board is rows of cell tokens (mark symbol or "" when empty). Clicks are optimistic —
+// the server validates turn/legality and rejects with a plain-text message we surface.
+function renderBoard(state) {
+  const board = $("board");
+  const rows = state.board;
+  const cols = rows[0] ? rows[0].length : 0;
+  board.style.setProperty("--cols", cols);
+  board.innerHTML = "";
+
+  const over = Boolean(state.winner) || state.draw === true;
+
+  rows.forEach((cells, r) => {
+    cells.forEach((mark, c) => {
+      const cell = document.createElement("div");
+      cell.className = "cell" + (mark ? ` mark-${mark}` : "") + (over ? " disabled" : " clickable");
+      cell.textContent = mark;
+      if (!over) cell.onclick = () => submitMove(r, c);
+      board.appendChild(cell);
+    });
+  });
+
+  if (state.winner) setStatus(`${state.winner} wins!`);
+  else if (state.draw) setStatus("Draw.");
+  else setStatus(`Turn: ${state.currentPlayer}`);
+}
+
+async function submitMove(row, col) {
+  const game = session.game;
+  if (!game) return;
+  setError("game-error", "");
+  const payload = GAMES[game.gameType].move(row, col);
+  const res = await api(`/${game.gameType}/${game.gameId}/move`, { method: "POST", body: payload });
+  // Successful moves redraw via the WebSocket push; only failures need surfacing here.
+  if (!res.ok) setError("game-error", res.data?.error || res.data || "Move rejected");
+}
+
+// --- View helpers ----------------------------------------------------------------------------------------------------
+function showPanel(name) {
+  for (const id of ["login", "lobby", "game"]) $(id).classList.toggle("hidden", id !== name);
+}
+
+function setStatus(text) {
+  $("game-status").textContent = text;
+}
+
+function setError(id, text) {
+  $(id).textContent = text;
+}
+
+// --- Wiring ----------------------------------------------------------------------------------------------------------
+$("login-form").addEventListener("submit", async (e) => {
+  e.preventDefault();
+  setError("login-error", "");
+  const name = $("name").value.trim();
+  if (!name) return;
+  const button = e.target.querySelector("button");
+  button.disabled = true;
+  try {
+    await authenticate(name);
+    await connectWs();
+    $("whoami").textContent = `Signed in as ${session.me.name}`;
+    showPanel("lobby");
+    refreshLobbies();
+  } catch (err) {
+    setError("login-error", err.message || "Sign-in failed");
+  } finally {
+    button.disabled = false;
+  }
+});
+
+for (const button of document.querySelectorAll("[data-gametype]")) {
+  button.addEventListener("click", () => createGame(button.dataset.gametype));
+}
+
+$("refresh-lobbies").addEventListener("click", refreshLobbies);
+$("start-game").addEventListener("click", startGame);
+$("leave-game").addEventListener("click", leaveGame);

--- a/game-service-server/src/main/resources/web/app.js
+++ b/game-service-server/src/main/resources/web/app.js
@@ -188,7 +188,10 @@ async function enterGame({ gameId, gameType, isHost }) {
 // A pre-game lobby changed: refresh the player count, surface the host, and (for the host) enable Start when ready.
 function onLobbyUpdated(metadata) {
   if (!session.game || metadata.gameId !== session.game.gameId) return;
-  if (metadata.status === "InProgress") return; // game state pushes take over from here
+  if (metadata.status === "InProgress") {
+    $("start-game").classList.add("hidden"); // the game is live; Start no longer applies
+    return; // game state pushes take over from here
+  }
 
   const count = Object.keys(metadata.players).length;
   const host = metadata.players[metadata.hostId];
@@ -267,6 +270,7 @@ function sendChat(text) {
 // the server validates turn/legality and rejects with a plain-text message we surface.
 function renderBoard(state) {
   const board = $("board");
+  $("start-game").classList.add("hidden"); // a live board means the game has started; Start no longer applies
   const rows = state.board;
   const cols = rows[0] ? rows[0].length : 0;
   board.style.setProperty("--cols", cols);

--- a/game-service-server/src/main/resources/web/app.js
+++ b/game-service-server/src/main/resources/web/app.js
@@ -130,7 +130,9 @@ async function joinGame(gameId, gameType) {
 
 async function refreshLobbies() {
   setError("lobby-error", "");
-  const res = await api("/lobby/list");
+  // The server filters by game type when a `gameType` query param is supplied; empty means all types.
+  const filter = $("lobby-filter").value;
+  const res = await api(`/lobby/list${filter ? `?gameType=${filter}` : ""}`);
   const list = $("lobby-list");
   list.innerHTML = "";
   if (!res.ok) return setError("lobby-error", "Could not list lobbies");
@@ -139,7 +141,7 @@ async function refreshLobbies() {
   if (lobbies.length === 0) {
     const li = document.createElement("li");
     li.className = "meta";
-    li.textContent = "No open lobbies. Create one above.";
+    li.textContent = filter ? "No open lobbies for this game. Create one above." : "No open lobbies. Create one above.";
     list.appendChild(li);
     return;
   }
@@ -336,6 +338,7 @@ for (const button of document.querySelectorAll("[data-gametype]")) {
 }
 
 $("refresh-lobbies").addEventListener("click", refreshLobbies);
+$("lobby-filter").addEventListener("change", refreshLobbies);
 $("start-game").addEventListener("click", startGame);
 $("leave-game").addEventListener("click", leaveGame);
 

--- a/game-service-server/src/main/resources/web/app.js
+++ b/game-service-server/src/main/resources/web/app.js
@@ -118,14 +118,14 @@ function handleEvent(msg) {
 async function createGame(gameType) {
   setError("lobby-error", "");
   const res = await api(`/lobby/create/${gameType}`, { method: "POST", body: {} });
-  if (!res.ok) return setError("lobby-error", res.data?.error || res.data || "Could not create game");
+  if (!res.ok) return flashError("lobby-error", res.data?.error || res.data || "Could not create game");
   await enterGame({ gameId: res.data.gameId, gameType, isHost: true });
 }
 
 async function joinGame(gameId, gameType) {
   setError("lobby-error", "");
   const res = await api(`/lobby/${gameId}/join`, { method: "POST", body: {} });
-  if (!res.ok) return setError("lobby-error", res.data?.error || res.data || "Could not join game");
+  if (!res.ok) return flashError("lobby-error", res.data?.error || res.data || "Could not join game");
   await enterGame({ gameId, gameType, isHost: false });
 }
 
@@ -136,7 +136,7 @@ async function refreshLobbies() {
   const res = await api(`/lobby/list${filter ? `?gameType=${filter}` : ""}`);
   const list = $("lobby-list");
   list.innerHTML = "";
-  if (!res.ok) return setError("lobby-error", "Could not list lobbies");
+  if (!res.ok) return flashError("lobby-error", "Could not list lobbies");
 
   const lobbies = (res.data.lobbies || []).filter((l) => GAMES[l.gameType.toLowerCase()]);
   if (lobbies.length === 0) {
@@ -183,7 +183,7 @@ async function enterGame({ gameId, gameType, isHost }) {
   showPanel("game");
 
   const res = await api(`/lobby/${gameId}/subscribe`, { method: "POST", body: {} });
-  if (!res.ok) setError("game-error", res.data?.error || res.data || "Could not subscribe to the lobby");
+  if (!res.ok) flashError("game-error", res.data?.error || res.data || "Could not subscribe to the lobby");
   loadChatHistory(gameId, gameType);
 }
 
@@ -216,7 +216,7 @@ function onLobbyUpdated(metadata) {
 async function startGame() {
   setError("game-error", "");
   const res = await api(`/lobby/${session.game.gameId}/start`, { method: "POST", body: {} });
-  if (!res.ok) setError("game-error", res.data?.error || res.data || "Could not start the game");
+  if (!res.ok) flashError("game-error", res.data?.error || res.data || "Could not start the game");
   // On success the game-state push arrives over the WebSocket and renders the board.
 }
 
@@ -274,6 +274,7 @@ function sendChat(text) {
 function renderBoard(state) {
   const board = $("board");
   $("start-game").classList.add("hidden"); // a live board means the game has started; Start no longer applies
+  setError("game-error", ""); // the state changed, so any prior move error (e.g. "not your turn") is now stale
   const rows = state.board;
   const cols = rows[0] ? rows[0].length : 0;
   board.style.setProperty("--cols", cols);
@@ -325,7 +326,7 @@ async function submitMove(row, col) {
   const payload = GAMES[game.gameType].move(row, col);
   const res = await api(`/${game.gameType}/${game.gameId}/move`, { method: "POST", body: payload });
   // Successful moves redraw via the WebSocket push; only failures need surfacing here.
-  if (!res.ok) setError("game-error", res.data?.error || res.data || "Move rejected");
+  if (!res.ok) flashError("game-error", res.data?.error || res.data || "Move rejected");
 }
 
 // --- View helpers ----------------------------------------------------------------------------------------------------
@@ -339,6 +340,15 @@ function setStatus(text) {
 
 function setError(id, text) {
   $(id).textContent = text;
+  clearTimeout(errorTimers[id]); // cancel any pending auto-dismiss; an explicit set/clear wins
+}
+
+// Show a transient error that auto-dismisses after a few seconds, so a rejected action (e.g. an illegal move that
+// triggers no state update to clear it) doesn't leave a message stranded on screen.
+const errorTimers = {};
+function flashError(id, text) {
+  setError(id, text);
+  if (text) errorTimers[id] = setTimeout(() => setError(id, ""), 5000);
 }
 
 // --- Wiring ----------------------------------------------------------------------------------------------------------

--- a/game-service-server/src/main/resources/web/app.js
+++ b/game-service-server/src/main/resources/web/app.js
@@ -178,6 +178,8 @@ async function enterGame({ gameId, gameType, isHost }) {
   setError("game-error", "");
   $("start-game").classList.add("hidden");
   $("start-game").disabled = true;
+  clearTimeout(copyLinkTimer);
+  $("copy-link").textContent = COPY_LINK_LABEL;
   setStatus(isHost ? "Waiting for an opponent to join…" : "Joined. Waiting for the host to start…");
   $("chat-log").innerHTML = "";
   showPanel("game");
@@ -329,6 +331,60 @@ async function submitMove(row, col) {
   if (!res.ok) flashError("game-error", res.data?.error || res.data || "Move rejected");
 }
 
+// --- Deep links ------------------------------------------------------------------------------------------------------
+// A shareable URL hash (#join/<gameId>) drops a visitor straight into a specific lobby. The hash keeps the request on
+// the static-served `/` route (a path like /lobby/<id> is a JSON API route). It is captured once at load and consumed
+// after the visitor signs in, since joining needs a token and an open WebSocket.
+// Parse a #join/<gameId> invite hash, or null. Captured at load and also watched live via hashchange below.
+function parseJoinHash() {
+  return (location.hash.match(/^#join\/([0-9a-fA-F-]+)$/) || [])[1] || null;
+}
+
+// A pending invite to consume once the visitor is signed in. Set from the initial hash and from later hash changes.
+let pendingJoinGameId = parseJoinHash();
+if (pendingJoinGameId) history.replaceState(null, "", location.pathname + location.search);
+
+// Following an invite link while the page is already open changes only the hash (no reload). If we're already signed
+// in, join right away; otherwise hold it until sign-in. A link opened in a fresh tab is a full load, which — with the
+// in-memory-only token — always starts at sign-in.
+window.addEventListener("hashchange", () => {
+  const id = parseJoinHash();
+  if (!id) return;
+  history.replaceState(null, "", location.pathname + location.search);
+  if (session.me) joinByGameId(id);
+  else pendingJoinGameId = id;
+});
+
+// Join the lobby named by a deep link: look up its game type, then join — falling back to the lobby list on any issue.
+async function joinByGameId(gameId) {
+  showPanel("lobby");
+  refreshLobbies();
+  const res = await api(`/lobby/${gameId}`);
+  if (!res.ok) return flashError("lobby-error", "That lobby is no longer available.");
+  const type = res.data.gameType.toLowerCase();
+  if (!GAMES[type]) return flashError("lobby-error", "That game isn't supported in the web UI yet.");
+  joinGame(gameId, type);
+}
+
+// Copy a shareable invite link for the current lobby/game to the clipboard, with a prompt() fallback. Briefly flips the
+// button label to confirm; uses a fixed label and a single tracked timer so a quick re-click or game switch can't leave
+// it stuck on "Link copied!".
+const COPY_LINK_LABEL = "Copy invite link";
+let copyLinkTimer;
+async function copyInviteLink() {
+  if (!session.game) return;
+  const link = `${location.origin}/#join/${session.game.gameId}`;
+  const btn = $("copy-link");
+  try {
+    await navigator.clipboard.writeText(link);
+    btn.textContent = "Link copied!";
+    clearTimeout(copyLinkTimer);
+    copyLinkTimer = setTimeout(() => (btn.textContent = COPY_LINK_LABEL), 1500);
+  } catch (_) {
+    window.prompt("Copy this invite link:", link);
+  }
+}
+
 // --- View helpers ----------------------------------------------------------------------------------------------------
 function showPanel(name) {
   for (const id of ["login", "lobby", "game"]) $(id).classList.toggle("hidden", id !== name);
@@ -363,8 +419,14 @@ $("login-form").addEventListener("submit", async (e) => {
     await authenticate(name);
     await connectWs();
     $("whoami").textContent = `Signed in as ${session.me.name}`;
-    showPanel("lobby");
-    refreshLobbies();
+    if (pendingJoinGameId) {
+      const id = pendingJoinGameId;
+      pendingJoinGameId = null;
+      joinByGameId(id); // arrived via an invite link — go straight to that lobby
+    } else {
+      showPanel("lobby");
+      refreshLobbies();
+    }
   } catch (err) {
     setError("login-error", err.message || "Sign-in failed");
   } finally {
@@ -380,6 +442,7 @@ $("refresh-lobbies").addEventListener("click", refreshLobbies);
 $("lobby-filter").addEventListener("change", refreshLobbies);
 $("start-game").addEventListener("click", startGame);
 $("leave-game").addEventListener("click", leaveGame);
+$("copy-link").addEventListener("click", copyInviteLink);
 
 $("chat-form").addEventListener("submit", (e) => {
   e.preventDefault();

--- a/game-service-server/src/main/resources/web/index.html
+++ b/game-service-server/src/main/resources/web/index.html
@@ -33,6 +33,12 @@
     </div>
     <div class="row">
       <button id="refresh-lobbies">Refresh open lobbies</button>
+      <label for="lobby-filter">Show:</label>
+      <select id="lobby-filter">
+        <option value="">All games</option>
+        <option value="tictactoe">Tic-Tac-Toe</option>
+        <option value="connectfour">Connect Four</option>
+      </select>
     </div>
     <ul id="lobby-list"></ul>
     <p id="lobby-error" class="error"></p>

--- a/game-service-server/src/main/resources/web/index.html
+++ b/game-service-server/src/main/resources/web/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Pekko Game Service</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>Pekko Game Service</h1>
+    <span id="whoami" class="whoami"></span>
+  </header>
+
+  <!-- Login screen: a single name field. authenticate() hides the real signup behind it. -->
+  <section id="login" class="panel">
+    <h2>Quick start</h2>
+    <p>Pick a display name to jump in. (A throwaway account is created behind the scenes.)</p>
+    <form id="login-form">
+      <input id="name" type="text" placeholder="Your name" autocomplete="off" required />
+      <button type="submit">Play</button>
+    </form>
+    <p id="login-error" class="error"></p>
+  </section>
+
+  <!-- Lobby screen: create a game, or refresh and join an open one. -->
+  <section id="lobby" class="panel hidden">
+    <h2>Lobbies</h2>
+    <div class="row">
+      <span>New game:</span>
+      <button data-gametype="tictactoe">Tic-Tac-Toe</button>
+      <button data-gametype="connectfour">Connect Four</button>
+    </div>
+    <div class="row">
+      <button id="refresh-lobbies">Refresh open lobbies</button>
+    </div>
+    <ul id="lobby-list"></ul>
+    <p id="lobby-error" class="error"></p>
+  </section>
+
+  <!-- Game screen: live board, status line, controls. -->
+  <section id="game" class="panel hidden">
+    <h2 id="game-title"></h2>
+    <p id="game-status" class="status"></p>
+    <div id="board"></div>
+    <div class="row">
+      <button id="start-game" class="hidden">Start game</button>
+      <button id="leave-game">Leave</button>
+    </div>
+    <p id="game-error" class="error"></p>
+  </section>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/game-service-server/src/main/resources/web/index.html
+++ b/game-service-server/src/main/resources/web/index.html
@@ -53,6 +53,7 @@
     <div id="board"></div>
     <div class="row">
       <button id="start-game" class="hidden">Start game</button>
+      <button id="copy-link">Copy invite link</button>
       <button id="leave-game">Leave</button>
     </div>
     <p id="game-error" class="error"></p>

--- a/game-service-server/src/main/resources/web/index.html
+++ b/game-service-server/src/main/resources/web/index.html
@@ -48,6 +48,8 @@
   <section id="game" class="panel hidden">
     <h2 id="game-title"></h2>
     <p id="game-status" class="status"></p>
+    <!-- Drop buttons for column-based games (Connect Four); empty (and hidden) for cell-click games. -->
+    <div id="column-controls"></div>
     <div id="board"></div>
     <div class="row">
       <button id="start-game" class="hidden">Start game</button>

--- a/game-service-server/src/main/resources/web/index.html
+++ b/game-service-server/src/main/resources/web/index.html
@@ -48,6 +48,15 @@
       <button id="leave-game">Leave</button>
     </div>
     <p id="game-error" class="error"></p>
+
+    <!-- Chat: works while waiting in the lobby and during the game (the server routes by game phase). -->
+    <div id="chat">
+      <ul id="chat-log"></ul>
+      <form id="chat-form" class="row">
+        <input id="chat-input" type="text" placeholder="Message…" autocomplete="off" maxlength="500" />
+        <button type="submit">Send</button>
+      </form>
+    </div>
   </section>
 
   <script src="app.js"></script>

--- a/game-service-server/src/main/resources/web/style.css
+++ b/game-service-server/src/main/resources/web/style.css
@@ -121,6 +121,26 @@ button:disabled { opacity: 0.5; cursor: default; }
 .cell.mark-R { color: var(--error); }
 .cell.mark-Y { color: #f5c451; }
 
+/* Drop buttons for column-based games (Connect Four), aligned to the board columns. */
+#column-controls {
+  display: grid;
+  grid-template-columns: repeat(var(--cols, 7), 1fr);
+  gap: 4px;
+  max-width: 360px;
+  margin: 1rem 0 0;
+}
+
+#column-controls:empty { display: none; }
+
+/* When the drop buttons are present, pull the board up snug beneath them. */
+#column-controls:not(:empty) + #board { margin-top: 4px; }
+
+.col-btn {
+  padding: 0.3rem 0;
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
 /* Chat */
 #chat { margin-top: 1rem; }
 

--- a/game-service-server/src/main/resources/web/style.css
+++ b/game-service-server/src/main/resources/web/style.css
@@ -120,3 +120,24 @@ button:disabled { opacity: 0.5; cursor: default; }
 .cell.mark-O { color: var(--o); }
 .cell.mark-R { color: var(--error); }
 .cell.mark-Y { color: #f5c451; }
+
+/* Chat */
+#chat { margin-top: 1rem; }
+
+#chat-log {
+  list-style: none;
+  margin: 0 0 0.5rem;
+  padding: 0.4rem 0.6rem;
+  max-height: 180px;
+  overflow-y: auto;
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+}
+
+.chat-msg { padding: 0.15rem 0; word-break: break-word; }
+.chat-who { color: var(--muted); font-weight: 600; margin-right: 0.4rem; }
+.chat-msg.own .chat-who { color: var(--accent); }
+.chat-text { color: var(--text); }
+
+#chat-input { flex: 1; }

--- a/game-service-server/src/main/resources/web/style.css
+++ b/game-service-server/src/main/resources/web/style.css
@@ -1,0 +1,122 @@
+:root {
+  --bg: #11151c;
+  --panel: #1b212b;
+  --line: #2c3543;
+  --text: #e6edf3;
+  --muted: #8b97a7;
+  --accent: #4f9cf9;
+  --accent-dim: #2f6dc0;
+  --error: #ff6b6b;
+  --x: #ff8c5a;
+  --o: #4f9cf9;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.5;
+}
+
+header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--line);
+}
+
+header h1 { font-size: 1.2rem; margin: 0; }
+
+.whoami { color: var(--muted); font-size: 0.9rem; }
+
+.panel {
+  max-width: 640px;
+  margin: 1.5rem auto;
+  padding: 1.25rem 1.5rem;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+}
+
+.panel h2 { margin-top: 0; }
+
+.hidden { display: none !important; }
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin: 0.75rem 0;
+}
+
+input[type="text"] {
+  padding: 0.5rem 0.7rem;
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 1rem;
+}
+
+button {
+  padding: 0.5rem 0.9rem;
+  background: var(--accent-dim);
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+button:hover { background: var(--accent); }
+button:disabled { opacity: 0.5; cursor: default; }
+
+.status { color: var(--accent); font-weight: 600; min-height: 1.5em; }
+.error { color: var(--error); min-height: 1.2em; margin: 0.5rem 0 0; }
+
+#lobby-list { list-style: none; padding: 0; margin: 0.5rem 0 0; }
+#lobby-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.7rem;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  margin-bottom: 0.4rem;
+}
+#lobby-list .meta { color: var(--muted); font-size: 0.9rem; }
+
+/* Board: a grid of square cells sized from the --cols custom property. */
+#board {
+  display: grid;
+  grid-template-columns: repeat(var(--cols, 3), 1fr);
+  gap: 4px;
+  max-width: 360px;
+  margin: 1rem 0;
+}
+
+.cell {
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.8rem;
+  font-weight: 700;
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.cell.clickable:hover { border-color: var(--accent); }
+.cell.disabled { cursor: default; }
+.cell.mark-X { color: var(--x); }
+.cell.mark-O { color: var(--o); }
+.cell.mark-R { color: var(--error); }
+.cell.mark-Y { color: #f5c451; }

--- a/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
@@ -45,6 +45,7 @@ import com.andy327.server.http.routes.{
   LobbyRoutes,
   MetricsRoutes,
   PlayerRoutes,
+  StaticRoutes,
   WebSocketRoutes
 }
 import com.andy327.server.pubsub.RedisPubSubResource
@@ -143,7 +144,9 @@ object GameServer {
       new GameRoutes(GameType.ConnectFour, system).routes,
       new GameRoutes(GameType.Battleship, system).routes,
       new WebSocketRoutes(system).routes,
-      new MetricsRoutes(metricsRegistry).routes
+      new MetricsRoutes(metricsRegistry).routes,
+      // Static web UI; composed last so its catch-all resource lookup never shadows an API route
+      new StaticRoutes().routes
     )
 
     // Start HTTP server

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/StaticRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/StaticRoutes.scala
@@ -1,0 +1,25 @@
+package com.andy327.server.http.routes
+
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.http.scaladsl.server.Route
+
+/** Serves the static web UI bundled under `src/main/resources/web` on the classpath.
+  *
+  * The UI is plain HTML/CSS/JS with no build step, served same-origin with the API so the browser needs no CORS
+  * handling and can talk to the REST and WebSocket endpoints directly. These routes must be composed last (after the API
+  * routes) so the catch-all resource lookup only handles paths no API route claimed.
+  *
+  * Route Summary:
+  *   - GET / - the application shell (`web/index.html`)
+  *   - GET /{file} - any other asset under `web/` (e.g. `app.js`, `style.css`)
+  */
+class StaticRoutes {
+
+  val routes: Route =
+    concat(
+      pathSingleSlash {
+        getFromResource("web/index.html")
+      },
+      getFromResourceDirectory("web")
+    )
+}

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/StaticRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/StaticRoutes.scala
@@ -1,5 +1,6 @@
 package com.andy327.server.http.routes
 
+import org.apache.pekko.http.scaladsl.model.headers.{`Cache-Control`, CacheDirectives}
 import org.apache.pekko.http.scaladsl.server.Directives._
 import org.apache.pekko.http.scaladsl.server.Route
 
@@ -15,11 +16,20 @@ import org.apache.pekko.http.scaladsl.server.Route
   */
 class StaticRoutes {
 
+  /** Classpath resources carry a fixed, ancient `Last-Modified`, which browsers turn into a multi-year heuristic
+    * freshness window — so an updated `app.js`/`index.html` is served from cache and never picked up. `no-cache` forces
+    * the browser to revalidate every request; the resource directives still answer conditional GETs with a cheap `304`,
+    * so this costs a round-trip but no payload when the asset is unchanged.
+    */
+  private val revalidate = `Cache-Control`(CacheDirectives.`no-cache`)
+
   val routes: Route =
-    concat(
-      pathSingleSlash {
-        getFromResource("web/index.html")
-      },
-      getFromResourceDirectory("web")
-    )
+    respondWithHeader(revalidate) {
+      concat(
+        pathSingleSlash {
+          getFromResource("web/index.html")
+        },
+        getFromResourceDirectory("web")
+      )
+    }
 }

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/StaticRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/StaticRoutesSpec.scala
@@ -1,0 +1,33 @@
+package com.andy327.server.http.routes
+
+import org.apache.pekko.http.scaladsl.model.{ContentTypes, StatusCodes}
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class StaticRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
+
+  val routes: Route = new StaticRoutes().routes
+
+  "StaticRoutes" should {
+    "serve the application shell at the root path" in
+      Get("/") ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+        contentType shouldBe ContentTypes.`text/html(UTF-8)`
+        responseAs[String] should include("Pekko Game Service")
+      }
+
+    "serve the client script with a JavaScript content type" in
+      Get("/app.js") ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+        mediaType.subType shouldBe "javascript"
+        responseAs[String] should include("authenticate")
+      }
+
+    "reject an unknown asset path" in
+      Get("/does-not-exist.js") ~> routes ~> check {
+        handled shouldBe false
+      }
+  }
+}

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/StaticRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/StaticRoutesSpec.scala
@@ -1,5 +1,6 @@
 package com.andy327.server.http.routes
 
+import org.apache.pekko.http.scaladsl.model.headers.{`Cache-Control`, CacheDirectives}
 import org.apache.pekko.http.scaladsl.model.{ContentTypes, StatusCodes}
 import org.apache.pekko.http.scaladsl.server.Route
 import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
@@ -23,6 +24,11 @@ class StaticRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest
         status shouldBe StatusCodes.OK
         mediaType.subType shouldBe "javascript"
         responseAs[String] should include("authenticate")
+      }
+
+    "tell browsers to revalidate assets so an updated UI is never served stale" in
+      Get("/app.js") ~> routes ~> check {
+        header[`Cache-Control`].map(_.directives) shouldBe Some(Seq(CacheDirectives.`no-cache`))
       }
 
     "reject an unknown asset path" in


### PR DESCRIPTION
Adds a plain HTML/CSS/JS web UI (no framework, no build step) served same-origin by Pekko HTTP, so the game service can be played in a browser instead of only via raw HTTP/WebSocket calls. Builds on the `access_token` WebSocket auth already on `main` (browsers can't set the handshake's `Authorization` header).

## What's included
- **Static serving** — `StaticRoutes` serves `web/` from the classpath, composed last so it never shadows an API route; `Cache-Control: no-cache` so an updated UI is never served stale.
- **Quick-start auth** — a single name field; `authenticate()` registers a throwaway account and keeps the token in memory only. Isolated behind one function so swapping in real login later is localized.
- **Play grid games** — create/join/start lobbies and play Tic-Tac-Toe and Connect Four, with live board updates pushed over a single per-player WebSocket. Connect Four uses per-column drop buttons.
- **Lobby chat** — works in the waiting room and in-game, with backscroll on join.
- **Lobby quality-of-life** — host shown in the list and waiting room (with a "(you)" marker), filter by game type, and shareable `#join/<id>` invite links.
- **UX fixes** — Start button hidden once a game is underway; transient errors clear on state change and auto-dismiss.

## Design notes
- Same-origin (Pekko serves the UI), so no CORS; the board is redrawn purely from server pushes (server stays authoritative).
- One WebSocket per player; lobby subscribers are carried over to the game on start, so no re-subscribe is needed.

## Testing
- `sbt server/test` — 184 passing (incl. `StaticRoutesSpec`, `JwtPlayerDirectivesSpec`).
- Manually verified two-player create/join/start/play/chat for both grid games, the invite-link flow, and error/turn handling.

## Out of scope (follow-ups)
- Battleship in the UI; a real email/password login form; a "my current sessions" panel.
- Backend: lobby creation timestamps, startup cleanup of stale lobbies, and post-game rooms (chat-after-end + rematch).