### PR TITLE
Add post-game rooms with rematch, and a RoomId/MatchId identifier sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ $ http POST :8080/auth/register username=bob   email=bob@example.com   password=
 { "token": "eyJhbGciOi..." }   // save Alice's as $ALICE and Bob's as $BOB
 ```
 
-Alice creates a Tic-Tac-Toe lobby (she becomes the host); the response carries the new `gameId`:
+Alice creates a Tic-Tac-Toe lobby (she becomes the host); the response carries the new `roomId`:
 
 ```
 $ http POST :8080/lobby/create/tictactoe "Authorization: Bearer $ALICE"
@@ -148,14 +148,14 @@ $ http POST :8080/lobby/create/tictactoe "Authorization: Bearer $ALICE"
 Bob joins it, then Alice — the host — starts the match:
 
 ```
-$ http POST :8080/lobby/$GAME_ID/join  "Authorization: Bearer $BOB"
-$ http POST :8080/lobby/$GAME_ID/start "Authorization: Bearer $ALICE"
+$ http POST :8080/lobby/$ROOM_ID/join  "Authorization: Bearer $BOB"
+$ http POST :8080/lobby/$ROOM_ID/start "Authorization: Bearer $ALICE"
 ```
 
 Now play. Moves are game-specific JSON; for Tic-Tac-Toe that's a zero-based `(row, col)`, with `(0,0)` at the top-left. Alice (X) takes the center:
 
 ```
-$ http POST :8080/tictactoe/$GAME_ID/move "Authorization: Bearer $ALICE" row:=1 col:=1
+$ http POST :8080/tictactoe/$ROOM_ID/move "Authorization: Bearer $ALICE" row:=1 col:=1
 ```
 
 The response is the updated board, and every connected participant is pushed the new state over their WebSocket in real time (see [API reference](#api-reference) for the `/ws` protocol). Bob can reply with his own `move`, and so on until someone wins or the board fills.
@@ -179,22 +179,22 @@ All gameplay endpoints require a `Authorization: Bearer <jwt>` header; obtain a 
 |--------|------|-------------|
 | `POST`   | `/lobby/create/{gameType}` | Create a lobby for a game type; the caller becomes host |
 | `GET`    | `/lobby/list` | List all open lobbies |
-| `GET`    | `/lobby/{gameId}` | Fetch metadata for one lobby |
-| `POST`   | `/lobby/{gameId}/join` | Join an open lobby |
-| `POST`   | `/lobby/{gameId}/leave` | Leave a lobby (or forfeit an in-progress game) |
-| `POST`   | `/lobby/{gameId}/start` | Start the match (host only); also doubles as the rematch call when the room is in its post-game `Finished` state |
-| `DELETE` | `/lobby/{gameId}` | Cancel a pre-game lobby (host only) |
-| `POST` / `DELETE` | `/lobby/{gameId}/subscribe` | Start / stop spectating a lobby's push events |
+| `GET`    | `/lobby/{roomId}` | Fetch metadata for one lobby |
+| `POST`   | `/lobby/{roomId}/join` | Join an open lobby |
+| `POST`   | `/lobby/{roomId}/leave` | Leave a lobby (or forfeit an in-progress game) |
+| `POST`   | `/lobby/{roomId}/start` | Start the match (host only); also doubles as the rematch call when the room is in its post-game `Finished` state |
+| `DELETE` | `/lobby/{roomId}` | Cancel a pre-game lobby (host only) |
+| `POST` / `DELETE` | `/lobby/{roomId}/subscribe` | Start / stop spectating a lobby's push events |
 
 ### Gameplay
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `POST`   | `/{gameType}/{gameId}/move` | Submit a move; payload shape is game-specific (e.g. `{ "row": 1, "col": 1 }` for Tic-Tac-Toe) |
-| `GET`    | `/{gameType}/{gameId}/status` | Fetch current game state (your view) |
-| `GET`    | `/{gameType}/{gameId}/history` | Fetch the ordered move log |
-| `GET`    | `/{gameType}/{gameId}/chat` | Fetch recent chat backscroll |
-| `POST` / `DELETE` | `/{gameType}/{gameId}/subscribe` | Start / stop spectating a game's push events |
+| `POST`   | `/{gameType}/{roomId}/move` | Submit a move; payload shape is game-specific (e.g. `{ "row": 1, "col": 1 }` for Tic-Tac-Toe) |
+| `GET`    | `/{gameType}/{roomId}/status` | Fetch current game state (your view) |
+| `GET`    | `/{gameType}/{roomId}/history` | Fetch the ordered move log |
+| `GET`    | `/{gameType}/{roomId}/chat` | Fetch recent chat backscroll |
+| `POST` / `DELETE` | `/{gameType}/{roomId}/subscribe` | Start / stop spectating a game's push events |
 
 ### Player & metrics
 
@@ -215,12 +215,12 @@ After authenticating, a client opens a single WebSocket to `GET /ws` (Bearer tok
 | `LobbyUpdated` | lobby `metadata` | A player joins/leaves or the lobby's status changes, including the room turning `Finished` after a match ends, or `InProgress` again on rematch |
 | `GameStateUpdated` | the viewer's `state` | A move is applied — each recipient gets their own per-viewer projection |
 | `GameEnded` | final `result` | The game reaches a win or draw, or a post-game room is evicted for sitting idle/empty |
-| `ChatMessage` | `gameId`, `senderId`, `senderName`, `text`, `sentAt` | Anyone watching that match posts chat |
+| `ChatMessage` | `roomId`, `senderId`, `senderName`, `text`, `sentAt` | Anyone watching that match posts chat |
 
 **Client → server** frames are likewise tagged by `type`. Today the sole inbound message is chat; unrecognized or malformed frames are logged and dropped:
 
 ```jsonc
-{ "type": "ChatSend", "gameId": "<uuid>", "text": "good luck!" }
+{ "type": "ChatSend", "roomId": "<uuid>", "text": "good luck!" }
 ```
 
 REST actions (joining, starting, moving) and WebSocket pushes work together: you `POST` a move over HTTP and receive the resulting state both in the HTTP response and as a `GameStateUpdated` push to every participant.
@@ -247,7 +247,7 @@ Each game actor is the single source of truth for one match. Because an actor pr
 
 ### The move lifecycle
 
-A move is server-authoritative end to end. The client POSTs it; the route hands it to `GameManager`, which routes it by `gameId` to the right game actor; the actor asks the pure game model to validate and apply it. Only if the model accepts the move does anything change.
+A move is server-authoritative end to end. The client POSTs it; the route hands it to `GameManager`, which routes it by `roomId` to the right game actor; the actor asks the pure game model to validate and apply it. Only if the model accepts the move does anything change.
 
 ```mermaid
 sequenceDiagram
@@ -260,7 +260,7 @@ sequenceDiagram
 
     Client->>Routes: POST /{type}/{id}/move (JWT)
     Routes->>GameManager: RunGameOperation(MakeMove)
-    GameManager->>Game: MakeMove (routed by gameId)
+    GameManager->>Game: MakeMove (routed by roomId)
     Note over Game: game model validates turn + legality
     Game--)Postgres: SaveSnapshot (fire-and-forget)
     Game-->>GameManager: Right(acting player's view)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Although it runs as a single instance today, the system is **designed for horizo
 
 - 🔐 Credentialed accounts — register, log in, and change password (Argon2-hashed), issuing expiring JWTs for player actions
 - 🏛️ Full lobby lifecycle — create, join, leave, list, and start matches
+- 🔁 Post-game rooms — a finished match keeps its room alive for chat, and the host can start a same-roster rematch; idle/empty rooms are evicted automatically
 - 🎲 Multiple game types — Tic-Tac-Toe, Connect Four, and Battleship
 - ✅ Server-side move validation (turn order and legality enforced by the game model)
 - ⚡ Real-time state delivery to all participants over WebSockets
@@ -44,6 +45,7 @@ Although it runs as a single instance today, the system is **designed for horizo
 
 - **Authentication** — players register and log in with a password (Argon2-hashed) to obtain a JWT, which they present to perform actions. Tokens expire, so clients re-authenticate when a request returns 401; WebSocket connections are authenticated only at connect, so an expiring token never drops a live socket.
 - **Lobbies** — create a lobby for a chosen game type; join, leave, and list open lobbies; start a match once the required number of players is present.
+- **Post-game rooms & rematch** — when a match ends, its room survives in a non-joinable `Finished` state instead of disappearing: the same players keep chatting, and the host can start a rematch (same `start` call, same roster, seating rotated so the other player leads). A room with no connected players, or sitting idle, is evicted automatically after a grace period.
 - **Gameplay** — submit moves; the server validates turn order and legality and applies them to authoritative game state.
 - **Real-time updates** — connected players and spectators receive game-state changes pushed over WebSockets.
 - **Hidden information** — players see only their own view of state; spectators receive a fog-of-war view (no leakage of hidden state).
@@ -180,7 +182,7 @@ All gameplay endpoints require a `Authorization: Bearer <jwt>` header; obtain a 
 | `GET`    | `/lobby/{gameId}` | Fetch metadata for one lobby |
 | `POST`   | `/lobby/{gameId}/join` | Join an open lobby |
 | `POST`   | `/lobby/{gameId}/leave` | Leave a lobby (or forfeit an in-progress game) |
-| `POST`   | `/lobby/{gameId}/start` | Start the match (host only) |
+| `POST`   | `/lobby/{gameId}/start` | Start the match (host only); also doubles as the rematch call when the room is in its post-game `Finished` state |
 | `DELETE` | `/lobby/{gameId}` | Cancel a pre-game lobby (host only) |
 | `POST` / `DELETE` | `/lobby/{gameId}/subscribe` | Start / stop spectating a lobby's push events |
 
@@ -210,9 +212,9 @@ After authenticating, a client opens a single WebSocket to `GET /ws` (Bearer tok
 
 | `type` | Payload | Sent when |
 |--------|---------|-----------|
-| `LobbyUpdated` | lobby `metadata` | A player joins/leaves or the lobby's status changes |
+| `LobbyUpdated` | lobby `metadata` | A player joins/leaves or the lobby's status changes, including the room turning `Finished` after a match ends, or `InProgress` again on rematch |
 | `GameStateUpdated` | the viewer's `state` | A move is applied — each recipient gets their own per-viewer projection |
-| `GameEnded` | final `result` | The game reaches a win or draw |
+| `GameEnded` | final `result` | The game reaches a win or draw, or a post-game room is evicted for sitting idle/empty |
 | `ChatMessage` | `gameId`, `senderId`, `senderName`, `text`, `sentAt` | Anyone watching that match posts chat |
 
 **Client → server** frames are likewise tagged by `type`. Today the sole inbound message is chat; unrecognized or malformed frames are logged and dropped:

--- a/game-service-actor/src/main/scala/com/andy327/actor/chat/ChatRepository.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/chat/ChatRepository.scala
@@ -3,7 +3,7 @@ package com.andy327.actor.chat
 import cats.effect.IO
 
 import com.andy327.actor.core.PlayerEvent
-import com.andy327.model.core.GameId
+import com.andy327.model.core.RoomId
 
 /** Repository for a bounded, recent-message history of each match's chat thread.
   *
@@ -17,6 +17,6 @@ trait ChatRepository {
   /** Append a chat message to its game's history, evicting the oldest once the buffer is full. */
   def append(message: PlayerEvent.ChatMessage): IO[Unit]
 
-  /** Load the recent chat history for `gameId`, oldest first. Empty if the game has no recorded messages. */
-  def recent(gameId: GameId): IO[List[PlayerEvent.ChatMessage]]
+  /** Load the recent chat history for `roomId`, oldest first. Empty if the game has no recorded messages. */
+  def recent(roomId: RoomId): IO[List[PlayerEvent.ChatMessage]]
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/chat/NoOpChatRepository.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/chat/NoOpChatRepository.scala
@@ -3,7 +3,7 @@ package com.andy327.actor.chat
 import cats.effect.IO
 
 import com.andy327.actor.core.PlayerEvent
-import com.andy327.model.core.GameId
+import com.andy327.model.core.RoomId
 
 /** A [[ChatRepository]] that records nothing and returns no history.
   *
@@ -12,5 +12,5 @@ import com.andy327.model.core.GameId
   */
 object NoOpChatRepository extends ChatRepository {
   override def append(message: PlayerEvent.ChatMessage): IO[Unit] = IO.unit
-  override def recent(gameId: GameId): IO[List[PlayerEvent.ChatMessage]] = IO.pure(Nil)
+  override def recent(roomId: RoomId): IO[List[PlayerEvent.ChatMessage]] = IO.pure(Nil)
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/chat/RedisChatRepository.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/chat/RedisChatRepository.scala
@@ -7,11 +7,11 @@ import cats.effect.IO
 import dev.profunktor.redis4cats.RedisCommands
 
 import com.andy327.actor.core.PlayerEvent
-import com.andy327.model.core.GameId
+import com.andy327.model.core.RoomId
 
 /** A [[ChatRepository]] backed by a per-game Redis list used as a fixed-size ring buffer.
   *
-  * Each message is `LPUSH`ed onto the head of `chat:{gameId}` and the list is immediately `LTRIM`med to the newest
+  * Each message is `LPUSH`ed onto the head of `chat:{roomId}` and the list is immediately `LTRIM`med to the newest
   * `maxMessages` entries, so storage per game is bounded regardless of how chatty a match gets. [[recent]] reads the
   * buffer with `LRANGE` and reverses it to oldest-first display order. Corrupt entries are skipped with a warning
   * rather than failing the whole read.
@@ -23,20 +23,20 @@ class RedisChatRepository(redis: RedisCommands[IO, String, String], maxMessages:
 
   private val logger = LoggerFactory.getLogger(getClass)
 
-  private def chatKey(gameId: GameId): String = s"chat:$gameId"
+  private def chatKey(roomId: RoomId): String = s"chat:$roomId"
 
   override def append(message: PlayerEvent.ChatMessage): IO[Unit] = {
-    val key = chatKey(message.gameId)
+    val key = chatKey(message.roomId)
     redis.lPush(key, ChatCodecs.serialize(message)) *> redis.lTrim(key, 0, maxMessages - 1L)
   }
 
-  override def recent(gameId: GameId): IO[List[PlayerEvent.ChatMessage]] =
-    redis.lRange(chatKey(gameId), 0, maxMessages - 1L).map { raw =>
+  override def recent(roomId: RoomId): IO[List[PlayerEvent.ChatMessage]] =
+    redis.lRange(chatKey(roomId), 0, maxMessages - 1L).map { raw =>
       raw.reverse.flatMap { json =>
         ChatCodecs.deserialize(json) match {
           case Right(message) => Some(message)
           case Left(err)      =>
-            logger.warn(s"Skipping corrupt chat message for $gameId: ${err.getMessage}")
+            logger.warn(s"Skipping corrupt chat message for $roomId: ${err.getMessage}")
             None
         }
       }

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/GameActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/GameActor.scala
@@ -111,11 +111,21 @@ trait GameActor[G <: Game[_, _, _, _, _]] {
     */
   protected def snapshotSavedResult(cmd: Command): Option[Either[Throwable, Unit]]
 
+  /** Extract the `replyTo` ref from `cmd` if it is a command that expects a `GameError`/`GameState` reply (a move,
+    * a leave, or a state read), otherwise `None`.
+    *
+    * Used by [[terminating]] to answer a request that lands in the brief window between game completion and the
+    * final snapshot being confirmed, rather than leaving the caller's `ask` to time out silently.
+    */
+  protected def replyToInTerminating(cmd: Command): Option[ActorRef[Either[GameError, GameState]]]
+
   /** Waits for the final snapshot confirmation after a game ends, then stops the actor.
     *
-    * Entered after a win or draw is detected. All commands except `SnapshotSaved` are ignored — the actor is
-    * shutting down and should not process new moves or subscribe requests. The actor self-stops once the final
-    * snapshot is confirmed, so [[com.andy327.actor.core.GameManager]] does not need to call `context.stop`.
+    * Entered after a win or draw is detected. A move/leave/state-read landing in this window is answered with
+    * `GameError.GameOver` rather than dropped, so the caller's `ask` doesn't time out; everything else
+    * (subscribe/unsubscribe/broadcast) is ignored — the actor is shutting down and should not take on new subscribers.
+    * The actor self-stops once the final snapshot is confirmed, so [[com.andy327.actor.core.GameManager]] does not need
+    * to call `context.stop`.
     *
     * A `Terminated` signal from a still-watched subscriber is ignored here; without an explicit handler Pekko would
     * raise `DeathPactException` and crash the actor before the final snapshot is confirmed.
@@ -130,6 +140,7 @@ trait GameActor[G <: Game[_, _, _, _, _]] {
           }
           Behaviors.stopped
         case None =>
+          replyToInTerminating(msg).foreach(_ ! Left(GameError.GameOver))
           Behaviors.same
       }
     }.receiveSignal { case (_, Terminated(_)) =>

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/GameActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/GameActor.scala
@@ -6,7 +6,7 @@ import org.apache.pekko.actor.typed.{ActorRef, Behavior, Terminated}
 import com.andy327.actor.events.EventPublisher
 import com.andy327.actor.game.GameState
 import com.andy327.actor.persistence.PersistenceProtocol
-import com.andy327.model.core.{Game, GameError, GameId, GameType, GameTypeTag, PlayerId}
+import com.andy327.model.core.{Game, GameError, GameType, GameTypeTag, MatchId, PlayerId, RoomId}
 
 object GameActor {
 
@@ -47,7 +47,8 @@ trait GameActor[G <: Game[_, _, _, _, _]] {
 
   /** Spawn a fresh game actor for a newly created game.
     *
-    * @param gameId the unique identifier for the game
+    * @param matchId the unique identifier for this match; keys its snapshot, move log, results, and analytics
+    * @param roomId the room hosting the match; carried so push events and completion can be addressed to the room
     * @param players the ordered list of players; game type determines how many are required
     * @param persist the shared persistence actor used to save snapshots
     * @param gameManager the parent GameManager actor, used to report game-end events
@@ -55,7 +56,8 @@ trait GameActor[G <: Game[_, _, _, _, _]] {
     * @return the initial game model and a `Behavior` ready to receive commands
     */
   def create(
-      gameId: GameId,
+      matchId: MatchId,
+      roomId: RoomId,
       players: Seq[PlayerId],
       persist: ActorRef[PersistenceProtocol.Command],
       gameManager: ActorRef[GameManager.Command],
@@ -64,7 +66,8 @@ trait GameActor[G <: Game[_, _, _, _, _]] {
 
   /** Re-hydrate an actor from a snapshot already loaded from the database.
     *
-    * @param gameId the unique identifier for the game being restored
+    * @param matchId the unique identifier for the match being restored
+    * @param roomId the room hosting the match; carried so push events and completion can be addressed to the room
     * @param snap the snapshot returned by the persistence layer; must be a valid `G`
     * @param persist the shared persistence actor used to save future snapshots
     * @param gameManager the parent GameManager actor
@@ -72,7 +75,8 @@ trait GameActor[G <: Game[_, _, _, _, _]] {
     * @return a `Behavior` initialised from the snapshot state
     */
   def fromSnapshot(
-      gameId: GameId,
+      matchId: MatchId,
+      roomId: RoomId,
       snap: Game[_, _, _, _, _],
       persist: ActorRef[PersistenceProtocol.Command],
       gameManager: ActorRef[GameManager.Command],
@@ -116,13 +120,13 @@ trait GameActor[G <: Game[_, _, _, _, _]] {
     * A `Terminated` signal from a still-watched subscriber is ignored here; without an explicit handler Pekko would
     * raise `DeathPactException` and crash the actor before the final snapshot is confirmed.
     */
-  protected def terminating(gameId: GameId): Behavior[Command] =
+  protected def terminating(matchId: MatchId): Behavior[Command] =
     Behaviors.receive[Command] { (context, msg) =>
       snapshotSavedResult(msg) match {
         case Some(result) =>
           result match {
-            case Left(e)  => context.log.error(s"[$gameId] final snapshot failed", e)
-            case Right(_) => context.log.debug(s"[$gameId] final snapshot saved, stopping")
+            case Left(e)  => context.log.error(s"[$matchId] final snapshot failed", e)
+            case Right(_) => context.log.debug(s"[$matchId] final snapshot saved, stopping")
           }
           Behaviors.stopped
         case None =>

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
@@ -161,9 +161,12 @@ object GameManager {
       lobbies: List[LobbyMetadata]
   ) extends Command
 
-  /** Sent by LobbyManager after validating a StartGame request; GameManager spawns the child actor. */
+  /** Sent by LobbyManager after validating a StartGame request; GameManager spawns the child actor. Carries the stable
+    * `roomId` and the freshly-minted `matchId` for this playthrough.
+    */
   final private[core] case class SpawnGame(
-      gameId: GameId,
+      roomId: RoomId,
+      matchId: MatchId,
       gameType: GameType,
       players: Set[PlayerId],
       replyTo: ActorRef[GameResponse],
@@ -393,6 +396,16 @@ object GameManager {
     *
     * Waits for a single [[RestoreGames]] message, spawns actors for every recovered game, then unstashes
     * all buffered messages and transitions to [[running]].
+    *
+    * @param lobbyManager child actor owning all lobby/room lifecycle state
+    * @param playerManager child actor tracking connected players' sessions (their PlayerActor refs)
+    * @param persistActor shared actor for all persistence I/O (snapshots, move log, results)
+    * @param gameRepo repository used for the initial game restore and completed-game state lookups
+    * @param moveRepo repository read to serve move-history queries
+    * @param chatRepo repository written on each chat message and read to serve backscroll
+    * @param stash buffer holding commands received before the restore completes; drained into [[running]]
+    * @param publisher emit seam for analytics events (game started/move made/game completed/chat sent)
+    * @param onReady optional ref signalled once the running state is entered (used in tests)
     */
   private def initializing(
       lobbyManager: ActorRef[LobbyManager.Command],
@@ -407,18 +420,32 @@ object GameManager {
   )(implicit runtime: IORuntime): Behavior[Command] = Behaviors.receive { (context, message) =>
     message match {
       case RestoreGames(games, lobbies) =>
-        val restoredActors = games.map { case (gameId, (gameType, game)) =>
-          val gameActor = GameRegistry.forType(gameType).actor
-          // 3a: matchId == roomId == gameId; a fresh per-match id is introduced in the next commit
-          val behavior = gameActor.fromSnapshot(gameId, gameId, game, persistActor, context.self, publisher)
-          val actorRef = context.spawn(behavior, s"game-$gameId").unsafeUpcast[GameActor.GameCommand]
-          gameId -> (gameType, actorRef)
+        // a persisted game is keyed by its matchId; recover the room hosting it from the lobby that recorded that match
+        // as current. An orphan match (no such lobby — e.g. its lobby was lost from Redis) falls back to a self-room
+        // keyed by the matchId so the game is still reachable.
+        val matchToRoom: Map[MatchId, RoomId] =
+          lobbies.flatMap(m => m.currentMatchId.map(_ -> m.gameId)).toMap
+
+        // resolve each restored game to its room once, then derive the actor map and the player index from it
+        val resolved = games.toList.map { case (matchId, (gameType, game)) =>
+          val roomId = matchToRoom.getOrElse(matchId, matchId)
+          if (!matchToRoom.contains(matchId))
+            context.log.warn(s"Restored match $matchId has no owning lobby; treating it as its own room")
+          (roomId, matchId, gameType, game)
         }
 
-        // Rebuild the player -> live-games index from each restored game's roster, so a reconnecting player can
+        val restoredActors = resolved.map { case (roomId, matchId, gameType, game) =>
+          val gameActor = GameRegistry.forType(gameType).actor
+          val behavior = gameActor.fromSnapshot(matchId, roomId, game, persistActor, context.self, publisher)
+          val actorRef = context.spawn(behavior, s"game-$matchId").unsafeUpcast[GameActor.GameCommand]
+          roomId -> (gameType, matchId, actorRef)
+        }.toMap
+
+        // Rebuild the player -> live-rooms index from each restored game's roster, so a reconnecting player can
         // rediscover in-flight matches that survived a restart.
-        val restoredPlayerGames = games.foldLeft(Map.empty[PlayerId, Set[GameId]]) { case (acc, (gameId, (_, game))) =>
-          game.players.foldLeft(acc)((idx, pid) => idx.updated(pid, idx.getOrElse(pid, Set.empty) + gameId))
+        val restoredPlayerGames = resolved.foldLeft(Map.empty[PlayerId, Set[RoomId]]) {
+          case (acc, (roomId, _, _, game)) =>
+            game.players.foldLeft(acc)((idx, pid) => idx.updated(pid, idx.getOrElse(pid, Set.empty) + roomId))
         }
 
         context.log.info(s"Initialized ${restoredActors.size} game actors from snapshots")
@@ -450,16 +477,24 @@ object GameManager {
     * Lobby and player session commands are forwarded to [[LobbyManager]] and [[PlayerManager]] respectively.
     * Game operation commands are dispatched to the appropriate game actor via [[GameRegistry]].
     *
-    * @param activeGames map from GameId to (GameType, game actor ref) for all currently running games
-    * @param completedGameTypes retains the GameType of finished games so GetState queries can fall back to the DB
-    * @param playerGames reverse index from PlayerId to the set of live games they are seated in, used to answer
-    *                    "which games am I in?" without scanning every game; populated at spawn/restore, pruned on
+    * @param activeGames map from RoomId to (GameType, matchId, game actor ref) for the live match in each running room
+    * @param completedMatch retains the (matchId, GameType) of each room's finished match so GetState/history queries
+    *                       can fall back to the DB by match id after the actor has stopped
+    * @param playerGames reverse index from PlayerId to the set of live rooms they are seated in, used to answer
+    *                    "which games am I in?" without scanning every room; populated at spawn/restore, pruned on
     *                    completion
+    * @param lobbyManager child actor owning all lobby/room lifecycle state
+    * @param playerManager child actor tracking connected players' sessions (their PlayerActor refs)
+    * @param persistActor shared actor for all persistence I/O (snapshots, move log, results)
+    * @param gameRepo repository used for completed-game state lookups (the DB fallback for GetState)
+    * @param moveRepo repository read to serve move-history queries
+    * @param chatRepo repository written on each chat message and read to serve backscroll
+    * @param publisher emit seam for analytics events (game started/move made/game completed/chat sent)
     */
   private def running(
-      activeGames: Map[GameId, (GameType, ActorRef[GameActor.GameCommand])],
-      completedGameTypes: Map[GameId, GameType],
-      playerGames: Map[PlayerId, Set[GameId]],
+      activeGames: Map[RoomId, (GameType, MatchId, ActorRef[GameActor.GameCommand])],
+      completedMatch: Map[RoomId, (MatchId, GameType)],
+      playerGames: Map[PlayerId, Set[RoomId]],
       lobbyManager: ActorRef[LobbyManager.Command],
       playerManager: ActorRef[PlayerManager.Command],
       persistActor: ActorRef[PersistenceProtocol.Command],
@@ -484,7 +519,7 @@ object GameManager {
           activeGames.get(gameId) match {
             // game in progress: leaving it is a forfeit, handled by the game actor (which then self-completes and
             // triggers GameCompleted -> MarkCompleted, moving the lobby to Completed)
-            case Some((gameType, gameActor)) =>
+            case Some((gameType, _, gameActor)) =>
               val adaptedRef: ActorRef[Either[GameError, GameState]] =
                 context.messageAdapter(response => WrappedForfeitResponse(response, gameId, replyTo))
               gameActor ! GameRegistry.forType(gameType).actor.forfeitCommand(player.id, adaptedRef)
@@ -562,8 +597,8 @@ object GameManager {
         case GetPlayerSessions(playerId, replyTo) =>
           // resolve the player's live games from the reverse index, intersected with activeGames so a stale entry can
           // never surface a game that is no longer running
-          val games = playerGames.getOrElse(playerId, Set.empty).toList.flatMap { gid =>
-            activeGames.get(gid).map { case (gameType, _) => ActiveGameSummary(gid, gameType) }
+          val games = playerGames.getOrElse(playerId, Set.empty).toList.flatMap { roomId =>
+            activeGames.get(roomId).map { case (gameType, _, _) => ActiveGameSummary(roomId, gameType) }
           }
           implicit val t: Timeout = subscribeAskTimeout
           context.ask(lobbyManager, LobbyManager.ListLobbiesForPlayer(playerId, _)) {
@@ -578,15 +613,16 @@ object GameManager {
 
         case SendChat(gameId, sender, text) =>
           val event = PlayerEvent.ChatMessage(gameId, sender.id, sender.name, text, Instant.now())
-          activeGames.get(gameId) match {
-            case Some((gameType, gameActor)) =>
+          val liveMatch = activeGames.get(gameId)
+          liveMatch match {
+            case Some((gameType, _, gameActor)) =>
               gameActor ! GameRegistry.forType(gameType).actor.broadcastCommand(event)
             case None =>
               // not in progress (or unknown): fan out via the lobby; a bogus gameId is a harmless no-op there
               lobbyManager ! LobbyManager.BroadcastChat(gameId, event)
           }
           // record the send for analytics (gameType is None for lobby chat, before the game starts)
-          publisher.publish(GameEvent.ChatSent(gameId, activeGames.get(gameId).map(_._1)))
+          publisher.publish(GameEvent.ChatSent(gameId, liveMatch.map(_._1)))
           // record to the bounded chat history so late joiners can backscroll; best-effort, never blocks the send
           chatRepo.append(event).unsafeRunAsync {
             case Left(ex) => context.log.warn(s"Failed to persist chat message for $gameId", ex)
@@ -604,7 +640,7 @@ object GameManager {
           playerRefOpt match {
             case Some(ref) =>
               activeGames.get(gameId) match {
-                case Some((gameType, gameActor)) =>
+                case Some((gameType, _, gameActor)) =>
                   gameActor ! GameRegistry.forType(gameType).actor.subscribeCommand(ref, playerId)
                   replyTo ! SubscribeAcknowledged(gameId)
                 case None =>
@@ -627,7 +663,7 @@ object GameManager {
           // drop their session from the game actor's subscriber set; otherwise there is nothing to remove. Either way
           // the DELETE succeeds, so a client can safely call it without first checking its own subscription state.
           (playerRefOpt, activeGames.get(gameId)) match {
-            case (Some(ref), Some((gameType, gameActor))) =>
+            case (Some(ref), Some((gameType, _, gameActor))) =>
               gameActor ! GameRegistry.forType(gameType).actor.unsubscribeCommand(ref)
             case _ =>
               ()
@@ -643,39 +679,38 @@ object GameManager {
           playerManager ! PlayerManager.PlayerDisconnected(playerId, playerRef)
           Behaviors.same
 
-        case SpawnGame(gameId, gameType, players, replyTo, subscribers) =>
+        case SpawnGame(roomId, matchId, gameType, players, replyTo, subscribers) =>
           val n = players.size
           if (n < gameType.minPlayers || n > gameType.maxPlayers) {
             val expected =
               if (gameType.minPlayers == gameType.maxPlayers) s"${gameType.minPlayers}"
               else s"${gameType.minPlayers}–${gameType.maxPlayers}"
-            context.log.error(s"SpawnGame rejected for $gameId: $n players supplied, expected $expected")
+            context.log.error(s"SpawnGame rejected for room $roomId: $n players supplied, expected $expected")
             replyTo ! ErrorResponse(s"$expected players required, got $n")
             Behaviors.same
           } else {
             val bundle = GameRegistry.forType(gameType)
-            // 3a: matchId == roomId == gameId; a fresh per-match id is introduced in the next commit
             val (game, behavior) =
-              bundle.actor.create(gameId, gameId, players.toSeq, persistActor, context.self, publisher)
-            val actorRef = context.spawn(behavior, s"game-$gameId").unsafeUpcast[GameActor.GameCommand]
+              bundle.actor.create(matchId, roomId, players.toSeq, persistActor, context.self, publisher)
+            val actorRef = context.spawn(behavior, s"game-$matchId").unsafeUpcast[GameActor.GameCommand]
 
             subscribers.foreach { case (pid, ref) => actorRef ! bundle.actor.subscribeCommand(ref, pid) }
 
             persistActor ! PersistenceProtocol.SaveSnapshot(
-              gameId,
+              matchId,
               gameType,
               game.asInstanceOf[Game[_, _, _, _, _]],
               replyTo = context.system.ignoreRef
             )
 
-            context.log.info(s"Created and persisted new game with gameId: $gameId")
-            publisher.publish(GameEvent.GameStarted(gameId, gameType, n))
-            replyTo ! GameStarted(gameId)
+            context.log.info(s"Created and persisted new match $matchId in room $roomId")
+            publisher.publish(GameEvent.GameStarted(matchId, gameType, n))
+            replyTo ! GameStarted(roomId)
             val updatedPlayerGames =
-              players.foldLeft(playerGames)((idx, pid) => idx.updated(pid, idx.getOrElse(pid, Set.empty) + gameId))
+              players.foldLeft(playerGames)((idx, pid) => idx.updated(pid, idx.getOrElse(pid, Set.empty) + roomId))
             running(
-              activeGames + (gameId -> (gameType, actorRef)),
-              completedGameTypes,
+              activeGames + (roomId -> (gameType, matchId, actorRef)),
+              completedMatch,
               updatedPlayerGames,
               lobbyManager,
               playerManager,
@@ -689,7 +724,7 @@ object GameManager {
 
         case GameCompleted(matchId, roomId, result) =>
           activeGames.get(roomId) match {
-            case Some((gameType, _)) =>
+            case Some((gameType, _, _)) =>
               context.log.info(s"Match $matchId in room $roomId completed with result $result — actor self-terminating")
               lobbyManager ! LobbyManager.MarkCompleted(roomId, result)
               // drop the finished game from every player's index, removing players left with no live games
@@ -697,7 +732,7 @@ object GameManager {
                 playerGames.view.mapValues(_ - roomId).filter(_._2.nonEmpty).toMap
               running(
                 activeGames - roomId,
-                completedGameTypes + (roomId -> gameType),
+                completedMatch + (roomId -> (matchId, gameType)),
                 prunedPlayerGames,
                 lobbyManager,
                 playerManager,
@@ -714,7 +749,7 @@ object GameManager {
 
         case RunGameOperation(gameId, op, replyTo) =>
           activeGames.get(gameId) match {
-            case Some((gameType, gameActor)) =>
+            case Some((gameType, _, gameActor)) =>
               val adaptedRef: ActorRef[Either[GameError, GameState]] =
                 context.messageAdapter(response => WrappedGameResponse(response, replyTo))
 
@@ -724,11 +759,11 @@ object GameManager {
               }
 
             case None =>
-              completedGameTypes.get(gameId) match {
-                case Some(gameType) =>
+              completedMatch.get(gameId) match {
+                case Some((matchId, gameType)) =>
                   op match {
                     case GameOperation.GetState =>
-                      context.pipeToSelf(gameRepo.loadGame(gameId, gameType).attempt.unsafeToFuture()) {
+                      context.pipeToSelf(gameRepo.loadGame(matchId, gameType).attempt.unsafeToFuture()) {
                         case Success(result) => CompletedGameLoaded(result, gameId, gameType, replyTo)
                         // $COVERAGE-OFF$ .attempt converts IO failures to Success(Left(ex)); Failure is unreachable
                         case Failure(ex) => CompletedGameLoaded(Left(ex), gameId, gameType, replyTo)
@@ -738,7 +773,7 @@ object GameManager {
                       replyTo ! MoveRejected("Game has already ended")
                   }
                 case None =>
-                  context.log.warn(s"No game found with gameId $gameId to forward operation $op")
+                  context.log.warn(s"No game found for room $gameId to forward operation $op")
                   replyTo ! GameNotFound(gameId)
               }
           }
@@ -758,7 +793,10 @@ object GameManager {
           Behaviors.same
 
         case GetMoveHistory(gameId, replyTo) =>
-          context.pipeToSelf(moveRepo.loadMoves(gameId).attempt.unsafeToFuture()) {
+          // the move log is keyed by matchId. Resolve the room's live or most-recent match; if the id is not a known
+          // room (e.g. a game finished before a restart, or a direct match lookup), fall back to using it as the match.
+          val matchId = activeGames.get(gameId).map(_._2).orElse(completedMatch.get(gameId).map(_._1)).getOrElse(gameId)
+          context.pipeToSelf(moveRepo.loadMoves(matchId).attempt.unsafeToFuture()) {
             case Success(result) => MoveHistoryLoaded(result, gameId, replyTo)
             // $COVERAGE-OFF$ .attempt converts IO failures to Success(Left(ex)); Failure is unreachable
             case Failure(ex) => MoveHistoryLoaded(Left(ex), gameId, replyTo)

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
@@ -158,6 +158,12 @@ object GameManager {
       subscribers: Map[PlayerId, ActorRef[PlayerActor.Command]] = Map.empty
   ) extends Command
 
+  /** Sent by [[LobbyManager]] when `roomId`'s room is retired for good (cancelled by the host, or evicted for sitting
+    * idle/empty) so GameManager can drop its `completedMatch` entry. A no-op if the room never completed a match —
+    * LobbyManager sends this from every room-closing path regardless of whether one is present.
+    */
+  final private[core] case class RoomClosed(roomId: RoomId) extends Command
+
   // --- Internal commands (not reachable from HTTP) ---
 
   /** Carries the result of the async restore initiated at startup; transitions from initializing to running. */
@@ -485,7 +491,8 @@ object GameManager {
     *
     * @param activeGames map from RoomId to (GameType, matchId, game actor ref) for the live match in each running room
     * @param completedMatch retains the (matchId, GameType) of each room's finished match so GetState/history queries
-    *                       can fall back to the DB by match id after the actor has stopped
+    *                       can fall back to the DB by match id after the actor has stopped; pruned on [[RoomClosed]]
+    *                       once the room itself is retired
     * @param playerGames reverse index from PlayerId to the set of live rooms they are seated in, used to answer
     *                    "which games am I in?" without scanning every room; populated at spawn/restore, pruned on
     *                    completion
@@ -753,6 +760,20 @@ object GameManager {
               context.log.warn(s"Received GameCompleted for unknown room: $roomId")
               Behaviors.same
           }
+
+        case RoomClosed(roomId) =>
+          running(
+            activeGames,
+            completedMatch - roomId,
+            playerGames,
+            lobbyManager,
+            playerManager,
+            persistActor,
+            gameRepo,
+            moveRepo,
+            chatRepo,
+            publisher
+          )
 
         case RunGameOperation(gameId, op, replyTo) =>
           activeGames.get(gameId) match {

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
@@ -167,13 +167,14 @@ object GameManager {
   ) extends Command
 
   /** Sent by LobbyManager after validating a StartGame request; GameManager spawns the child actor. Carries the stable
-    * `roomId` and the freshly-minted `matchId` for this playthrough.
+    * `roomId`, the freshly-minted `matchId` for this playthrough, and the seated `players` in turn order (seat 0 moves
+    * first); LobbyManager rotates that order across rematches.
     */
   final private[core] case class SpawnGame(
       roomId: RoomId,
       matchId: MatchId,
       gameType: GameType,
-      players: Set[PlayerId],
+      players: Seq[PlayerId],
       replyTo: ActorRef[GameResponse],
       subscribers: Map[PlayerId, ActorRef[PlayerActor.Command]] = Map.empty
   ) extends Command
@@ -696,7 +697,7 @@ object GameManager {
           } else {
             val bundle = GameRegistry.forType(gameType)
             val (game, behavior) =
-              bundle.actor.create(matchId, roomId, players.toSeq, persistActor, context.self, publisher)
+              bundle.actor.create(matchId, roomId, players, persistActor, context.self, publisher)
             val actorRef = context.spawn(behavior, s"game-$matchId").unsafeUpcast[GameActor.GameCommand]
 
             subscribers.foreach { case (pid, ref) => actorRef ! bundle.actor.subscribeCommand(ref, pid) }

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
@@ -17,7 +17,7 @@ import com.andy327.actor.events.{EventPublisher, GameEvent, NoOpEventPublisher}
 import com.andy327.actor.game.{GameOperation, GameRegistry, GameState}
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyError, LobbyMetadata, LobbyRepository, Player}
 import com.andy327.actor.persistence.PersistenceProtocol
-import com.andy327.model.core.{Game, GameError, GameId, GameType, MatchId, PlayerId, RoomId}
+import com.andy327.model.core.{Game, GameError, GameType, MatchId, PlayerId, RoomId}
 import com.andy327.persistence.db.{GameRepository, MoveHistoryRepository, MoveRecord, NoOpMoveHistoryRepository}
 
 /** A supervisor actor responsible for game actor lifecycle and request routing.
@@ -49,21 +49,21 @@ object GameManager {
   final case class CreateLobby(gameType: GameType, host: Player, replyTo: ActorRef[GameResponse]) extends Command
 
   /** Join an existing lobby; replies with [[LobbyJoined]] or a [[LobbyErrorResponse]]. */
-  final case class JoinLobby(gameId: GameId, player: Player, replyTo: ActorRef[GameResponse]) extends Command
+  final case class JoinLobby(roomId: RoomId, player: Player, replyTo: ActorRef[GameResponse]) extends Command
 
   /** Leave a lobby. If the host leaves, the host role migrates to a remaining member and the lobby survives; it is
     * cancelled only when the host was the last player. Rejected with
     * [[com.andy327.actor.lobby.LobbyError.GameInProgress]] once the game has started (leaving is then a forfeit).
     */
-  final case class LeaveLobby(gameId: GameId, player: Player, replyTo: ActorRef[GameResponse]) extends Command
+  final case class LeaveLobby(roomId: RoomId, player: Player, replyTo: ActorRef[GameResponse]) extends Command
 
   /** Cancel a pre-game lobby on behalf of its host; replies with [[LobbyLeft]] on success or a [[LobbyErrorResponse]]
     * (not host, lobby not found). Rejected once the game has started — at that point leaving is a forfeit.
     */
-  final case class CancelLobby(gameId: GameId, playerId: PlayerId, replyTo: ActorRef[GameResponse]) extends Command
+  final case class CancelLobby(roomId: RoomId, playerId: PlayerId, replyTo: ActorRef[GameResponse]) extends Command
 
   /** Start a game in a lobby the caller hosts; replies with [[GameStarted]] or a [[LobbyErrorResponse]]. */
-  final case class StartGame(gameId: GameId, playerId: PlayerId, replyTo: ActorRef[GameResponse]) extends Command
+  final case class StartGame(roomId: RoomId, playerId: PlayerId, replyTo: ActorRef[GameResponse]) extends Command
 
   /** List joinable lobbies with optional game-type filter and pagination; replies with [[LobbiesListed]]. */
   final case class ListLobbies(
@@ -74,18 +74,18 @@ object GameManager {
   ) extends Command
 
   /** Fetch metadata for a specific lobby (active or recently ended); replies with [[LobbyInfo]]. */
-  final case class GetLobbyInfo(gameId: GameId, replyTo: ActorRef[GameResponse]) extends Command
+  final case class GetLobbyInfo(roomId: RoomId, replyTo: ActorRef[GameResponse]) extends Command
 
   /** Subscribe the authenticated player to lobby push events as a spectator; replies with [[SubscribeAcknowledged]] or
     * [[ErrorResponse]].
     */
-  final case class SubscribePlayerToLobby(gameId: GameId, playerId: PlayerId, replyTo: ActorRef[GameResponse])
+  final case class SubscribePlayerToLobby(roomId: RoomId, playerId: PlayerId, replyTo: ActorRef[GameResponse])
       extends Command
 
   /** Stop spectating a lobby: deregister the authenticated player from [[LobbyManager]]'s push events. Idempotent —
     * replies with [[UnsubscribeAcknowledged]] even if the player was not subscribed.
     */
-  final case class UnsubscribePlayerFromLobby(gameId: GameId, playerId: PlayerId, replyTo: ActorRef[GameResponse])
+  final case class UnsubscribePlayerFromLobby(roomId: RoomId, playerId: PlayerId, replyTo: ActorRef[GameResponse])
       extends Command
 
   /** Return the caller's current participation — joined pre-game lobbies and live games they are seated in; replies
@@ -96,37 +96,37 @@ object GameManager {
 
   // --- Game operation commands (routed to a specific game actor via GameRegistry) ---
 
-  /** Forward `op` to the game actor for `gameId`; replies with [[GameStatus]], [[GameNotFound]], [[MoveRejected]],
+  /** Forward `op` to the game actor for `roomId`; replies with [[GameStatus]], [[GameNotFound]], [[MoveRejected]],
     * or [[ErrorResponse]] (internal failure).
     */
-  final case class RunGameOperation(gameId: GameId, op: GameOperation, replyTo: ActorRef[GameResponse]) extends Command
+  final case class RunGameOperation(roomId: RoomId, op: GameOperation, replyTo: ActorRef[GameResponse]) extends Command
 
-  /** Fetch the ordered move history for `gameId` from the move log; replies with [[MoveHistory]] (empty if none) or
+  /** Fetch the ordered move history for `roomId` from the move log; replies with [[MoveHistory]] (empty if none) or
     * [[ErrorResponse]] on a storage failure. Served by a direct DB read, so it works for active and finished games.
     */
-  final case class GetMoveHistory(gameId: GameId, replyTo: ActorRef[GameResponse]) extends Command
+  final case class GetMoveHistory(roomId: RoomId, replyTo: ActorRef[GameResponse]) extends Command
 
-  /** Fetch the recent chat history for `gameId` (backscroll) from the chat store; replies with [[ChatHistory]] (empty
+  /** Fetch the recent chat history for `roomId` (backscroll) from the chat store; replies with [[ChatHistory]] (empty
     * if none) or [[ErrorResponse]] on a storage failure. Served by a direct read, so it works for active and finished
     * games; live messages continue to arrive over the WebSocket.
     */
-  final case class GetChatHistory(gameId: GameId, replyTo: ActorRef[GameResponse]) extends Command
+  final case class GetChatHistory(roomId: RoomId, replyTo: ActorRef[GameResponse]) extends Command
 
   /** Post a chat message to a match: fans it out to the match's subscribers (the game actor's while in progress, the
     * lobby's otherwise) and emits a `ChatSent` analytics event.
     */
-  final case class SendChat(gameId: GameId, sender: Player, text: String) extends Command
+  final case class SendChat(roomId: RoomId, sender: Player, text: String) extends Command
 
   /** Subscribe the authenticated player to game push events as a spectator; replies with [[SubscribeAcknowledged]] or
     * [[ErrorResponse]].
     */
-  final case class SubscribePlayerToGame(gameId: GameId, playerId: PlayerId, replyTo: ActorRef[GameResponse])
+  final case class SubscribePlayerToGame(roomId: RoomId, playerId: PlayerId, replyTo: ActorRef[GameResponse])
       extends Command
 
   /** Stop spectating a game: deregister the authenticated player from the game actor's push events. Idempotent —
     * replies with [[UnsubscribeAcknowledged]] even if the player was not subscribed or the game is no longer active.
     */
-  final case class UnsubscribePlayerFromGame(gameId: GameId, playerId: PlayerId, replyTo: ActorRef[GameResponse])
+  final case class UnsubscribePlayerFromGame(roomId: RoomId, playerId: PlayerId, replyTo: ActorRef[GameResponse])
       extends Command
 
   // --- Player session commands (forwarded to PlayerManager) ---
@@ -168,7 +168,7 @@ object GameManager {
 
   /** Carries the result of the async restore initiated at startup; transitions from initializing to running. */
   final protected[core] case class RestoreGames(
-      games: Map[GameId, (GameType, Game[_, _, _, _, _])],
+      games: Map[MatchId, (GameType, Game[_, _, _, _, _])],
       lobbies: List[LobbyMetadata]
   ) extends Command
 
@@ -194,7 +194,7 @@ object GameManager {
     */
   final private case class WrappedForfeitResponse(
       response: Either[GameError, GameState],
-      gameId: GameId,
+      roomId: RoomId,
       replyTo: ActorRef[GameResponse]
   ) extends Command
 
@@ -223,7 +223,7 @@ object GameManager {
   /** Carries the result of a [[PlayerManager.LookupPlayer]] ask for a [[SubscribePlayerToLobby]] request. */
   final private case class PlayerRefForLobbySpectate(
       playerRef: Option[ActorRef[PlayerActor.Command]],
-      gameId: GameId,
+      roomId: RoomId,
       playerId: PlayerId,
       replyTo: ActorRef[GameResponse]
   ) extends Command
@@ -231,7 +231,7 @@ object GameManager {
   /** Carries the result of a [[PlayerManager.LookupPlayer]] ask for a [[SubscribePlayerToGame]] request. */
   final private case class PlayerRefForGameSpectate(
       playerRef: Option[ActorRef[PlayerActor.Command]],
-      gameId: GameId,
+      roomId: RoomId,
       playerId: PlayerId,
       replyTo: ActorRef[GameResponse]
   ) extends Command
@@ -239,7 +239,7 @@ object GameManager {
   /** Carries the result of a [[PlayerManager.LookupPlayer]] ask for an [[UnsubscribePlayerFromGame]] request. */
   final private case class PlayerRefForGameUnsubscribe(
       playerRef: Option[ActorRef[PlayerActor.Command]],
-      gameId: GameId,
+      roomId: RoomId,
       replyTo: ActorRef[GameResponse]
   ) extends Command
 
@@ -247,7 +247,7 @@ object GameManager {
     */
   final private case class PlayerRefForSubscribe(
       playerRef: Option[ActorRef[PlayerActor.Command]],
-      gameId: GameId,
+      roomId: RoomId,
       playerId: PlayerId,
       response: GameResponse,
       replyTo: ActorRef[GameResponse]
@@ -256,7 +256,7 @@ object GameManager {
   /** Result of a DB fallback load for a completed game's current state. */
   final private case class CompletedGameLoaded(
       result: Either[Throwable, Option[Game[_, _, _, _, _]]],
-      gameId: GameId,
+      roomId: RoomId,
       gameType: GameType,
       replyTo: ActorRef[GameResponse]
   ) extends Command
@@ -264,14 +264,14 @@ object GameManager {
   /** Carries the result of an async move-history load for a [[GetMoveHistory]] request. */
   final private case class MoveHistoryLoaded(
       result: Either[Throwable, List[MoveRecord]],
-      gameId: GameId,
+      roomId: RoomId,
       replyTo: ActorRef[GameResponse]
   ) extends Command
 
   /** Carries the result of an async chat-history load for a [[GetChatHistory]] request. */
   final private case class ChatHistoryLoaded(
       result: Either[Throwable, List[PlayerEvent.ChatMessage]],
-      gameId: GameId,
+      roomId: RoomId,
       replyTo: ActorRef[GameResponse]
   ) extends Command
 
@@ -280,9 +280,9 @@ object GameManager {
   sealed trait GameResponse
 
   // Lobby responses
-  final case class LobbyCreated(gameId: GameId, host: Player) extends GameResponse
-  final case class LobbyJoined(gameId: GameId, metadata: LobbyMetadata, joinedPlayer: Player) extends GameResponse
-  final case class LobbyLeft(gameId: GameId, message: String) extends GameResponse
+  final case class LobbyCreated(roomId: RoomId, host: Player) extends GameResponse
+  final case class LobbyJoined(roomId: RoomId, metadata: LobbyMetadata, joinedPlayer: Player) extends GameResponse
+  final case class LobbyLeft(roomId: RoomId, message: String) extends GameResponse
   final case class LobbyInfo(metadata: LobbyMetadata) extends GameResponse
 
   /** Paginated list of joinable lobbies. */
@@ -291,7 +291,7 @@ object GameManager {
   /** A single live game the requesting player is seated in, carried by [[PlayerSessions]]. Deliberately minimal — just
     * the id and kind, enough to re-discover and reconnect to the match; full state is fetched via the game endpoint.
     */
-  final case class ActiveGameSummary(gameId: GameId, gameType: GameType)
+  final case class ActiveGameSummary(roomId: RoomId, gameType: GameType)
 
   /** The caller's current participation: joined pre-game `lobbies` and the live `games` they are seated in. Either list
     * may be empty. Serialized directly to the wire (no separate response DTO), like [[LobbiesListed]].
@@ -299,22 +299,22 @@ object GameManager {
   final case class PlayerSessions(lobbies: List[LobbyMetadata], games: List[ActiveGameSummary]) extends GameResponse
 
   // Game responses
-  final case class GameStarted(gameId: GameId) extends GameResponse
+  final case class GameStarted(roomId: RoomId) extends GameResponse
   final case class GameStatus(state: GameState) extends GameResponse
 
   /** A player left an in-progress game and thereby forfeited it; `state` is the leaver's view of the finished game. */
-  final case class GameForfeited(gameId: GameId, state: GameState) extends GameResponse
+  final case class GameForfeited(roomId: RoomId, state: GameState) extends GameResponse
 
   /** The ordered move history for a game; `moves` is empty if the game has no recorded moves. */
-  final case class MoveHistory(gameId: GameId, moves: List[MoveRecord]) extends GameResponse
+  final case class MoveHistory(roomId: RoomId, moves: List[MoveRecord]) extends GameResponse
 
   /** The recent chat history for a game, oldest first; `messages` is empty if the game has no recorded messages. */
-  final case class ChatHistory(gameId: GameId, messages: List[PlayerEvent.ChatMessage]) extends GameResponse
+  final case class ChatHistory(roomId: RoomId, messages: List[PlayerEvent.ChatMessage]) extends GameResponse
 
   // Error responses
 
   /** No game exists for the requested ID (neither active nor in completed-game storage). Maps to HTTP 404. */
-  final case class GameNotFound(gameId: GameId) extends GameResponse
+  final case class GameNotFound(roomId: RoomId) extends GameResponse
 
   /** The game exists but rejected the operation (wrong turn, illegal move, game already over). Maps to HTTP 409. */
   final case class MoveRejected(message: String) extends GameResponse
@@ -323,10 +323,10 @@ object GameManager {
   final case class ErrorResponse(message: String) extends GameResponse
 
   /** Sent in response to a successful [[SubscribePlayerToLobby]] or [[SubscribePlayerToGame]] request. */
-  final case class SubscribeAcknowledged(gameId: GameId) extends GameResponse
+  final case class SubscribeAcknowledged(roomId: RoomId) extends GameResponse
 
   /** Sent in response to a successful [[UnsubscribePlayerFromGame]] or [[UnsubscribePlayerFromLobby]] request. */
-  final case class UnsubscribeAcknowledged(gameId: GameId) extends GameResponse
+  final case class UnsubscribeAcknowledged(roomId: RoomId) extends GameResponse
 
   /** Emitted once when the DB restore is complete; used in tests to await the running state. */
   case object Ready extends GameResponse
@@ -436,7 +436,7 @@ object GameManager {
         // as current. An orphan match (no such lobby — e.g. its lobby was lost from Redis) falls back to a self-room
         // keyed by the matchId so the game is still reachable.
         val matchToRoom: Map[MatchId, RoomId] =
-          lobbies.flatMap(m => m.currentMatchId.map(_ -> m.gameId)).toMap
+          lobbies.flatMap(m => m.currentMatchId.map(_ -> m.roomId)).toMap
 
         // resolve each restored game to its room once, then derive the actor map and the player index from it
         val resolved = games.toList.map { case (matchId, (gameType, game)) =>
@@ -523,35 +523,35 @@ object GameManager {
           lobbyManager ! LobbyManager.CreateLobby(gameType, host, adapter)
           Behaviors.same
 
-        case JoinLobby(gameId, player, replyTo) =>
+        case JoinLobby(roomId, player, replyTo) =>
           val adapter = context.messageAdapter[GameResponse](LobbyResponseIntercepted(_, player.id, replyTo))
-          lobbyManager ! LobbyManager.JoinLobby(gameId, player, adapter)
+          lobbyManager ! LobbyManager.JoinLobby(roomId, player, adapter)
           Behaviors.same
 
-        case LeaveLobby(gameId, player, replyTo) =>
-          activeGames.get(gameId) match {
+        case LeaveLobby(roomId, player, replyTo) =>
+          activeGames.get(roomId) match {
             // game in progress: leaving it is a forfeit, handled by the game actor (which then self-completes and
             // triggers GameCompleted -> MarkCompleted, moving the lobby to Completed)
             case Some((gameType, _, gameActor)) =>
               val adaptedRef: ActorRef[Either[GameError, GameState]] =
-                context.messageAdapter(response => WrappedForfeitResponse(response, gameId, replyTo))
+                context.messageAdapter(response => WrappedForfeitResponse(response, roomId, replyTo))
               gameActor ! GameRegistry.forType(gameType).actor.forfeitCommand(player.id, adaptedRef)
             // pre-game (or unknown) lobby: ordinary leave / host-cancel handled by LobbyManager as before
             case None =>
-              lobbyManager ! LobbyManager.LeaveLobby(gameId, player, replyTo)
+              lobbyManager ! LobbyManager.LeaveLobby(roomId, player, replyTo)
           }
           Behaviors.same
 
-        case CancelLobby(gameId, playerId, replyTo) =>
+        case CancelLobby(roomId, playerId, replyTo) =>
           // an in-progress game cannot be cancelled — at that point a host leaving is a forfeit, not a lobby cancel
-          if (activeGames.contains(gameId))
-            replyTo ! LobbyErrorResponse(LobbyError.GameInProgress(gameId))
+          if (activeGames.contains(roomId))
+            replyTo ! LobbyErrorResponse(LobbyError.GameInProgress(roomId))
           else
-            lobbyManager ! LobbyManager.CancelLobby(gameId, playerId, replyTo)
+            lobbyManager ! LobbyManager.CancelLobby(roomId, playerId, replyTo)
           Behaviors.same
 
-        case StartGame(gameId, playerId, replyTo) =>
-          lobbyManager ! LobbyManager.StartGame(gameId, playerId, replyTo)
+        case StartGame(roomId, playerId, replyTo) =>
+          lobbyManager ! LobbyManager.StartGame(roomId, playerId, replyTo)
           Behaviors.same
 
         case ListLobbies(gameType, page, limit, replyTo) =>
@@ -559,52 +559,52 @@ object GameManager {
           lobbyManager ! LobbyManager.ListLobbies(gameType, page, limit, adapter)
           Behaviors.same
 
-        case GetLobbyInfo(gameId, replyTo) =>
-          lobbyManager ! LobbyManager.GetLobbyInfo(gameId, replyTo)
+        case GetLobbyInfo(roomId, replyTo) =>
+          lobbyManager ! LobbyManager.GetLobbyInfo(roomId, replyTo)
           Behaviors.same
 
         case LobbyResponseIntercepted(response, playerId, replyTo) =>
-          val maybeGameId = response match {
-            case LobbyCreated(gameId, _)   => Some(gameId)
-            case LobbyJoined(gameId, _, _) => Some(gameId)
+          val maybeRoomId = response match {
+            case LobbyCreated(roomId, _)   => Some(roomId)
+            case LobbyJoined(roomId, _, _) => Some(roomId)
             case _                         => None
           }
-          maybeGameId match {
-            case Some(gameId) =>
+          maybeRoomId match {
+            case Some(roomId) =>
               askPlayerRef(context, playerManager, playerId) { ref =>
-                PlayerRefForSubscribe(ref, gameId, playerId, response, replyTo)
+                PlayerRefForSubscribe(ref, roomId, playerId, response, replyTo)
               }
             case None =>
               replyTo ! response
           }
           Behaviors.same
 
-        case PlayerRefForSubscribe(playerRefOpt, gameId, playerId, response, replyTo) =>
+        case PlayerRefForSubscribe(playerRefOpt, roomId, playerId, response, replyTo) =>
           playerRefOpt.foreach(ref =>
-            lobbyManager ! LobbyManager.SubscribeToLobby(gameId, playerId, ref, context.system.ignoreRef)
+            lobbyManager ! LobbyManager.SubscribeToLobby(roomId, playerId, ref, context.system.ignoreRef)
           )
           replyTo ! response
           Behaviors.same
 
-        case SubscribePlayerToLobby(gameId, playerId, replyTo) =>
+        case SubscribePlayerToLobby(roomId, playerId, replyTo) =>
           askPlayerRef(context, playerManager, playerId) { ref =>
-            PlayerRefForLobbySpectate(ref, gameId, playerId, replyTo)
+            PlayerRefForLobbySpectate(ref, roomId, playerId, replyTo)
           }
           Behaviors.same
 
-        case PlayerRefForLobbySpectate(playerRefOpt, gameId, playerId, replyTo) =>
+        case PlayerRefForLobbySpectate(playerRefOpt, roomId, playerId, replyTo) =>
           playerRefOpt match {
             case Some(ref) =>
-              lobbyManager ! LobbyManager.SubscribeToLobby(gameId, playerId, ref, replyTo)
+              lobbyManager ! LobbyManager.SubscribeToLobby(roomId, playerId, ref, replyTo)
             case None =>
               context.log.warn(s"SubscribePlayerToLobby: player $playerId is not connected")
               replyTo ! ErrorResponse("Player is not connected via WebSocket")
           }
           Behaviors.same
 
-        case UnsubscribePlayerFromLobby(gameId, playerId, replyTo) =>
+        case UnsubscribePlayerFromLobby(roomId, playerId, replyTo) =>
           // LobbyManager keys subscribers by playerId, so no PlayerActor lookup is needed; it acks directly.
-          lobbyManager ! LobbyManager.UnsubscribeFromLobby(gameId, playerId, replyTo)
+          lobbyManager ! LobbyManager.UnsubscribeFromLobby(roomId, playerId, replyTo)
           Behaviors.same
 
         case GetPlayerSessions(playerId, replyTo) =>
@@ -624,64 +624,64 @@ object GameManager {
           replyTo ! PlayerSessions(lobbies, games)
           Behaviors.same
 
-        case SendChat(gameId, sender, text) =>
-          val event = PlayerEvent.ChatMessage(gameId, sender.id, sender.name, text, Instant.now())
-          val liveMatch = activeGames.get(gameId)
+        case SendChat(roomId, sender, text) =>
+          val event = PlayerEvent.ChatMessage(roomId, sender.id, sender.name, text, Instant.now())
+          val liveMatch = activeGames.get(roomId)
           liveMatch match {
             case Some((gameType, _, gameActor)) =>
               gameActor ! GameRegistry.forType(gameType).actor.broadcastCommand(event)
             case None =>
-              // not in progress (or unknown): fan out via the lobby; a bogus gameId is a harmless no-op there
-              lobbyManager ! LobbyManager.BroadcastChat(gameId, event)
+              // not in progress (or unknown): fan out via the lobby; a bogus roomId is a harmless no-op there
+              lobbyManager ! LobbyManager.BroadcastChat(roomId, event)
           }
           // record the send for analytics (gameType is None for lobby chat, before the game starts)
-          publisher.publish(GameEvent.ChatSent(gameId, liveMatch.map(_._1)))
+          publisher.publish(GameEvent.ChatSent(roomId, liveMatch.map(_._1)))
           // record to the bounded chat history so late joiners can backscroll; best-effort, never blocks the send
           chatRepo.append(event).unsafeRunAsync {
-            case Left(ex) => context.log.warn(s"Failed to persist chat message for $gameId", ex)
+            case Left(ex) => context.log.warn(s"Failed to persist chat message for $roomId", ex)
             case Right(_) => ()
           }
           Behaviors.same
 
-        case SubscribePlayerToGame(gameId, playerId, replyTo) =>
+        case SubscribePlayerToGame(roomId, playerId, replyTo) =>
           askPlayerRef(context, playerManager, playerId) { ref =>
-            PlayerRefForGameSpectate(ref, gameId, playerId, replyTo)
+            PlayerRefForGameSpectate(ref, roomId, playerId, replyTo)
           }
           Behaviors.same
 
-        case PlayerRefForGameSpectate(playerRefOpt, gameId, playerId, replyTo) =>
+        case PlayerRefForGameSpectate(playerRefOpt, roomId, playerId, replyTo) =>
           playerRefOpt match {
             case Some(ref) =>
-              activeGames.get(gameId) match {
+              activeGames.get(roomId) match {
                 case Some((gameType, _, gameActor)) =>
                   gameActor ! GameRegistry.forType(gameType).actor.subscribeCommand(ref, playerId)
-                  replyTo ! SubscribeAcknowledged(gameId)
+                  replyTo ! SubscribeAcknowledged(roomId)
                 case None =>
-                  replyTo ! ErrorResponse(s"No active game found for $gameId")
+                  replyTo ! ErrorResponse(s"No active game found for $roomId")
               }
             case None =>
-              context.log.warn(s"SubscribePlayerToGame: player is not connected for game $gameId")
+              context.log.warn(s"SubscribePlayerToGame: player is not connected for game $roomId")
               replyTo ! ErrorResponse("Player is not connected via WebSocket")
           }
           Behaviors.same
 
-        case UnsubscribePlayerFromGame(gameId, playerId, replyTo) =>
+        case UnsubscribePlayerFromGame(roomId, playerId, replyTo) =>
           askPlayerRef(context, playerManager, playerId) { ref =>
-            PlayerRefForGameUnsubscribe(ref, gameId, replyTo)
+            PlayerRefForGameUnsubscribe(ref, roomId, replyTo)
           }
           Behaviors.same
 
-        case PlayerRefForGameUnsubscribe(playerRefOpt, gameId, replyTo) =>
+        case PlayerRefForGameUnsubscribe(playerRefOpt, roomId, replyTo) =>
           // Unsubscribe is best-effort and idempotent: if the player is still connected and the game is still active,
           // drop their session from the game actor's subscriber set; otherwise there is nothing to remove. Either way
           // the DELETE succeeds, so a client can safely call it without first checking its own subscription state.
-          (playerRefOpt, activeGames.get(gameId)) match {
+          (playerRefOpt, activeGames.get(roomId)) match {
             case (Some(ref), Some((gameType, _, gameActor))) =>
               gameActor ! GameRegistry.forType(gameType).actor.unsubscribeCommand(ref)
             case _ =>
               ()
           }
-          replyTo ! UnsubscribeAcknowledged(gameId)
+          replyTo ! UnsubscribeAcknowledged(roomId)
           Behaviors.same
 
         case RegisterPlayer(player, sessionOut, replyTo) =>
@@ -775,8 +775,8 @@ object GameManager {
             publisher
           )
 
-        case RunGameOperation(gameId, op, replyTo) =>
-          activeGames.get(gameId) match {
+        case RunGameOperation(roomId, op, replyTo) =>
+          activeGames.get(roomId) match {
             case Some((gameType, _, gameActor)) =>
               val adaptedRef: ActorRef[Either[GameError, GameState]] =
                 context.messageAdapter(response => WrappedGameResponse(response, replyTo))
@@ -787,74 +787,74 @@ object GameManager {
               }
 
             case None =>
-              completedMatch.get(gameId) match {
+              completedMatch.get(roomId) match {
                 case Some((matchId, gameType)) =>
                   op match {
                     case GameOperation.GetState =>
                       context.pipeToSelf(gameRepo.loadGame(matchId, gameType).attempt.unsafeToFuture()) {
-                        case Success(result) => CompletedGameLoaded(result, gameId, gameType, replyTo)
+                        case Success(result) => CompletedGameLoaded(result, roomId, gameType, replyTo)
                         // $COVERAGE-OFF$ .attempt converts IO failures to Success(Left(ex)); Failure is unreachable
-                        case Failure(ex) => CompletedGameLoaded(Left(ex), gameId, gameType, replyTo)
+                        case Failure(ex) => CompletedGameLoaded(Left(ex), roomId, gameType, replyTo)
                         // $COVERAGE-ON$
                       }
                     case _ =>
                       replyTo ! MoveRejected("Game has already ended")
                   }
                 case None =>
-                  context.log.warn(s"No game found for room $gameId to forward operation $op")
-                  replyTo ! GameNotFound(gameId)
+                  context.log.warn(s"No game found for room $roomId to forward operation $op")
+                  replyTo ! GameNotFound(roomId)
               }
           }
           Behaviors.same
 
-        case CompletedGameLoaded(result, gameId, gameType, replyTo) =>
+        case CompletedGameLoaded(result, roomId, gameType, replyTo) =>
           result match {
             case Right(Some(game)) =>
               replyTo ! GameStatus(GameRegistry.forType(gameType).serializeGame(game, None))
             case Right(None) =>
-              context.log.warn(s"Completed game $gameId has no record in the database")
-              replyTo ! GameNotFound(gameId)
+              context.log.warn(s"Completed game $roomId has no record in the database")
+              replyTo ! GameNotFound(roomId)
             case Left(ex) =>
               context.log.error("Failed to load completed game state from DB", ex)
               replyTo ! ErrorResponse("Failed to retrieve game state")
           }
           Behaviors.same
 
-        case GetMoveHistory(gameId, replyTo) =>
+        case GetMoveHistory(roomId, replyTo) =>
           // the move log is keyed by matchId. Resolve the room's live or most-recent match; if the id is not a known
           // room (e.g. a game finished before a restart, or a direct match lookup), fall back to using it as the match.
-          val matchId = activeGames.get(gameId).map(_._2).orElse(completedMatch.get(gameId).map(_._1)).getOrElse(gameId)
+          val matchId = activeGames.get(roomId).map(_._2).orElse(completedMatch.get(roomId).map(_._1)).getOrElse(roomId)
           context.pipeToSelf(moveRepo.loadMoves(matchId).attempt.unsafeToFuture()) {
-            case Success(result) => MoveHistoryLoaded(result, gameId, replyTo)
+            case Success(result) => MoveHistoryLoaded(result, roomId, replyTo)
             // $COVERAGE-OFF$ .attempt converts IO failures to Success(Left(ex)); Failure is unreachable
-            case Failure(ex) => MoveHistoryLoaded(Left(ex), gameId, replyTo)
+            case Failure(ex) => MoveHistoryLoaded(Left(ex), roomId, replyTo)
             // $COVERAGE-ON$
           }
           Behaviors.same
 
-        case MoveHistoryLoaded(result, gameId, replyTo) =>
+        case MoveHistoryLoaded(result, roomId, replyTo) =>
           result match {
-            case Right(moves) => replyTo ! MoveHistory(gameId, moves)
+            case Right(moves) => replyTo ! MoveHistory(roomId, moves)
             case Left(ex)     =>
-              context.log.error(s"Failed to load move history for $gameId", ex)
+              context.log.error(s"Failed to load move history for $roomId", ex)
               replyTo ! ErrorResponse("Failed to retrieve move history")
           }
           Behaviors.same
 
-        case GetChatHistory(gameId, replyTo) =>
-          context.pipeToSelf(chatRepo.recent(gameId).attempt.unsafeToFuture()) {
-            case Success(result) => ChatHistoryLoaded(result, gameId, replyTo)
+        case GetChatHistory(roomId, replyTo) =>
+          context.pipeToSelf(chatRepo.recent(roomId).attempt.unsafeToFuture()) {
+            case Success(result) => ChatHistoryLoaded(result, roomId, replyTo)
             // $COVERAGE-OFF$ .attempt converts IO failures to Success(Left(ex)); Failure is unreachable
-            case Failure(ex) => ChatHistoryLoaded(Left(ex), gameId, replyTo)
+            case Failure(ex) => ChatHistoryLoaded(Left(ex), roomId, replyTo)
             // $COVERAGE-ON$
           }
           Behaviors.same
 
-        case ChatHistoryLoaded(result, gameId, replyTo) =>
+        case ChatHistoryLoaded(result, roomId, replyTo) =>
           result match {
-            case Right(messages) => replyTo ! ChatHistory(gameId, messages)
+            case Right(messages) => replyTo ! ChatHistory(roomId, messages)
             case Left(ex)        =>
-              context.log.error(s"Failed to load chat history for $gameId", ex)
+              context.log.error(s"Failed to load chat history for $roomId", ex)
               replyTo ! ErrorResponse("Failed to retrieve chat history")
           }
           Behaviors.same
@@ -870,9 +870,9 @@ object GameManager {
           }
           Behaviors.same
 
-        case WrappedForfeitResponse(response, gameId, replyTo) =>
+        case WrappedForfeitResponse(response, roomId, replyTo) =>
           response match {
-            case Right(state) => replyTo ! GameForfeited(gameId, state)
+            case Right(state) => replyTo ! GameForfeited(roomId, state)
             case Left(error)  => replyTo ! MoveRejected(error.message)
           }
           Behaviors.same

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
@@ -17,7 +17,7 @@ import com.andy327.actor.events.{EventPublisher, GameEvent, NoOpEventPublisher}
 import com.andy327.actor.game.{GameOperation, GameRegistry, GameState}
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyError, LobbyMetadata, LobbyRepository, Player}
 import com.andy327.actor.persistence.PersistenceProtocol
-import com.andy327.model.core.{Game, GameError, GameId, GameType, PlayerId}
+import com.andy327.model.core.{Game, GameError, GameId, GameType, MatchId, PlayerId, RoomId}
 import com.andy327.persistence.db.{GameRepository, MoveHistoryRepository, MoveRecord, NoOpMoveHistoryRepository}
 
 /** A supervisor actor responsible for game actor lifecycle and request routing.
@@ -147,8 +147,11 @@ object GameManager {
 
   // --- Lifecycle commands ---
 
-  /** Sent by a game actor when its game reaches a terminal state (won or draw). */
-  final case class GameCompleted(gameId: GameId, result: GameLifecycleStatus.GameEnded) extends Command
+  /** Sent by a game actor when its match reaches a terminal state (won or draw). Carries both the `matchId` that just
+    * ended and the `roomId` hosting it, so GameManager can retire the match and address the room.
+    */
+  final case class GameCompleted(matchId: MatchId, roomId: RoomId, result: GameLifecycleStatus.GameEnded)
+      extends Command
 
   // --- Internal commands (not reachable from HTTP) ---
 
@@ -406,7 +409,8 @@ object GameManager {
       case RestoreGames(games, lobbies) =>
         val restoredActors = games.map { case (gameId, (gameType, game)) =>
           val gameActor = GameRegistry.forType(gameType).actor
-          val behavior = gameActor.fromSnapshot(gameId, game, persistActor, context.self, publisher)
+          // 3a: matchId == roomId == gameId; a fresh per-match id is introduced in the next commit
+          val behavior = gameActor.fromSnapshot(gameId, gameId, game, persistActor, context.self, publisher)
           val actorRef = context.spawn(behavior, s"game-$gameId").unsafeUpcast[GameActor.GameCommand]
           gameId -> (gameType, actorRef)
         }
@@ -650,7 +654,9 @@ object GameManager {
             Behaviors.same
           } else {
             val bundle = GameRegistry.forType(gameType)
-            val (game, behavior) = bundle.actor.create(gameId, players.toSeq, persistActor, context.self, publisher)
+            // 3a: matchId == roomId == gameId; a fresh per-match id is introduced in the next commit
+            val (game, behavior) =
+              bundle.actor.create(gameId, gameId, players.toSeq, persistActor, context.self, publisher)
             val actorRef = context.spawn(behavior, s"game-$gameId").unsafeUpcast[GameActor.GameCommand]
 
             subscribers.foreach { case (pid, ref) => actorRef ! bundle.actor.subscribeCommand(ref, pid) }
@@ -681,17 +687,17 @@ object GameManager {
             )
           }
 
-        case GameCompleted(gameId, result) =>
-          activeGames.get(gameId) match {
+        case GameCompleted(matchId, roomId, result) =>
+          activeGames.get(roomId) match {
             case Some((gameType, _)) =>
-              context.log.info(s"Game $gameId completed with result $result — actor self-terminating")
-              lobbyManager ! LobbyManager.MarkCompleted(gameId, result)
+              context.log.info(s"Match $matchId in room $roomId completed with result $result — actor self-terminating")
+              lobbyManager ! LobbyManager.MarkCompleted(roomId, result)
               // drop the finished game from every player's index, removing players left with no live games
               val prunedPlayerGames =
-                playerGames.view.mapValues(_ - gameId).filter(_._2.nonEmpty).toMap
+                playerGames.view.mapValues(_ - roomId).filter(_._2.nonEmpty).toMap
               running(
-                activeGames - gameId,
-                completedGameTypes + (gameId -> gameType),
+                activeGames - roomId,
+                completedGameTypes + (roomId -> gameType),
                 prunedPlayerGames,
                 lobbyManager,
                 playerManager,
@@ -702,7 +708,7 @@ object GameManager {
                 publisher
               )
             case None =>
-              context.log.warn(s"Received GameCompleted for unknown game: $gameId")
+              context.log.warn(s"Received GameCompleted for unknown room: $roomId")
               Behaviors.same
           }
 

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
@@ -147,11 +147,16 @@ object GameManager {
 
   // --- Lifecycle commands ---
 
-  /** Sent by a game actor when its match reaches a terminal state (won or draw). Carries both the `matchId` that just
-    * ended and the `roomId` hosting it, so GameManager can retire the match and address the room.
+  /** Sent by a game actor when its match reaches a terminal state (won or draw). Carries the `matchId` that just ended,
+    * the `roomId` hosting it, and the match's `subscribers` (by playerId) so GameManager can hand them back to the
+    * room, which then survives as a post-game room for chat and rematch.
     */
-  final case class GameCompleted(matchId: MatchId, roomId: RoomId, result: GameLifecycleStatus.GameEnded)
-      extends Command
+  final case class GameCompleted(
+      matchId: MatchId,
+      roomId: RoomId,
+      result: GameLifecycleStatus.GameEnded,
+      subscribers: Map[PlayerId, ActorRef[PlayerActor.Command]] = Map.empty
+  ) extends Command
 
   // --- Internal commands (not reachable from HTTP) ---
 
@@ -722,11 +727,12 @@ object GameManager {
             )
           }
 
-        case GameCompleted(matchId, roomId, result) =>
+        case GameCompleted(matchId, roomId, result, subscribers) =>
           activeGames.get(roomId) match {
             case Some((gameType, _, _)) =>
               context.log.info(s"Match $matchId in room $roomId completed with result $result — actor self-terminating")
-              lobbyManager ! LobbyManager.MarkCompleted(roomId, result)
+              // hand the match's subscribers back to the room so it survives as a post-game room (chat + rematch)
+              lobbyManager ! LobbyManager.MatchEnded(roomId, subscribers)
               // drop the finished game from every player's index, removing players left with no live games
               val prunedPlayerGames =
                 playerGames.view.mapValues(_ - roomId).filter(_._2.nonEmpty).toMap

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
@@ -15,7 +15,7 @@ import org.apache.pekko.actor.typed.scaladsl.Behaviors
 import org.apache.pekko.actor.typed.{ActorRef, Behavior, Terminated}
 
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyError, LobbyMetadata, LobbyRepository, Player}
-import com.andy327.model.core.{GameId, GameType, PlayerId}
+import com.andy327.model.core.{GameId, GameType, PlayerId, RoomId}
 
 /** A child actor of GameManager that owns all lobby lifecycle state.
   *
@@ -115,8 +115,14 @@ object LobbyManager {
 
   // --- Internal commands (sent by GameManager, not reachable from HTTP) ---
 
-  /** Move the lobby to the recently-ended cache and fan-out a [[PlayerEvent.GameEnded]] to subscribers. */
-  final private[core] case class MarkCompleted(gameId: GameId, result: GameLifecycleStatus.GameEnded) extends Command
+  /** A match in `gameId`'s room has ended. Move the room to [[GameLifecycleStatus.Finished]] and re-own the match's
+    * `subscribers` (handed back from the game actor) so the room can keep fanning out chat and the post-game state.
+    * The room survives in memory for chat and rematch; its now-stale in-progress record is dropped from Redis.
+    */
+  final private[core] case class MatchEnded(
+      gameId: RoomId,
+      subscribers: Map[PlayerId, ActorRef[PlayerActor.Command]]
+  ) extends Command
 
   /** Replace the in-memory lobby map with lobbies restored from Redis at startup. */
   final private[core] case class RestoreLobbies(lobbies: List[LobbyMetadata]) extends Command
@@ -390,17 +396,28 @@ object LobbyManager {
         replyTo ! GameManager.UnsubscribeAcknowledged(gameId)
         running(lobbies, recentlyEnded, updated, gameManager, lobbyRepo)
 
-      case MarkCompleted(gameId, result) =>
+      case MatchEnded(gameId, returnedSubscribers) =>
         lobbies.get(gameId) match {
           case Some(metadata) =>
-            context.log.info(s"Marking lobby $gameId as $result")
-            val updated = metadata.copy(status = result)
-            recentlyEnded.put(gameId, updated)
-            fanOut(subscribers, gameId, PlayerEvent.GameEnded(result))
+            context.log.info(s"Match in room $gameId ended; returning ${returnedSubscribers.size} players to the room")
+            val finished = metadata.copy(status = GameLifecycleStatus.Finished)
+            // re-own the match's subscribers (the game actor already sent them GameEnded before handing them back) and
+            // watch each so a later disconnect drops it, mirroring SubscribeToLobby
+            returnedSubscribers.values.foreach(context.watch)
+            val merged = subscribers.getOrElse(gameId, Map.empty) ++ returnedSubscribers
+            // tell everyone in the room it is now in its post-game state (drives the rematch process)
+            merged.values.foreach(_ ! PlayerActor.SendEvent(PlayerEvent.LobbyUpdated(finished)))
+            // the post-game room lives in memory only; drop the stale in-progress record so a restart won't revive it
             persist(lobbyRepo.deleteLobby(gameId))
-            running(lobbies - gameId, recentlyEnded, subscribers - gameId, gameManager, lobbyRepo)
+            running(
+              lobbies + (gameId -> finished),
+              recentlyEnded,
+              subscribers + (gameId -> merged),
+              gameManager,
+              lobbyRepo
+            )
           case None =>
-            context.log.info(s"MarkCompleted for $gameId: no lobby entry (already removed or never restored)")
+            context.log.info(s"MatchEnded for $gameId: no lobby entry (orphan match); dropping returned subscribers")
             Behaviors.same
         }
     }

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
@@ -42,8 +42,8 @@ import com.andy327.model.core.{GameId, GameType, PlayerId, RoomId}
   * Actor relationships:
   *   - Parent: [[GameManager]]
   *   - Receives from: [[GameManager]] (all lobby `Command` messages)
-  *   - Sends to: [[GameManager]] (`SpawnGame` to trigger game actor creation), [[PlayerActor]] (fan-out `LobbyUpdated`
-  *     and `GameEnded` events via `SendEvent`)
+  *   - Sends to: [[GameManager]] (`SpawnGame` to trigger game actor creation; `RoomClosed` when a room is retired for
+  *     good), [[PlayerActor]] (fan-out `LobbyUpdated` and `GameEnded` events via `SendEvent`)
   */
 object LobbyManager {
   sealed trait Command
@@ -326,6 +326,9 @@ object LobbyManager {
                   fanOut(subscribers, gameId, PlayerEvent.GameEnded(GameLifecycleStatus.Cancelled))
                   replyTo ! GameManager.LobbyLeft(gameId, s"Lobby $gameId ended - host left")
                   persist(lobbyRepo.deleteLobby(gameId))
+                  // a no-op if this room never completed a match (e.g. a pre-game lobby), but lets GameManager drop a
+                  // stale completedMatch entry if it had
+                  gameManager ! GameManager.RoomClosed(gameId)
                   running(lobbies - gameId, recentlyEnded, subscribers - gameId, gameManager, lobbyRepo, emptyRoomGrace)
                 case Some((newHostId, newHost)) =>
                   // promote a remaining member to host so the lobby survives the host leaving (host migration)
@@ -375,6 +378,8 @@ object LobbyManager {
             fanOut(subscribers, gameId, PlayerEvent.GameEnded(GameLifecycleStatus.Cancelled))
             replyTo ! GameManager.LobbyLeft(gameId, s"Lobby $gameId cancelled by host")
             persist(lobbyRepo.deleteLobby(gameId))
+            // a no-op unless this was a post-game room (a host can cancel a Finished room directly, ahead of eviction)
+            gameManager ! GameManager.RoomClosed(gameId)
             running(lobbies - gameId, recentlyEnded, subscribers - gameId, gameManager, lobbyRepo, emptyRoomGrace)
           case Some(_) =>
             replyTo ! GameManager.LobbyErrorResponse(LobbyError.NotHostError(gameId))
@@ -529,6 +534,8 @@ object LobbyManager {
             // tell any remaining watchers the room has closed, then retire it to the recently-ended cache
             fanOut(subscribers, id, PlayerEvent.GameEnded(GameLifecycleStatus.Cancelled))
             recentlyEnded.put(id, m.copy(status = GameLifecycleStatus.Cancelled))
+            // every evicted room here was Finished, so it always has a completedMatch entry for GameManager to drop
+            gameManager ! GameManager.RoomClosed(id)
           }
           running(
             lobbies -- stale.keySet,

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
@@ -15,7 +15,7 @@ import org.apache.pekko.actor.typed.scaladsl.Behaviors
 import org.apache.pekko.actor.typed.{ActorRef, Behavior, Terminated}
 
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyError, LobbyMetadata, LobbyRepository, Player}
-import com.andy327.model.core.{GameId, GameType, PlayerId, RoomId}
+import com.andy327.model.core.{GameType, PlayerId, RoomId}
 
 /** A child actor of GameManager that owns all lobby lifecycle state.
   *
@@ -55,25 +55,25 @@ object LobbyManager {
       extends Command
 
   /** Add `player` to an existing joinable lobby; replies with [[GameManager.LobbyJoined]] or an error. */
-  final case class JoinLobby(gameId: GameId, player: Player, replyTo: ActorRef[GameManager.GameResponse])
+  final case class JoinLobby(roomId: RoomId, player: Player, replyTo: ActorRef[GameManager.GameResponse])
       extends Command
 
   /** Remove `player` from a lobby. If the host leaves, the host role migrates to a remaining member and the lobby
     * survives; it is cancelled only when the host was the last player. Rejected with
     * [[lobby.LobbyError.GameInProgress]] once the game has started.
     */
-  final case class LeaveLobby(gameId: GameId, player: Player, replyTo: ActorRef[GameManager.GameResponse])
+  final case class LeaveLobby(roomId: RoomId, player: Player, replyTo: ActorRef[GameManager.GameResponse])
       extends Command
 
   /** Cancel a pre-game lobby on behalf of its host, moving it to the recently-ended cache and notifying subscribers.
     * Replies with [[GameManager.LobbyLeft]] on success, [[GameManager.LobbyErrorResponse]] if the caller is not the
     * host or the lobby is unknown.
     */
-  final case class CancelLobby(gameId: GameId, playerId: PlayerId, replyTo: ActorRef[GameManager.GameResponse])
+  final case class CancelLobby(roomId: RoomId, playerId: PlayerId, replyTo: ActorRef[GameManager.GameResponse])
       extends Command
 
   /** Validate the start request and, if valid, ask GameManager to spawn the game actor via a `SpawnGame` message. */
-  final case class StartGame(gameId: GameId, playerId: PlayerId, replyTo: ActorRef[GameManager.GameResponse])
+  final case class StartGame(roomId: RoomId, playerId: PlayerId, replyTo: ActorRef[GameManager.GameResponse])
       extends Command
 
   /** Return a paginated, optionally filtered list of joinable lobbies; replies with [[LobbiesListed]]. */
@@ -92,35 +92,35 @@ object LobbyManager {
       extends Command
 
   /** Return full metadata for one lobby (active or recently ended); replies with [[GameManager.LobbyInfo]]. */
-  final case class GetLobbyInfo(gameId: GameId, replyTo: ActorRef[GameManager.GameResponse]) extends Command
+  final case class GetLobbyInfo(roomId: RoomId, replyTo: ActorRef[GameManager.GameResponse]) extends Command
 
-  /** Register `playerRef` to receive [[PlayerEvent.LobbyUpdated]] push events for `gameId`.
+  /** Register `playerRef` to receive [[PlayerEvent.LobbyUpdated]] push events for `roomId`.
     *
     * Rejects with [[GameManager.LobbyErrorResponse]](`LobbyError.GameAlreadyStarted`) if the game is already
     * in progress; the caller should use the game subscribe endpoint instead. Pass `context.system.ignoreRef` for
     * `replyTo` on auto-subscribe paths where no acknowledgment is needed.
     */
   final case class SubscribeToLobby(
-      gameId: GameId,
+      roomId: RoomId,
       playerId: PlayerId,
       playerRef: ActorRef[PlayerActor.Command],
       replyTo: ActorRef[GameManager.GameResponse]
   ) extends Command
 
-  /** Deregister `playerId` from `gameId`'s push events. Idempotent: replies with
+  /** Deregister `playerId` from `roomId`'s push events. Idempotent: replies with
     * [[GameManager.UnsubscribeAcknowledged]] even if the player was not subscribed or the lobby is unknown.
     */
-  final case class UnsubscribeFromLobby(gameId: GameId, playerId: PlayerId, replyTo: ActorRef[GameManager.GameResponse])
+  final case class UnsubscribeFromLobby(roomId: RoomId, playerId: PlayerId, replyTo: ActorRef[GameManager.GameResponse])
       extends Command
 
   // --- Internal commands (sent by GameManager, not reachable from HTTP) ---
 
-  /** A match in `gameId`'s room has ended. Move the room to [[GameLifecycleStatus.Finished]] and re-own the match's
+  /** A match in `roomId`'s room has ended. Move the room to [[GameLifecycleStatus.Finished]] and re-own the match's
     * `subscribers` (handed back from the game actor) so the room can keep fanning out chat and the post-game state.
     * The room survives in memory for chat and rematch; its now-stale in-progress record is dropped from Redis.
     */
   final private[core] case class MatchEnded(
-      gameId: RoomId,
+      roomId: RoomId,
       subscribers: Map[PlayerId, ActorRef[PlayerActor.Command]]
   ) extends Command
 
@@ -128,7 +128,7 @@ object LobbyManager {
   final private[core] case class RestoreLobbies(lobbies: List[LobbyMetadata]) extends Command
 
   /** Fan `event` (a chat message) out to the lobby's subscribers, used while the match is still in its lobby phase. */
-  final private[core] case class BroadcastChat(gameId: GameId, event: PlayerEvent) extends Command
+  final private[core] case class BroadcastChat(roomId: RoomId, event: PlayerEvent) extends Command
 
   /** Periodic self-tick that tears down post-game (Finished) rooms idle past [[finishedRoomTtl]], or empty (no
     * connected subscribers) for at least [[emptyRoomGrace]].
@@ -178,9 +178,9 @@ object LobbyManager {
   )(implicit runtime: IORuntime): Behavior[Command] =
     Behaviors.withTimers { timers =>
       timers.startTimerWithFixedDelay(EvictIdleRooms, evictInterval)
-      val recentlyEnded: Cache[GameId, LobbyMetadata] = Scaffeine()
+      val recentlyEnded: Cache[RoomId, LobbyMetadata] = Scaffeine()
         .expireAfterWrite(recentlyEndedTtl)
-        .build[GameId, LobbyMetadata]()
+        .build[RoomId, LobbyMetadata]()
       running(Map.empty, recentlyEnded, Map.empty, gameManager, lobbyRepo, emptyRoomGrace)
     }
 
@@ -190,11 +190,11 @@ object LobbyManager {
     * players receive the update without the caller needing to know which actors are subscribed.
     */
   private def fanOut(
-      subscribers: Map[GameId, Map[PlayerId, ActorRef[PlayerActor.Command]]],
-      gameId: GameId,
+      subscribers: Map[RoomId, Map[PlayerId, ActorRef[PlayerActor.Command]]],
+      roomId: RoomId,
       event: PlayerEvent
   ): Unit =
-    subscribers.getOrElse(gameId, Map.empty).values.foreach(_ ! PlayerActor.SendEvent(event))
+    subscribers.getOrElse(roomId, Map.empty).values.foreach(_ ! PlayerActor.SendEvent(event))
 
   /** Seat order for a match: the host first, then the remaining players ordered by id, rotated left by the room's
     * match count. Rotation makes the first-move seat (seat 0) alternate across rematches; the first match (count 0)
@@ -218,9 +218,9 @@ object LobbyManager {
     *                       it down; see [[emptyRoomGrace]]
     */
   private def running(
-      lobbies: Map[GameId, LobbyMetadata],
-      recentlyEnded: Cache[GameId, LobbyMetadata],
-      subscribers: Map[GameId, Map[PlayerId, ActorRef[PlayerActor.Command]]],
+      lobbies: Map[RoomId, LobbyMetadata],
+      recentlyEnded: Cache[RoomId, LobbyMetadata],
+      subscribers: Map[RoomId, Map[PlayerId, ActorRef[PlayerActor.Command]]],
       gameManager: ActorRef[GameManager.Command],
       lobbyRepo: LobbyRepository,
       emptyRoomGrace: FiniteDuration
@@ -231,18 +231,18 @@ object LobbyManager {
         // (WaitingForPlayers/ReadyToStart) are dead across a restart — their players' sessions are gone — so drop and
         // delete them from Redis rather than leaving stale, un-rejoinable lobbies advertised in the list.
         val (keep, drop) = restored.partition(_.status == GameLifecycleStatus.InProgress)
-        val restoredMap = keep.map(m => m.gameId -> m).toMap
+        val restoredMap = keep.map(m => m.roomId -> m).toMap
         context.log.info(s"Restoring ${restoredMap.size} in-progress lobbies; deleting ${drop.size} dead pre-game ones")
-        drop.foreach(m => persist(lobbyRepo.deleteLobby(m.gameId)))
+        drop.foreach(m => persist(lobbyRepo.deleteLobby(m.roomId)))
         running(restoredMap, recentlyEnded, subscribers, gameManager, lobbyRepo, emptyRoomGrace)
 
-      case BroadcastChat(gameId, event) =>
-        fanOut(subscribers, gameId, event)
+      case BroadcastChat(roomId, event) =>
+        fanOut(subscribers, roomId, event)
         // chat keeps a post-game room alive: bump its activity so eviction doesn't close it mid-conversation
-        lobbies.get(gameId) match {
+        lobbies.get(roomId) match {
           case Some(m) =>
             running(
-              lobbies + (gameId -> m.copy(lastActivityAt = Instant.now())),
+              lobbies + (roomId -> m.copy(lastActivityAt = Instant.now())),
               recentlyEnded,
               subscribers,
               gameManager,
@@ -255,18 +255,18 @@ object LobbyManager {
       case CreateLobby(gameType, host, replyTo) =>
         context.log.info(s"Creating new lobby for game type $gameType with host ${host.name}")
         val lobby = LobbyMetadata.newLobby(gameType, host)
-        replyTo ! GameManager.LobbyCreated(lobby.gameId, host)
+        replyTo ! GameManager.LobbyCreated(lobby.roomId, host)
         persist(lobbyRepo.saveLobby(lobby))
-        running(lobbies + (lobby.gameId -> lobby), recentlyEnded, subscribers, gameManager, lobbyRepo, emptyRoomGrace)
+        running(lobbies + (lobby.roomId -> lobby), recentlyEnded, subscribers, gameManager, lobbyRepo, emptyRoomGrace)
 
-      case JoinLobby(gameId, player, replyTo) =>
-        lobbies.get(gameId) match {
+      case JoinLobby(roomId, player, replyTo) =>
+        lobbies.get(roomId) match {
           case Some(metadata) if metadata.status.isJoinable =>
             if (metadata.players.contains(player.id)) {
-              replyTo ! GameManager.LobbyErrorResponse(LobbyError.AlreadyInLobby(gameId))
+              replyTo ! GameManager.LobbyErrorResponse(LobbyError.AlreadyInLobby(roomId))
               Behaviors.same
             } else if (metadata.players.size >= metadata.gameType.maxPlayers) {
-              replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyFull(gameId))
+              replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyFull(roomId))
               Behaviors.same
             } else {
               val updatedPlayers = metadata.players + (player.id -> player)
@@ -274,11 +274,11 @@ object LobbyManager {
                 if (updatedPlayers.size >= metadata.gameType.minPlayers) GameLifecycleStatus.ReadyToStart
                 else GameLifecycleStatus.WaitingForPlayers
               val updatedMetadata = metadata.copy(players = updatedPlayers, status = updatedStatus)
-              replyTo ! GameManager.LobbyJoined(gameId, updatedMetadata, player)
-              fanOut(subscribers, gameId, PlayerEvent.LobbyUpdated(updatedMetadata))
+              replyTo ! GameManager.LobbyJoined(roomId, updatedMetadata, player)
+              fanOut(subscribers, roomId, PlayerEvent.LobbyUpdated(updatedMetadata))
               persist(lobbyRepo.saveLobby(updatedMetadata))
               running(
-                lobbies + (gameId -> updatedMetadata),
+                lobbies + (roomId -> updatedMetadata),
                 recentlyEnded,
                 subscribers,
                 gameManager,
@@ -288,21 +288,21 @@ object LobbyManager {
             }
 
           case Some(_) =>
-            replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotJoinable(gameId))
+            replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotJoinable(roomId))
             Behaviors.same
 
           case None =>
-            replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotFound(gameId))
+            replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotFound(roomId))
             Behaviors.same
         }
 
-      case LeaveLobby(gameId, player, replyTo) =>
-        lobbies.get(gameId) match {
+      case LeaveLobby(roomId, player, replyTo) =>
+        lobbies.get(roomId) match {
           // Leaving an in-progress game is a forfeit, handled by the game actor; GameManager routes those directly and
           // never forwards them here. This branch only guards the edge case where a lobby still shows InProgress but no
           // live game actor exists (e.g. mid-restore) — reject so the lobby cannot revert to a joinable status.
           case Some(metadata) if metadata.status == GameLifecycleStatus.InProgress =>
-            replyTo ! GameManager.LobbyErrorResponse(LobbyError.GameInProgress(gameId))
+            replyTo ! GameManager.LobbyErrorResponse(LobbyError.GameInProgress(roomId))
             Behaviors.same
 
           case Some(metadata) =>
@@ -313,34 +313,34 @@ object LobbyManager {
             val newMetadata = metadata.copy(players = updatedPlayers, status = updatedStatus)
 
             if (!metadata.players.contains(player.id)) {
-              context.log.info(s"Player ${player.name} already absent from lobby $gameId")
-              replyTo ! GameManager.LobbyLeft(gameId, s"${player.name} already absent from lobby $gameId")
+              context.log.info(s"Player ${player.name} already absent from lobby $roomId")
+              replyTo ! GameManager.LobbyLeft(roomId, s"${player.name} already absent from lobby $roomId")
               Behaviors.same
             } else if (player.id == metadata.hostId) {
               updatedPlayers.headOption match {
                 case None =>
                   // host was the last player remaining — disband the lobby
-                  context.log.info(s"Host (${player.name}) left lobby $gameId with no players left. Cancelling game...")
+                  context.log.info(s"Host (${player.name}) left lobby $roomId with no players left. Cancelling game...")
                   val cancelled = newMetadata.copy(status = GameLifecycleStatus.Cancelled)
-                  recentlyEnded.put(gameId, cancelled)
-                  fanOut(subscribers, gameId, PlayerEvent.GameEnded(GameLifecycleStatus.Cancelled))
-                  replyTo ! GameManager.LobbyLeft(gameId, s"Lobby $gameId ended - host left")
-                  persist(lobbyRepo.deleteLobby(gameId))
+                  recentlyEnded.put(roomId, cancelled)
+                  fanOut(subscribers, roomId, PlayerEvent.GameEnded(GameLifecycleStatus.Cancelled))
+                  replyTo ! GameManager.LobbyLeft(roomId, s"Lobby $roomId ended - host left")
+                  persist(lobbyRepo.deleteLobby(roomId))
                   // a no-op if this room never completed a match (e.g. a pre-game lobby), but lets GameManager drop a
                   // stale completedMatch entry if it had
-                  gameManager ! GameManager.RoomClosed(gameId)
-                  running(lobbies - gameId, recentlyEnded, subscribers - gameId, gameManager, lobbyRepo, emptyRoomGrace)
+                  gameManager ! GameManager.RoomClosed(roomId)
+                  running(lobbies - roomId, recentlyEnded, subscribers - roomId, gameManager, lobbyRepo, emptyRoomGrace)
                 case Some((newHostId, newHost)) =>
                   // promote a remaining member to host so the lobby survives the host leaving (host migration)
-                  context.log.info(s"Host (${player.name}) left lobby $gameId; transferring host to ${newHost.name}")
+                  context.log.info(s"Host (${player.name}) left lobby $roomId; transferring host to ${newHost.name}")
                   val migrated = newMetadata.copy(hostId = newHostId)
-                  val msg = s"${player.name} left lobby $gameId; host transferred to ${newHost.name}"
-                  replyTo ! GameManager.LobbyLeft(gameId, msg)
-                  fanOut(subscribers, gameId, PlayerEvent.LobbyUpdated(migrated))
-                  val updatedSubscribers = subscribers.updatedWith(gameId)(_.map(_ - player.id))
+                  val msg = s"${player.name} left lobby $roomId; host transferred to ${newHost.name}"
+                  replyTo ! GameManager.LobbyLeft(roomId, msg)
+                  fanOut(subscribers, roomId, PlayerEvent.LobbyUpdated(migrated))
+                  val updatedSubscribers = subscribers.updatedWith(roomId)(_.map(_ - player.id))
                   persist(lobbyRepo.saveLobby(migrated))
                   running(
-                    lobbies + (gameId -> migrated),
+                    lobbies + (roomId -> migrated),
                     recentlyEnded,
                     updatedSubscribers,
                     gameManager,
@@ -349,13 +349,13 @@ object LobbyManager {
                   )
               }
             } else {
-              context.log.info(s"Player ${player.name} left lobby $gameId")
-              replyTo ! GameManager.LobbyLeft(gameId, s"${player.name} left lobby $gameId")
-              fanOut(subscribers, gameId, PlayerEvent.LobbyUpdated(newMetadata))
-              val updatedSubscribers = subscribers.updatedWith(gameId)(_.map(_ - player.id))
+              context.log.info(s"Player ${player.name} left lobby $roomId")
+              replyTo ! GameManager.LobbyLeft(roomId, s"${player.name} left lobby $roomId")
+              fanOut(subscribers, roomId, PlayerEvent.LobbyUpdated(newMetadata))
+              val updatedSubscribers = subscribers.updatedWith(roomId)(_.map(_ - player.id))
               persist(lobbyRepo.saveLobby(newMetadata))
               running(
-                lobbies + (gameId -> newMetadata),
+                lobbies + (roomId -> newMetadata),
                 recentlyEnded,
                 updatedSubscribers,
                 gameManager,
@@ -365,49 +365,49 @@ object LobbyManager {
             }
 
           case None =>
-            replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotFound(gameId))
+            replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotFound(roomId))
             Behaviors.same
         }
 
-      case CancelLobby(gameId, playerId, replyTo) =>
-        lobbies.get(gameId) match {
+      case CancelLobby(roomId, playerId, replyTo) =>
+        lobbies.get(roomId) match {
           case Some(metadata) if metadata.hostId == playerId =>
-            context.log.info(s"Host cancelled lobby $gameId")
+            context.log.info(s"Host cancelled lobby $roomId")
             val cancelled = metadata.copy(status = GameLifecycleStatus.Cancelled)
-            recentlyEnded.put(gameId, cancelled)
-            fanOut(subscribers, gameId, PlayerEvent.GameEnded(GameLifecycleStatus.Cancelled))
-            replyTo ! GameManager.LobbyLeft(gameId, s"Lobby $gameId cancelled by host")
-            persist(lobbyRepo.deleteLobby(gameId))
+            recentlyEnded.put(roomId, cancelled)
+            fanOut(subscribers, roomId, PlayerEvent.GameEnded(GameLifecycleStatus.Cancelled))
+            replyTo ! GameManager.LobbyLeft(roomId, s"Lobby $roomId cancelled by host")
+            persist(lobbyRepo.deleteLobby(roomId))
             // a no-op unless this was a post-game room (a host can cancel a Finished room directly, ahead of eviction)
-            gameManager ! GameManager.RoomClosed(gameId)
-            running(lobbies - gameId, recentlyEnded, subscribers - gameId, gameManager, lobbyRepo, emptyRoomGrace)
+            gameManager ! GameManager.RoomClosed(roomId)
+            running(lobbies - roomId, recentlyEnded, subscribers - roomId, gameManager, lobbyRepo, emptyRoomGrace)
           case Some(_) =>
-            replyTo ! GameManager.LobbyErrorResponse(LobbyError.NotHostError(gameId))
+            replyTo ! GameManager.LobbyErrorResponse(LobbyError.NotHostError(roomId))
             Behaviors.same
           case None =>
-            replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotFound(gameId))
+            replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotFound(roomId))
             Behaviors.same
         }
 
-      case StartGame(gameId, playerId, replyTo) =>
+      case StartGame(roomId, playerId, replyTo) =>
         // a host may start a ready pre-game lobby, or start a rematch from a finished room (same roster)
         def startable(status: GameLifecycleStatus): Boolean =
           status == GameLifecycleStatus.ReadyToStart || status == GameLifecycleStatus.Finished
-        lobbies.get(gameId) match {
+        lobbies.get(roomId) match {
           case Some(metadata) if metadata.hostId == playerId && startable(metadata.status) =>
             val rematch = metadata.status == GameLifecycleStatus.Finished
             val newStatus = if (rematch) "rematch" else "start"
-            context.log.info(s"Lobby $gameId validated for $newStatus — delegating to GM")
-            // mint a fresh match id for this playthrough; the room id (gameId) stays stable across rematches
+            context.log.info(s"Lobby $roomId validated for $newStatus — delegating to GM")
+            // mint a fresh match id for this playthrough; the room id (roomId) stays stable across rematches
             val matchId = UUID.randomUUID()
             val updatedMetadata = metadata.copy(
               status = GameLifecycleStatus.InProgress,
               currentMatchId = Some(matchId),
               matchCount = metadata.matchCount + 1
             )
-            val lobbySubscribers = subscribers.getOrElse(gameId, Map.empty)
+            val lobbySubscribers = subscribers.getOrElse(roomId, Map.empty)
             gameManager ! GameManager.SpawnGame(
-              gameId,
+              roomId,
               matchId,
               metadata.gameType,
               seatOrder(metadata),
@@ -416,24 +416,24 @@ object LobbyManager {
             )
             persist(lobbyRepo.saveLobby(updatedMetadata))
             running(
-              lobbies + (gameId -> updatedMetadata),
+              lobbies + (roomId -> updatedMetadata),
               recentlyEnded,
-              subscribers - gameId,
+              subscribers - roomId,
               gameManager,
               lobbyRepo,
               emptyRoomGrace
             )
 
           case Some(metadata) if metadata.hostId != playerId =>
-            replyTo ! GameManager.LobbyErrorResponse(LobbyError.NotHostError(gameId))
+            replyTo ! GameManager.LobbyErrorResponse(LobbyError.NotHostError(roomId))
             Behaviors.same
 
           case Some(_) =>
-            replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotReady(gameId))
+            replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotReady(roomId))
             Behaviors.same
 
           case None =>
-            replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotFound(gameId))
+            replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotFound(roomId))
             Behaviors.same
         }
 
@@ -456,62 +456,62 @@ object LobbyManager {
         replyTo ! LobbyManager.PlayerLobbies(mine)
         Behaviors.same
 
-      case GetLobbyInfo(gameId, replyTo) =>
-        context.log.info(s"Getting lobby metadata for game $gameId")
-        lobbies.get(gameId).orElse(recentlyEnded.getIfPresent(gameId)) match {
+      case GetLobbyInfo(roomId, replyTo) =>
+        context.log.info(s"Getting lobby metadata for game $roomId")
+        lobbies.get(roomId).orElse(recentlyEnded.getIfPresent(roomId)) match {
           case Some(metadata) => replyTo ! GameManager.LobbyInfo(metadata)
-          case None           => replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotFound(gameId))
+          case None           => replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotFound(roomId))
         }
         Behaviors.same
 
-      case SubscribeToLobby(gameId, playerId, playerRef, replyTo) =>
-        lobbies.get(gameId) match {
+      case SubscribeToLobby(roomId, playerId, playerRef, replyTo) =>
+        lobbies.get(roomId) match {
           case Some(metadata) if metadata.status == GameLifecycleStatus.InProgress =>
-            replyTo ! GameManager.LobbyErrorResponse(LobbyError.GameAlreadyStarted(gameId))
+            replyTo ! GameManager.LobbyErrorResponse(LobbyError.GameAlreadyStarted(roomId))
             Behaviors.same
           case Some(metadata) =>
             // watch the subscriber so a disconnect (its PlayerActor stopping) drops it from the map automatically,
             // mirroring TurnBasedGameActor; without this a dead ref would linger and receive dead-letter fan-out
             context.watch(playerRef)
-            val updated = subscribers.getOrElse(gameId, Map.empty) + (playerId -> playerRef)
+            val updated = subscribers.getOrElse(roomId, Map.empty) + (playerId -> playerRef)
             playerRef ! PlayerActor.SendEvent(PlayerEvent.LobbyUpdated(metadata))
-            replyTo ! GameManager.SubscribeAcknowledged(gameId)
-            running(lobbies, recentlyEnded, subscribers + (gameId -> updated), gameManager, lobbyRepo, emptyRoomGrace)
+            replyTo ! GameManager.SubscribeAcknowledged(roomId)
+            running(lobbies, recentlyEnded, subscribers + (roomId -> updated), gameManager, lobbyRepo, emptyRoomGrace)
           case None =>
-            replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotFound(gameId))
+            replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotFound(roomId))
             Behaviors.same
         }
 
-      case UnsubscribeFromLobby(gameId, playerId, replyTo) =>
+      case UnsubscribeFromLobby(roomId, playerId, replyTo) =>
         // idempotent: unwatch and drop the player's ref if present, otherwise a harmless no-op; either way ack
-        subscribers.getOrElse(gameId, Map.empty).get(playerId).foreach(context.unwatch)
-        val updated = subscribers.updatedWith(gameId)(_.map(_ - playerId).filter(_.nonEmpty))
-        replyTo ! GameManager.UnsubscribeAcknowledged(gameId)
+        subscribers.getOrElse(roomId, Map.empty).get(playerId).foreach(context.unwatch)
+        val updated = subscribers.updatedWith(roomId)(_.map(_ - playerId).filter(_.nonEmpty))
+        replyTo ! GameManager.UnsubscribeAcknowledged(roomId)
         running(lobbies, recentlyEnded, updated, gameManager, lobbyRepo, emptyRoomGrace)
 
-      case MatchEnded(gameId, returnedSubscribers) =>
-        lobbies.get(gameId) match {
+      case MatchEnded(roomId, returnedSubscribers) =>
+        lobbies.get(roomId) match {
           case Some(metadata) =>
-            context.log.info(s"Match in room $gameId ended; returning ${returnedSubscribers.size} players to the room")
+            context.log.info(s"Match in room $roomId ended; returning ${returnedSubscribers.size} players to the room")
             val finished = metadata.copy(status = GameLifecycleStatus.Finished, lastActivityAt = Instant.now())
             // re-own the match's subscribers (the game actor already sent them GameEnded before handing them back) and
             // watch each so a later disconnect drops it, mirroring SubscribeToLobby
             returnedSubscribers.values.foreach(context.watch)
-            val merged = subscribers.getOrElse(gameId, Map.empty) ++ returnedSubscribers
+            val merged = subscribers.getOrElse(roomId, Map.empty) ++ returnedSubscribers
             // tell everyone in the room it is now in its post-game state (drives the rematch process)
             merged.values.foreach(_ ! PlayerActor.SendEvent(PlayerEvent.LobbyUpdated(finished)))
             // the post-game room lives in memory only; drop the stale in-progress record so a restart won't revive it
-            persist(lobbyRepo.deleteLobby(gameId))
+            persist(lobbyRepo.deleteLobby(roomId))
             running(
-              lobbies + (gameId -> finished),
+              lobbies + (roomId -> finished),
               recentlyEnded,
-              subscribers + (gameId -> merged),
+              subscribers + (roomId -> merged),
               gameManager,
               lobbyRepo,
               emptyRoomGrace
             )
           case None =>
-            context.log.info(s"MatchEnded for $gameId: no lobby entry (orphan match); dropping returned subscribers")
+            context.log.info(s"MatchEnded for $roomId: no lobby entry (orphan match); dropping returned subscribers")
             Behaviors.same
         }
 

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
@@ -130,7 +130,9 @@ object LobbyManager {
   /** Fan `event` (a chat message) out to the lobby's subscribers, used while the match is still in its lobby phase. */
   final private[core] case class BroadcastChat(gameId: GameId, event: PlayerEvent) extends Command
 
-  /** Periodic self-tick that tears down post-game (Finished) rooms that are empty or idle past [[finishedRoomTtl]]. */
+  /** Periodic self-tick that tears down post-game (Finished) rooms idle past [[finishedRoomTtl]], or empty (no
+    * connected subscribers) for at least [[emptyRoomGrace]].
+    */
   final private[core] case object EvictIdleRooms extends Command
 
   // --- Response type owned by LobbyManager ---
@@ -148,6 +150,12 @@ object LobbyManager {
   /** A post-game (Finished) room with no connected players, or idle for longer than this, is torn down. */
   val finishedRoomTtl: FiniteDuration = 30.minutes
 
+  /** A post-game (Finished) room with no connected players is torn down once it has *also* sat idle this long, so a
+    * momentary zero-subscriber blip (e.g. a player's browser tab reloading) isn't enough to evict it on the very next
+    * tick.
+    */
+  val emptyRoomGrace: FiniteDuration = 2.minutes
+
   /** How often the idle-room eviction runs. */
   private val evictInterval: FiniteDuration = 1.minute
 
@@ -160,16 +168,20 @@ object LobbyManager {
       case Right(()) => ()
     }
 
+  /** @param emptyRoomGrace overrides [[emptyRoomGrace]] for the empty-subscriber eviction check; exposed so tests can
+    *                        shrink it instead of sleeping real time.
+    */
   def apply(
       gameManager: ActorRef[GameManager.Command],
-      lobbyRepo: LobbyRepository
+      lobbyRepo: LobbyRepository,
+      emptyRoomGrace: FiniteDuration = LobbyManager.emptyRoomGrace
   )(implicit runtime: IORuntime): Behavior[Command] =
     Behaviors.withTimers { timers =>
       timers.startTimerWithFixedDelay(EvictIdleRooms, evictInterval)
       val recentlyEnded: Cache[GameId, LobbyMetadata] = Scaffeine()
         .expireAfterWrite(recentlyEndedTtl)
         .build[GameId, LobbyMetadata]()
-      running(Map.empty, recentlyEnded, Map.empty, gameManager, lobbyRepo)
+      running(Map.empty, recentlyEnded, Map.empty, gameManager, lobbyRepo, emptyRoomGrace)
     }
 
   /** Sends a [[PlayerEvent]] to every PlayerActor subscribed to the given lobby.
@@ -202,13 +214,16 @@ object LobbyManager {
     * @param subscribers per-lobby map from PlayerId to PlayerActor ref for players registered to receive push events
     * @param gameManager parent ref used to send [[GameManager.SpawnGame]] on a valid start request
     * @param lobbyRepo repository used for fire-and-forget persistence on every state change
+    * @param emptyRoomGrace how long a Finished room with no subscribers must sit idle before [[EvictIdleRooms]] tears
+    *                       it down; see [[emptyRoomGrace]]
     */
   private def running(
       lobbies: Map[GameId, LobbyMetadata],
       recentlyEnded: Cache[GameId, LobbyMetadata],
       subscribers: Map[GameId, Map[PlayerId, ActorRef[PlayerActor.Command]]],
       gameManager: ActorRef[GameManager.Command],
-      lobbyRepo: LobbyRepository
+      lobbyRepo: LobbyRepository,
+      emptyRoomGrace: FiniteDuration
   )(implicit runtime: IORuntime): Behavior[Command] = Behaviors.receive[Command] { (context, message) =>
     message match {
       case RestoreLobbies(restored) =>
@@ -219,7 +234,7 @@ object LobbyManager {
         val restoredMap = keep.map(m => m.gameId -> m).toMap
         context.log.info(s"Restoring ${restoredMap.size} in-progress lobbies; deleting ${drop.size} dead pre-game ones")
         drop.foreach(m => persist(lobbyRepo.deleteLobby(m.gameId)))
-        running(restoredMap, recentlyEnded, subscribers, gameManager, lobbyRepo)
+        running(restoredMap, recentlyEnded, subscribers, gameManager, lobbyRepo, emptyRoomGrace)
 
       case BroadcastChat(gameId, event) =>
         fanOut(subscribers, gameId, event)
@@ -231,7 +246,8 @@ object LobbyManager {
               recentlyEnded,
               subscribers,
               gameManager,
-              lobbyRepo
+              lobbyRepo,
+              emptyRoomGrace
             )
           case None => Behaviors.same
         }
@@ -241,7 +257,7 @@ object LobbyManager {
         val lobby = LobbyMetadata.newLobby(gameType, host)
         replyTo ! GameManager.LobbyCreated(lobby.gameId, host)
         persist(lobbyRepo.saveLobby(lobby))
-        running(lobbies + (lobby.gameId -> lobby), recentlyEnded, subscribers, gameManager, lobbyRepo)
+        running(lobbies + (lobby.gameId -> lobby), recentlyEnded, subscribers, gameManager, lobbyRepo, emptyRoomGrace)
 
       case JoinLobby(gameId, player, replyTo) =>
         lobbies.get(gameId) match {
@@ -261,7 +277,14 @@ object LobbyManager {
               replyTo ! GameManager.LobbyJoined(gameId, updatedMetadata, player)
               fanOut(subscribers, gameId, PlayerEvent.LobbyUpdated(updatedMetadata))
               persist(lobbyRepo.saveLobby(updatedMetadata))
-              running(lobbies + (gameId -> updatedMetadata), recentlyEnded, subscribers, gameManager, lobbyRepo)
+              running(
+                lobbies + (gameId -> updatedMetadata),
+                recentlyEnded,
+                subscribers,
+                gameManager,
+                lobbyRepo,
+                emptyRoomGrace
+              )
             }
 
           case Some(_) =>
@@ -303,7 +326,7 @@ object LobbyManager {
                   fanOut(subscribers, gameId, PlayerEvent.GameEnded(GameLifecycleStatus.Cancelled))
                   replyTo ! GameManager.LobbyLeft(gameId, s"Lobby $gameId ended - host left")
                   persist(lobbyRepo.deleteLobby(gameId))
-                  running(lobbies - gameId, recentlyEnded, subscribers - gameId, gameManager, lobbyRepo)
+                  running(lobbies - gameId, recentlyEnded, subscribers - gameId, gameManager, lobbyRepo, emptyRoomGrace)
                 case Some((newHostId, newHost)) =>
                   // promote a remaining member to host so the lobby survives the host leaving (host migration)
                   context.log.info(s"Host (${player.name}) left lobby $gameId; transferring host to ${newHost.name}")
@@ -313,7 +336,14 @@ object LobbyManager {
                   fanOut(subscribers, gameId, PlayerEvent.LobbyUpdated(migrated))
                   val updatedSubscribers = subscribers.updatedWith(gameId)(_.map(_ - player.id))
                   persist(lobbyRepo.saveLobby(migrated))
-                  running(lobbies + (gameId -> migrated), recentlyEnded, updatedSubscribers, gameManager, lobbyRepo)
+                  running(
+                    lobbies + (gameId -> migrated),
+                    recentlyEnded,
+                    updatedSubscribers,
+                    gameManager,
+                    lobbyRepo,
+                    emptyRoomGrace
+                  )
               }
             } else {
               context.log.info(s"Player ${player.name} left lobby $gameId")
@@ -321,7 +351,14 @@ object LobbyManager {
               fanOut(subscribers, gameId, PlayerEvent.LobbyUpdated(newMetadata))
               val updatedSubscribers = subscribers.updatedWith(gameId)(_.map(_ - player.id))
               persist(lobbyRepo.saveLobby(newMetadata))
-              running(lobbies + (gameId -> newMetadata), recentlyEnded, updatedSubscribers, gameManager, lobbyRepo)
+              running(
+                lobbies + (gameId -> newMetadata),
+                recentlyEnded,
+                updatedSubscribers,
+                gameManager,
+                lobbyRepo,
+                emptyRoomGrace
+              )
             }
 
           case None =>
@@ -338,7 +375,7 @@ object LobbyManager {
             fanOut(subscribers, gameId, PlayerEvent.GameEnded(GameLifecycleStatus.Cancelled))
             replyTo ! GameManager.LobbyLeft(gameId, s"Lobby $gameId cancelled by host")
             persist(lobbyRepo.deleteLobby(gameId))
-            running(lobbies - gameId, recentlyEnded, subscribers - gameId, gameManager, lobbyRepo)
+            running(lobbies - gameId, recentlyEnded, subscribers - gameId, gameManager, lobbyRepo, emptyRoomGrace)
           case Some(_) =>
             replyTo ! GameManager.LobbyErrorResponse(LobbyError.NotHostError(gameId))
             Behaviors.same
@@ -373,7 +410,14 @@ object LobbyManager {
               lobbySubscribers
             )
             persist(lobbyRepo.saveLobby(updatedMetadata))
-            running(lobbies + (gameId -> updatedMetadata), recentlyEnded, subscribers - gameId, gameManager, lobbyRepo)
+            running(
+              lobbies + (gameId -> updatedMetadata),
+              recentlyEnded,
+              subscribers - gameId,
+              gameManager,
+              lobbyRepo,
+              emptyRoomGrace
+            )
 
           case Some(metadata) if metadata.hostId != playerId =>
             replyTo ! GameManager.LobbyErrorResponse(LobbyError.NotHostError(gameId))
@@ -427,7 +471,7 @@ object LobbyManager {
             val updated = subscribers.getOrElse(gameId, Map.empty) + (playerId -> playerRef)
             playerRef ! PlayerActor.SendEvent(PlayerEvent.LobbyUpdated(metadata))
             replyTo ! GameManager.SubscribeAcknowledged(gameId)
-            running(lobbies, recentlyEnded, subscribers + (gameId -> updated), gameManager, lobbyRepo)
+            running(lobbies, recentlyEnded, subscribers + (gameId -> updated), gameManager, lobbyRepo, emptyRoomGrace)
           case None =>
             replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotFound(gameId))
             Behaviors.same
@@ -438,7 +482,7 @@ object LobbyManager {
         subscribers.getOrElse(gameId, Map.empty).get(playerId).foreach(context.unwatch)
         val updated = subscribers.updatedWith(gameId)(_.map(_ - playerId).filter(_.nonEmpty))
         replyTo ! GameManager.UnsubscribeAcknowledged(gameId)
-        running(lobbies, recentlyEnded, updated, gameManager, lobbyRepo)
+        running(lobbies, recentlyEnded, updated, gameManager, lobbyRepo, emptyRoomGrace)
 
       case MatchEnded(gameId, returnedSubscribers) =>
         lobbies.get(gameId) match {
@@ -458,7 +502,8 @@ object LobbyManager {
               recentlyEnded,
               subscribers + (gameId -> merged),
               gameManager,
-              lobbyRepo
+              lobbyRepo,
+              emptyRoomGrace
             )
           case None =>
             context.log.info(s"MatchEnded for $gameId: no lobby entry (orphan match); dropping returned subscribers")
@@ -466,11 +511,16 @@ object LobbyManager {
         }
 
       case EvictIdleRooms =>
-        // a post-game room is torn down once everyone has left it or it has sat idle past the TTL
-        val cutoff = Instant.now().toEpochMilli - finishedRoomTtl.toMillis
+        // a post-game room is torn down once it has sat idle past the TTL, or once everyone has left it AND it has also
+        // been idle past the (shorter) empty-room grace period — so a momentary zero-subscriber blip (e.g. a browser
+        // tab reloading right after the match ends) doesn't evict the room on the very next tick
+        val now = Instant.now().toEpochMilli
+        val idleCutoff = now - finishedRoomTtl.toMillis
+        val emptyCutoff = now - emptyRoomGrace.toMillis
         val stale = lobbies.filter { case (id, m) =>
           m.status == GameLifecycleStatus.Finished &&
-          (subscribers.getOrElse(id, Map.empty).isEmpty || m.lastActivityAt.toEpochMilli < cutoff)
+          (m.lastActivityAt.toEpochMilli <= idleCutoff ||
+          (subscribers.getOrElse(id, Map.empty).isEmpty && m.lastActivityAt.toEpochMilli <= emptyCutoff))
         }
         if (stale.isEmpty) Behaviors.same
         else {
@@ -480,7 +530,14 @@ object LobbyManager {
             fanOut(subscribers, id, PlayerEvent.GameEnded(GameLifecycleStatus.Cancelled))
             recentlyEnded.put(id, m.copy(status = GameLifecycleStatus.Cancelled))
           }
-          running(lobbies -- stale.keySet, recentlyEnded, subscribers -- stale.keySet, gameManager, lobbyRepo)
+          running(
+            lobbies -- stale.keySet,
+            recentlyEnded,
+            subscribers -- stale.keySet,
+            gameManager,
+            lobbyRepo,
+            emptyRoomGrace
+          )
         }
     }
   }.receiveSignal { case (context, Terminated(ref)) =>
@@ -490,6 +547,6 @@ object LobbyManager {
       .mapValues(_.filterNot { case (_, r) => r == ref })
       .filter { case (_, refs) => refs.nonEmpty }
       .toMap
-    running(lobbies, recentlyEnded, cleaned, gameManager, lobbyRepo)
+    running(lobbies, recentlyEnded, cleaned, gameManager, lobbyRepo, emptyRoomGrace)
   }
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
@@ -1,6 +1,7 @@
 package com.andy327.actor.core
 
 import java.time.Instant
+import java.util.UUID
 
 import scala.concurrent.duration._
 
@@ -311,10 +312,14 @@ object LobbyManager {
         lobbies.get(gameId) match {
           case Some(metadata) if metadata.hostId == playerId && metadata.status == GameLifecycleStatus.ReadyToStart =>
             context.log.info(s"Lobby $gameId validated for start — delegating game actor spawn to GameManager")
-            val updatedMetadata = metadata.copy(status = GameLifecycleStatus.InProgress)
+            // mint a fresh match id for this playthrough; the room id (gameId) stays stable across rematches
+            val matchId = UUID.randomUUID()
+            val updatedMetadata =
+              metadata.copy(status = GameLifecycleStatus.InProgress, currentMatchId = Some(matchId))
             val lobbySubscribers = subscribers.getOrElse(gameId, Map.empty)
             gameManager ! GameManager.SpawnGame(
               gameId,
+              matchId,
               metadata.gameType,
               metadata.players.keySet,
               replyTo,

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
@@ -173,6 +173,17 @@ object LobbyManager {
   ): Unit =
     subscribers.getOrElse(gameId, Map.empty).values.foreach(_ ! PlayerActor.SendEvent(event))
 
+  /** Seat order for a match: the host first, then the remaining players ordered by id, rotated left by the room's
+    * match count. Rotation makes the first-move seat (seat 0) alternate across rematches; the first match (count 0)
+    * keeps the host in seat 0.
+    */
+  private def seatOrder(metadata: LobbyMetadata): Seq[PlayerId] = {
+    val others = (metadata.players.keySet - metadata.hostId).toList.sortBy(_.toString)
+    val roster = metadata.hostId :: others
+    val rotation = metadata.matchCount % roster.size
+    roster.drop(rotation) ::: roster.take(rotation)
+  }
+
   /** Steady-state behavior holding all lobby data.
     *
     * @param lobbies map of active lobbies (WaitingForPlayers, ReadyToStart, InProgress)
@@ -315,19 +326,27 @@ object LobbyManager {
         }
 
       case StartGame(gameId, playerId, replyTo) =>
+        // a host may start a ready pre-game lobby, or start a rematch from a finished room (same roster)
+        def startable(status: GameLifecycleStatus): Boolean =
+          status == GameLifecycleStatus.ReadyToStart || status == GameLifecycleStatus.Finished
         lobbies.get(gameId) match {
-          case Some(metadata) if metadata.hostId == playerId && metadata.status == GameLifecycleStatus.ReadyToStart =>
-            context.log.info(s"Lobby $gameId validated for start — delegating game actor spawn to GameManager")
+          case Some(metadata) if metadata.hostId == playerId && startable(metadata.status) =>
+            val rematch = metadata.status == GameLifecycleStatus.Finished
+            val newStatus = if (rematch) "rematch" else "start"
+            context.log.info(s"Lobby $gameId validated for $newStatus — delegating to GM")
             // mint a fresh match id for this playthrough; the room id (gameId) stays stable across rematches
             val matchId = UUID.randomUUID()
-            val updatedMetadata =
-              metadata.copy(status = GameLifecycleStatus.InProgress, currentMatchId = Some(matchId))
+            val updatedMetadata = metadata.copy(
+              status = GameLifecycleStatus.InProgress,
+              currentMatchId = Some(matchId),
+              matchCount = metadata.matchCount + 1
+            )
             val lobbySubscribers = subscribers.getOrElse(gameId, Map.empty)
             gameManager ! GameManager.SpawnGame(
               gameId,
               matchId,
               metadata.gameType,
-              metadata.players.keySet,
+              seatOrder(metadata),
               replyTo,
               lobbySubscribers
             )

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
@@ -1,5 +1,7 @@
 package com.andy327.actor.core
 
+import java.time.Instant
+
 import scala.concurrent.duration._
 
 import org.slf4j.LoggerFactory
@@ -181,8 +183,13 @@ object LobbyManager {
   )(implicit runtime: IORuntime): Behavior[Command] = Behaviors.receive[Command] { (context, message) =>
     message match {
       case RestoreLobbies(restored) =>
-        val restoredMap = restored.map(m => m.gameId -> m).toMap
-        context.log.info(s"Restoring ${restoredMap.size} lobbies from Redis")
+        // Only in-progress games are worth restoring: their game actor comes back from the database. Pre-game lobbies
+        // (WaitingForPlayers/ReadyToStart) are dead across a restart — their players' sessions are gone — so drop and
+        // delete them from Redis rather than leaving stale, un-rejoinable lobbies advertised in the list.
+        val (keep, drop) = restored.partition(_.status == GameLifecycleStatus.InProgress)
+        val restoredMap = keep.map(m => m.gameId -> m).toMap
+        context.log.info(s"Restoring ${restoredMap.size} in-progress lobbies; deleting ${drop.size} dead pre-game ones")
+        drop.foreach(m => persist(lobbyRepo.deleteLobby(m.gameId)))
         running(restoredMap, recentlyEnded, subscribers, gameManager, lobbyRepo)
 
       case BroadcastChat(gameId, event) =>
@@ -333,8 +340,10 @@ object LobbyManager {
         context.log.info("Listing available lobbies")
         val all = lobbies.values.filter(_.status.isJoinable).toList
         val filtered = gameTypeFilter.fold(all)(gt => all.filter(_.gameType == gt))
-        val total = filtered.size
-        val paged = filtered.drop((page - 1) * limit).take(limit)
+        // newest first, so freshly created lobbies surface at the top of the (paginated) list
+        val ordered = filtered.sortBy(_.createdAt)(Ordering[Instant].reverse)
+        val total = ordered.size
+        val paged = ordered.drop((page - 1) * limit).take(limit)
         replyTo ! LobbyManager.LobbiesListed(paged, page, limit, total)
         Behaviors.same
 

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
@@ -130,6 +130,9 @@ object LobbyManager {
   /** Fan `event` (a chat message) out to the lobby's subscribers, used while the match is still in its lobby phase. */
   final private[core] case class BroadcastChat(gameId: GameId, event: PlayerEvent) extends Command
 
+  /** Periodic self-tick that tears down post-game (Finished) rooms that are empty or idle past [[finishedRoomTtl]]. */
+  final private[core] case object EvictIdleRooms extends Command
+
   // --- Response type owned by LobbyManager ---
 
   /** Paginated lobby-list result; adapted into [[GameManager.LobbiesListed]] by a GameManager message adapter. */
@@ -141,6 +144,12 @@ object LobbyManager {
   final case class PlayerLobbies(lobbies: List[LobbyMetadata])
 
   val recentlyEndedTtl: FiniteDuration = 1.hour
+
+  /** A post-game (Finished) room with no connected players, or idle for longer than this, is torn down. */
+  val finishedRoomTtl: FiniteDuration = 30.minutes
+
+  /** How often the idle-room eviction runs. */
+  private val evictInterval: FiniteDuration = 1.minute
 
   private val logger = LoggerFactory.getLogger(getClass)
 
@@ -154,12 +163,14 @@ object LobbyManager {
   def apply(
       gameManager: ActorRef[GameManager.Command],
       lobbyRepo: LobbyRepository
-  )(implicit runtime: IORuntime): Behavior[Command] = {
-    val recentlyEnded: Cache[GameId, LobbyMetadata] = Scaffeine()
-      .expireAfterWrite(recentlyEndedTtl)
-      .build[GameId, LobbyMetadata]()
-    running(Map.empty, recentlyEnded, Map.empty, gameManager, lobbyRepo)
-  }
+  )(implicit runtime: IORuntime): Behavior[Command] =
+    Behaviors.withTimers { timers =>
+      timers.startTimerWithFixedDelay(EvictIdleRooms, evictInterval)
+      val recentlyEnded: Cache[GameId, LobbyMetadata] = Scaffeine()
+        .expireAfterWrite(recentlyEndedTtl)
+        .build[GameId, LobbyMetadata]()
+      running(Map.empty, recentlyEnded, Map.empty, gameManager, lobbyRepo)
+    }
 
   /** Sends a [[PlayerEvent]] to every PlayerActor subscribed to the given lobby.
     *
@@ -212,7 +223,18 @@ object LobbyManager {
 
       case BroadcastChat(gameId, event) =>
         fanOut(subscribers, gameId, event)
-        Behaviors.same
+        // chat keeps a post-game room alive: bump its activity so eviction doesn't close it mid-conversation
+        lobbies.get(gameId) match {
+          case Some(m) =>
+            running(
+              lobbies + (gameId -> m.copy(lastActivityAt = Instant.now())),
+              recentlyEnded,
+              subscribers,
+              gameManager,
+              lobbyRepo
+            )
+          case None => Behaviors.same
+        }
 
       case CreateLobby(gameType, host, replyTo) =>
         context.log.info(s"Creating new lobby for game type $gameType with host ${host.name}")
@@ -419,7 +441,7 @@ object LobbyManager {
         lobbies.get(gameId) match {
           case Some(metadata) =>
             context.log.info(s"Match in room $gameId ended; returning ${returnedSubscribers.size} players to the room")
-            val finished = metadata.copy(status = GameLifecycleStatus.Finished)
+            val finished = metadata.copy(status = GameLifecycleStatus.Finished, lastActivityAt = Instant.now())
             // re-own the match's subscribers (the game actor already sent them GameEnded before handing them back) and
             // watch each so a later disconnect drops it, mirroring SubscribeToLobby
             returnedSubscribers.values.foreach(context.watch)
@@ -438,6 +460,24 @@ object LobbyManager {
           case None =>
             context.log.info(s"MatchEnded for $gameId: no lobby entry (orphan match); dropping returned subscribers")
             Behaviors.same
+        }
+
+      case EvictIdleRooms =>
+        // a post-game room is torn down once everyone has left it or it has sat idle past the TTL
+        val cutoff = Instant.now().toEpochMilli - finishedRoomTtl.toMillis
+        val stale = lobbies.filter { case (id, m) =>
+          m.status == GameLifecycleStatus.Finished &&
+          (subscribers.getOrElse(id, Map.empty).isEmpty || m.lastActivityAt.toEpochMilli < cutoff)
+        }
+        if (stale.isEmpty) Behaviors.same
+        else {
+          stale.foreach { case (id, m) =>
+            context.log.info(s"Evicting idle/empty finished room $id")
+            // tell any remaining watchers the room has closed, then retire it to the recently-ended cache
+            fanOut(subscribers, id, PlayerEvent.GameEnded(GameLifecycleStatus.Cancelled))
+            recentlyEnded.put(id, m.copy(status = GameLifecycleStatus.Cancelled))
+          }
+          running(lobbies -- stale.keySet, recentlyEnded, subscribers -- stale.keySet, gameManager, lobbyRepo)
         }
     }
   }.receiveSignal { case (context, Terminated(ref)) =>

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
@@ -400,7 +400,10 @@ object LobbyManager {
         Behaviors.same
 
       case ListLobbiesForPlayer(playerId, replyTo) =>
-        val mine = lobbies.values.filter(m => m.status.isJoinable && m.players.contains(playerId)).toList
+        val mine = lobbies.values
+          .filter(m => m.players.contains(playerId))
+          .filter(m => m.status.isJoinable || m.status == GameLifecycleStatus.Finished)
+          .toList
         replyTo ! LobbyManager.PlayerLobbies(mine)
         Behaviors.same
 

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/PlayerEvent.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/PlayerEvent.scala
@@ -27,7 +27,8 @@ object PlayerEvent {
 
   /** The game has ended.
     *
-    * @param result Completed (someone won) or Cancelled (host left before the game started).
+    * @param result Completed (someone won or drew), or Cancelled — the host left/cancelled a pre-game lobby, or a
+    *               post-game room was evicted for sitting idle/empty too long.
     */
   final case class GameEnded(result: GameLifecycleStatus.GameEnded) extends PlayerEvent
 

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/PlayerEvent.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/PlayerEvent.scala
@@ -4,7 +4,7 @@ import java.time.Instant
 
 import com.andy327.actor.game.GameState
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyMetadata}
-import com.andy327.model.core.{GameId, PlayerId, RoomId}
+import com.andy327.model.core.{PlayerId, RoomId}
 
 /** Events pushed from the server to a connected player over WebSocket.
   *
@@ -34,12 +34,12 @@ object PlayerEvent {
 
   /** A chat message in a match's thread, pushed to everyone watching that game (in lobby or in progress).
     *
-    * @param gameId the match the message belongs to
+    * @param roomId the room the message belongs to
     * @param senderId the authenticated player who sent it
     * @param senderName the sender's display name, denormalized so clients can render without a lookup
     * @param text the message body
     * @param sentAt server timestamp when the message was accepted
     */
-  final case class ChatMessage(gameId: GameId, senderId: PlayerId, senderName: String, text: String, sentAt: Instant)
+  final case class ChatMessage(roomId: RoomId, senderId: PlayerId, senderName: String, text: String, sentAt: Instant)
       extends PlayerEvent
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/PlayerEvent.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/PlayerEvent.scala
@@ -4,7 +4,7 @@ import java.time.Instant
 
 import com.andy327.actor.game.GameState
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyMetadata}
-import com.andy327.model.core.{GameId, PlayerId}
+import com.andy327.model.core.{GameId, PlayerId, RoomId}
 
 /** Events pushed from the server to a connected player over WebSocket.
   *
@@ -17,8 +17,13 @@ object PlayerEvent {
   /** The lobby the player is in has changed — a player joined, left, or the status updated. */
   final case class LobbyUpdated(metadata: LobbyMetadata) extends PlayerEvent
 
-  /** The game state changed after a move — carries the full updated board state. */
-  final case class GameStateUpdated(state: GameState) extends PlayerEvent
+  /** The game state changed after a move — carries the full updated board state.
+    *
+    * @param roomId the room this update belongs to; lets a client routing several rooms dispatch the push to the right
+    *               one (a room hosts at most one live match at a time)
+    * @param state the full updated board state, rendered for the receiving subscriber
+    */
+  final case class GameStateUpdated(roomId: RoomId, state: GameState) extends PlayerEvent
 
   /** The game has ended.
     *

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/TurnBasedGameActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/TurnBasedGameActor.scala
@@ -204,7 +204,7 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
     context.log.info(s"Match $matchId updated:\n$nextState")
 
     persist ! PersistenceProtocol.SaveSnapshot(
-      gameId = matchId,
+      matchId = matchId,
       gameType = gameType,
       game = nextState,
       // pass the real save outcome through so a failed snapshot is logged by the SnapshotSaved handler

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/TurnBasedGameActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/TurnBasedGameActor.scala
@@ -234,7 +234,10 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
           persist ! PersistenceProtocol.RecordGameResult(pid, matchId, gameType, result, forfeit)
         }
         publisher.publish(GameEvent.GameCompleted(matchId, gameType, outcome, nextState.moveCount))
-        gameManager ! GameManager.GameCompleted(matchId, roomId, GameLifecycleStatus.Completed)
+        // hand the subscriber set back to the room so it survives this match's actor stopping and can keep fanning out
+        // chat and the post-game state; re-key by playerId to match the GameCompleted/MatchEnded shape
+        val subscribersByPlayer = subscribers.map { case (ref, pid) => pid -> ref }
+        gameManager ! GameManager.GameCompleted(matchId, roomId, GameLifecycleStatus.Completed, subscribersByPlayer)
         terminating(matchId)
 
       case InProgress =>

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/TurnBasedGameActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/TurnBasedGameActor.scala
@@ -10,7 +10,18 @@ import com.andy327.actor.events.{EventPublisher, GameEvent}
 import com.andy327.actor.game.{GameState, GameStateView}
 import com.andy327.actor.lobby.GameLifecycleStatus
 import com.andy327.actor.persistence.PersistenceProtocol
-import com.andy327.model.core.{Draw, Game, GameError, GameId, GameStatus, GameTypeTag, InProgress, PlayerId, Won}
+import com.andy327.model.core.{
+  Draw,
+  Game,
+  GameError,
+  GameStatus,
+  GameTypeTag,
+  InProgress,
+  MatchId,
+  PlayerId,
+  RoomId,
+  Won
+}
 import com.andy327.persistence.db.PlayerHistoryRepository.GameResult
 
 object TurnBasedGameActor {
@@ -108,7 +119,8 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
 
   /** Initializes a new game actor with an empty game. */
   override def create(
-      gameId: GameId,
+      matchId: MatchId,
+      roomId: RoomId,
       players: Seq[PlayerId],
       persist: ActorRef[PersistenceProtocol.Command],
       gameManager: ActorRef[GameManager.Command],
@@ -116,8 +128,8 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
   ): (G, Behavior[Command]) = {
     val game = newGame(players)
     val behavior = Behaviors.setup[Command] { context =>
-      context.log.info(s"[$gameId] starting new game")
-      active(game, gameId, persist, gameManager, Map.empty, publisher)
+      context.log.info(s"[$matchId] starting new game")
+      active(game, matchId, roomId, persist, gameManager, Map.empty, publisher)
     }
     (game, behavior)
   }
@@ -129,7 +141,8 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
     * behavior. Stops the actor if the snapshot type does not match `G`.
     */
   override def fromSnapshot(
-      gameId: GameId,
+      matchId: MatchId,
+      roomId: RoomId,
       snap: Game[_, _, _, _, _],
       persist: ActorRef[PersistenceProtocol.Command],
       gameManager: ActorRef[GameManager.Command],
@@ -140,15 +153,15 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
         case game: G =>
           game.gameStatus match {
             case InProgress =>
-              context.log.info(s"[$gameId] restored in-progress game")
-              active(game, gameId, persist, gameManager, Map.empty, publisher)
+              context.log.info(s"[$matchId] restored in-progress game")
+              active(game, matchId, roomId, persist, gameManager, Map.empty, publisher)
             case Won(_) | Draw =>
-              context.log.info(s"[$gameId] restored as already-completed game — notifying GameManager and stopping")
-              gameManager ! GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed)
+              context.log.info(s"[$matchId] restored as already-completed game — notifying GameManager and stopping")
+              gameManager ! GameManager.GameCompleted(matchId, roomId, GameLifecycleStatus.Completed)
               Behaviors.stopped
           }
         case _ =>
-          context.log.error(s"Unexpected snapshot type for game $gameId: $snap")
+          context.log.error(s"Unexpected snapshot type for game $matchId: $snap")
           Behaviors.stopped
       }
     }
@@ -171,7 +184,8 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
       context: ActorContext[Command],
       nextState: G,
       viewerId: PlayerId,
-      gameId: GameId,
+      matchId: MatchId,
+      roomId: RoomId,
       persist: ActorRef[PersistenceProtocol.Command],
       gameManager: ActorRef[GameManager.Command],
       subscribers: Map[ActorRef[PlayerActor.Command], PlayerId],
@@ -179,10 +193,10 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
       forfeit: Boolean,
       replyTo: ActorRef[Either[GameError, GameState]]
   )(appendMove: => Unit = ()): Behavior[Command] = {
-    context.log.info(s"Game $gameId updated:\n$nextState")
+    context.log.info(s"Match $matchId updated:\n$nextState")
 
     persist ! PersistenceProtocol.SaveSnapshot(
-      gameId = gameId,
+      gameId = matchId,
       gameType = gameType,
       game = nextState,
       // pass the real save outcome through so a failed snapshot is logged by the SnapshotSaved handler
@@ -194,12 +208,12 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
     // reply to the acting player with their own view; fan out a per-viewer view to each subscriber
     replyTo ! Right(view.fromGame(nextState, Some(viewerId)))
     subscribers.foreach { case (ref, subscriberId) =>
-      ref ! PlayerActor.SendEvent(PlayerEvent.GameStateUpdated(view.fromGame(nextState, Some(subscriberId))))
+      ref ! PlayerActor.SendEvent(PlayerEvent.GameStateUpdated(roomId, view.fromGame(nextState, Some(subscriberId))))
     }
 
     nextState.gameStatus match {
       case Won(_) | Draw =>
-        context.log.info(s"[$gameId] game completed with status: ${nextState.gameStatus}")
+        context.log.info(s"[$matchId] game completed with status: ${nextState.gameStatus}")
         val endEvent = PlayerEvent.GameEnded(GameLifecycleStatus.Completed)
         // GameEnded carries no board, so it is identical for every viewer
         subscribers.foreach { case (ref, _) => ref ! PlayerActor.SendEvent(endEvent) }
@@ -217,14 +231,14 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
             (nextState.players.map(_ -> GameResult.Draw), GameEvent.Outcome.Draw)
         }
         results.foreach { case (pid, result) =>
-          persist ! PersistenceProtocol.RecordGameResult(pid, gameId, gameType, result, forfeit)
+          persist ! PersistenceProtocol.RecordGameResult(pid, matchId, gameType, result, forfeit)
         }
-        publisher.publish(GameEvent.GameCompleted(gameId, gameType, outcome, nextState.moveCount))
-        gameManager ! GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed)
-        terminating(gameId)
+        publisher.publish(GameEvent.GameCompleted(matchId, gameType, outcome, nextState.moveCount))
+        gameManager ! GameManager.GameCompleted(matchId, roomId, GameLifecycleStatus.Completed)
+        terminating(matchId)
 
       case InProgress =>
-        active(nextState, gameId, persist, gameManager, subscribers, publisher)
+        active(nextState, matchId, roomId, persist, gameManager, subscribers, publisher)
     }
   }
 
@@ -237,7 +251,8 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
     */
   private def active(
       game: G,
-      gameId: GameId,
+      matchId: MatchId,
+      roomId: RoomId,
       persist: ActorRef[PersistenceProtocol.Command],
       gameManager: ActorRef[GameManager.Command],
       subscribers: Map[ActorRef[PlayerActor.Command], PlayerId],
@@ -254,7 +269,8 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
                   context,
                   nextState,
                   playerId,
-                  gameId,
+                  matchId,
+                  roomId,
                   persist,
                   gameManager,
                   subscribers,
@@ -263,18 +279,18 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
                   replyTo
                 ) {
                   // record the move in the append-only history log; seq is the pre-move count (0-based ordinal)
-                  persist ! PersistenceProtocol.AppendMove(gameId, game.moveCount, playerId, moveEncoder(move))
-                  publisher.publish(GameEvent.MoveMade(gameId, gameType, playerId, game.moveCount))
+                  persist ! PersistenceProtocol.AppendMove(matchId, game.moveCount, playerId, moveEncoder(move))
+                  publisher.publish(GameEvent.MoveMade(matchId, gameType, playerId, game.moveCount))
                 }
 
               case Left(err) =>
-                context.log.warn(s"[$gameId] move rejected: $err")
+                context.log.warn(s"[$matchId] move rejected: $err")
                 replyTo ! Left(err)
                 Behaviors.same
             }
 
           case None =>
-            context.log.warn(s"[$gameId] Player ID '$playerId' is not part of this game.")
+            context.log.warn(s"[$matchId] Player ID '$playerId' is not part of this game.")
             replyTo ! Left(GameError.InvalidPlayer(playerId))
             Behaviors.same
         }
@@ -283,12 +299,13 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
         // forfeit/fold-out semantics live in the model; the resulting status drives completion exactly like a move
         game.playerLeft(playerId) match {
           case Right(nextState) =>
-            context.log.info(s"[$gameId] player $playerId left the game")
+            context.log.info(s"[$matchId] player $playerId left the game")
             applyTransition(
               context,
               nextState,
               playerId,
-              gameId,
+              matchId,
+              roomId,
               persist,
               gameManager,
               subscribers,
@@ -298,7 +315,7 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
             )()
 
           case Left(err) =>
-            context.log.warn(s"[$gameId] leave rejected: $err")
+            context.log.warn(s"[$matchId] leave rejected: $err")
             replyTo ! Left(err)
             Behaviors.same
         }
@@ -310,12 +327,12 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
       case Subscribe(playerRef, playerId) =>
         // watch the subscriber so its termination (disconnect/reconnect) drops it from the map automatically
         context.watch(playerRef)
-        playerRef ! PlayerActor.SendEvent(PlayerEvent.GameStateUpdated(view.fromGame(game, Some(playerId))))
-        active(game, gameId, persist, gameManager, subscribers + (playerRef -> playerId), publisher)
+        playerRef ! PlayerActor.SendEvent(PlayerEvent.GameStateUpdated(roomId, view.fromGame(game, Some(playerId))))
+        active(game, matchId, roomId, persist, gameManager, subscribers + (playerRef -> playerId), publisher)
 
       case Unsubscribe(playerRef) =>
         context.unwatch(playerRef)
-        active(game, gameId, persist, gameManager, subscribers - playerRef, publisher)
+        active(game, matchId, roomId, persist, gameManager, subscribers - playerRef, publisher)
 
       case Broadcast(event) =>
         // chat and other broadcasts carry no hidden state, so every viewer gets the same event
@@ -324,14 +341,14 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
 
       case SnapshotSaved(result) =>
         result match {
-          case Left(e)  => context.log.error(s"[$gameId] snapshot failed", e)
-          case Right(_) => context.log.debug(s"[$gameId] snapshot saved successfully")
+          case Left(e)  => context.log.error(s"[$matchId] snapshot failed", e)
+          case Right(_) => context.log.debug(s"[$matchId] snapshot saved successfully")
         }
         Behaviors.same
     }
   }.receiveSignal { case (context, Terminated(ref)) =>
     // a subscribed PlayerActor stopped; drop its (now-dead) ref so we stop fanning events to it
-    context.log.debug(s"[$gameId] subscriber $ref terminated; removing from subscribers")
-    active(game, gameId, persist, gameManager, subscribers.filterNot { case (r, _) => r == ref }, publisher)
+    context.log.debug(s"[$matchId] subscriber $ref terminated; removing from subscribers")
+    active(game, matchId, roomId, persist, gameManager, subscribers.filterNot { case (r, _) => r == ref }, publisher)
   }
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/TurnBasedGameActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/TurnBasedGameActor.scala
@@ -117,6 +117,14 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
     case _                     => None
   }
 
+  override protected def replyToInTerminating(cmd: Command): Option[ActorRef[Either[GameError, GameState]]] =
+    cmd match {
+      case MakeMove(_, _, replyTo) => Some(replyTo)
+      case PlayerLeft(_, replyTo)  => Some(replyTo)
+      case GetState(replyTo)       => Some(replyTo)
+      case _                       => None
+    }
+
   /** Initializes a new game actor with an empty game. */
   override def create(
       matchId: MatchId,

--- a/game-service-actor/src/main/scala/com/andy327/actor/events/GameEvent.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/events/GameEvent.scala
@@ -1,18 +1,18 @@
 package com.andy327.actor.events
 
-import com.andy327.model.core.{GameId, GameType, PlayerId}
+import com.andy327.model.core.{GameType, MatchId, PlayerId, RoomId}
 
 /** Structured domain events describing a game's lifecycle, emitted from the actor layer for analytics. Unlike
   * [[com.andy327.actor.core.PlayerEvent]] (which carries rendered board state for WebSocket delivery), these
   * carry only the dimensions analytics needs. Published on the `game-analytics` channel and decoded by
   * `AnalyticsConsumer`; the wire codec lives in `GameEventCodecs`, keeping this ADT free of any serialization
   * concern.
+  *
+  * Each variant carries its own precisely-typed identifier — a `MatchId` for move/lifecycle events (`GameStarted`,
+  * `MoveMade`, `GameCompleted`), a `RoomId` for `ChatSent` — rather than a shared accessor on this trait, since the
+  * two only coincide at the value level, not the type.
   */
-sealed trait GameEvent {
-
-  /** The game this event refers to. */
-  def gameId: GameId
-}
+sealed trait GameEvent
 
 object GameEvent {
 
@@ -37,14 +37,15 @@ object GameEvent {
   }
 
   /** A new game was created and started. */
-  final case class GameStarted(gameId: GameId, gameType: GameType, playerCount: Int) extends GameEvent
+  final case class GameStarted(matchId: MatchId, gameType: GameType, playerCount: Int) extends GameEvent
 
   /** A move was successfully applied. `seq` is the 0-based ordinal of the move within the game. */
-  final case class MoveMade(gameId: GameId, gameType: GameType, playerId: PlayerId, seq: Int) extends GameEvent
+  final case class MoveMade(matchId: MatchId, gameType: GameType, playerId: PlayerId, seq: Int) extends GameEvent
 
   /** A game reached a terminal state. `moveCount` is the total number of moves played. */
-  final case class GameCompleted(gameId: GameId, gameType: GameType, outcome: Outcome, moveCount: Int) extends GameEvent
+  final case class GameCompleted(matchId: MatchId, gameType: GameType, outcome: Outcome, moveCount: Int)
+      extends GameEvent
 
   /** A chat message was sent. `gameType` is `None` for a message sent in a lobby before the game starts. */
-  final case class ChatSent(gameId: GameId, gameType: Option[GameType]) extends GameEvent
+  final case class ChatSent(roomId: RoomId, gameType: Option[GameType]) extends GameEvent
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/lobby/GameLifecycleStatus.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/lobby/GameLifecycleStatus.scala
@@ -31,6 +31,11 @@ object GameLifecycleStatus {
   /** Indicates that the game has started and is currently in progress. */
   case object InProgress extends GameLifecycleStatus
 
+  /** A match has finished but the room survives: the same players can chat and start a rematch. Distinct from the
+    * terminal [[GameEnded]] states — the room stays live (in memory) rather than being retired.
+    */
+  case object Finished extends GameLifecycleStatus
+
   /** Trait representing any terminal game state - where the game has ended and can no longer be interacted with. */
   sealed trait GameEnded extends GameLifecycleStatus
 

--- a/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyCodecs.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyCodecs.scala
@@ -30,6 +30,7 @@ object LobbyCodecs {
       case "WaitingForPlayers" => Right(GameLifecycleStatus.WaitingForPlayers)
       case "ReadyToStart"      => Right(GameLifecycleStatus.ReadyToStart)
       case "InProgress"        => Right(GameLifecycleStatus.InProgress)
+      case "Finished"          => Right(GameLifecycleStatus.Finished)
       case "Completed"         => Right(GameLifecycleStatus.Completed)
       case "Cancelled"         => Right(GameLifecycleStatus.Cancelled)
       case other               => Left(s"Unknown GameLifecycleStatus: $other")
@@ -38,6 +39,7 @@ object LobbyCodecs {
       case GameLifecycleStatus.WaitingForPlayers => "WaitingForPlayers"
       case GameLifecycleStatus.ReadyToStart      => "ReadyToStart"
       case GameLifecycleStatus.InProgress        => "InProgress"
+      case GameLifecycleStatus.Finished          => "Finished"
       case GameLifecycleStatus.Completed         => "Completed"
       case GameLifecycleStatus.Cancelled         => "Cancelled"
     }

--- a/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyError.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyError.scala
@@ -1,6 +1,6 @@
 package com.andy327.actor.lobby
 
-import com.andy327.model.core.GameId
+import com.andy327.model.core.RoomId
 
 /** Represents a typed error that can occur during lobby or game lifecycle operations.
   *
@@ -14,43 +14,43 @@ sealed trait LobbyError {
 object LobbyError {
 
   /** The referenced lobby does not exist. Maps to HTTP 404. */
-  case class LobbyNotFound(gameId: GameId) extends LobbyError {
-    def message: String = s"No such lobby: $gameId"
+  case class LobbyNotFound(roomId: RoomId) extends LobbyError {
+    def message: String = s"No such lobby: $roomId"
   }
 
   /** The player is already a member of the referenced lobby. Maps to HTTP 409. */
-  case class AlreadyInLobby(gameId: GameId) extends LobbyError {
-    def message: String = s"Player is already in lobby $gameId"
+  case class AlreadyInLobby(roomId: RoomId) extends LobbyError {
+    def message: String = s"Player is already in lobby $roomId"
   }
 
   /** The lobby has reached its maximum player count and cannot accept new players. Maps to HTTP 409. */
-  case class LobbyFull(gameId: GameId) extends LobbyError {
-    def message: String = s"Cannot join lobby $gameId - lobby is full"
+  case class LobbyFull(roomId: RoomId) extends LobbyError {
+    def message: String = s"Cannot join lobby $roomId - lobby is full"
   }
 
   /** The lobby cannot be joined because the game has already started or ended. Maps to HTTP 409. */
-  case class LobbyNotJoinable(gameId: GameId) extends LobbyError {
-    def message: String = s"Cannot join lobby $gameId - game has already started or ended"
+  case class LobbyNotJoinable(roomId: RoomId) extends LobbyError {
+    def message: String = s"Cannot join lobby $roomId - game has already started or ended"
   }
 
   /** The requesting player is not the host of the lobby and is not permitted to perform the action. Maps to HTTP 403.
     */
-  case class NotHostError(gameId: GameId) extends LobbyError {
-    def message: String = s"Only the host can start game $gameId"
+  case class NotHostError(roomId: RoomId) extends LobbyError {
+    def message: String = s"Only the host can start game $roomId"
   }
 
   /** The lobby does not yet have enough players to start the game. Maps to HTTP 409. */
-  case class LobbyNotReady(gameId: GameId) extends LobbyError {
-    def message: String = s"Lobby $gameId does not have enough players to start"
+  case class LobbyNotReady(roomId: RoomId) extends LobbyError {
+    def message: String = s"Lobby $roomId does not have enough players to start"
   }
 
   /** The game for this lobby has already started; use the game subscribe endpoint instead. Maps to HTTP 409. */
-  case class GameAlreadyStarted(gameId: GameId) extends LobbyError {
-    def message: String = s"Game $gameId has already started; use the game subscribe endpoint instead"
+  case class GameAlreadyStarted(roomId: RoomId) extends LobbyError {
+    def message: String = s"Game $roomId has already started; use the game subscribe endpoint instead"
   }
 
   /** The lobby's game is in progress, so players cannot leave it. Maps to HTTP 409. */
-  case class GameInProgress(gameId: GameId) extends LobbyError {
-    def message: String = s"Cannot leave lobby $gameId - game is in progress"
+  case class GameInProgress(roomId: RoomId) extends LobbyError {
+    def message: String = s"Cannot leave lobby $roomId - game is in progress"
   }
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyMetadata.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyMetadata.scala
@@ -35,6 +35,8 @@ object LobbyMetadata {
   * @param createdAt server time the lobby was created; used to order the lobby list newest-first
   * @param currentMatchId the match currently being played in this room, if any; links the room to the live (or
   *                       most-recent) match so an in-progress game can be re-associated with its room after a restart
+  * @param matchCount how many matches have been started in this room (incremented on each start/rematch); used to
+  *                   rotate the seating so the first-move seat alternates across rematches
   */
 case class LobbyMetadata(
     gameId: GameId,
@@ -43,5 +45,6 @@ case class LobbyMetadata(
     hostId: PlayerId,
     status: GameLifecycleStatus,
     createdAt: Instant,
-    currentMatchId: Option[MatchId] = None
+    currentMatchId: Option[MatchId] = None,
+    matchCount: Int = 0
 )

--- a/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyMetadata.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyMetadata.scala
@@ -1,5 +1,6 @@
 package com.andy327.actor.lobby
 
+import java.time.Instant
 import java.util.UUID
 
 import com.andy327.model.core.{GameId, GameType, PlayerId}
@@ -8,8 +9,8 @@ object LobbyMetadata {
 
   /** Creates a new lobby for the given game type with the specified host player.
     *
-    * This method generates a unique game ID, initializes the player map with the host, and sets the lifecycle status to
-    * `WaitingForPlayers`.
+    * This method generates a unique game ID, initializes the player map with the host, stamps the creation time, and
+    * sets the lifecycle status to `WaitingForPlayers`.
     *
     * @param gameType the type of game (e.g., TicTacToe)
     * @param host the player who is creating and hosting the lobby
@@ -18,7 +19,7 @@ object LobbyMetadata {
   def newLobby(gameType: GameType, host: Player): LobbyMetadata = {
     val gameId = UUID.randomUUID()
     val players = Map(host.id -> host)
-    LobbyMetadata(gameId, gameType, players, host.id, GameLifecycleStatus.WaitingForPlayers)
+    LobbyMetadata(gameId, gameType, players, host.id, GameLifecycleStatus.WaitingForPlayers, Instant.now())
   }
 }
 
@@ -31,11 +32,13 @@ object LobbyMetadata {
   * @param players map of player UUIDs to Player objects (includes host and any joined players)
   * @param hostId UUID of the player who created and controls the lobby
   * @param status current lifecycle status of the game (e.g., waiting, in progress, completed)
+  * @param createdAt server time the lobby was created; used to order the lobby list newest-first
   */
 case class LobbyMetadata(
     gameId: GameId,
     gameType: GameType,
     players: Map[PlayerId, Player], // includes the host
     hostId: PlayerId,
-    status: GameLifecycleStatus
+    status: GameLifecycleStatus,
+    createdAt: Instant
 )

--- a/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyMetadata.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyMetadata.scala
@@ -19,7 +19,8 @@ object LobbyMetadata {
   def newLobby(gameType: GameType, host: Player): LobbyMetadata = {
     val gameId = UUID.randomUUID()
     val players = Map(host.id -> host)
-    LobbyMetadata(gameId, gameType, players, host.id, GameLifecycleStatus.WaitingForPlayers, Instant.now())
+    val now = Instant.now()
+    LobbyMetadata(gameId, gameType, players, host.id, GameLifecycleStatus.WaitingForPlayers, now, lastActivityAt = now)
   }
 }
 
@@ -37,6 +38,8 @@ object LobbyMetadata {
   *                       most-recent) match so an in-progress game can be re-associated with its room after a restart
   * @param matchCount how many matches have been started in this room (incremented on each start/rematch); used to
   *                   rotate the seating so the first-move seat alternates across rematches
+  * @param lastActivityAt server time of the last activity in this room (start, leave, chat, match end); used to reap
+  *                       idle post-game (Finished) rooms
   */
 case class LobbyMetadata(
     gameId: GameId,
@@ -46,5 +49,6 @@ case class LobbyMetadata(
     status: GameLifecycleStatus,
     createdAt: Instant,
     currentMatchId: Option[MatchId] = None,
-    matchCount: Int = 0
+    matchCount: Int = 0,
+    lastActivityAt: Instant = Instant.EPOCH
 )

--- a/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyMetadata.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyMetadata.scala
@@ -3,7 +3,7 @@ package com.andy327.actor.lobby
 import java.time.Instant
 import java.util.UUID
 
-import com.andy327.model.core.{GameId, GameType, PlayerId}
+import com.andy327.model.core.{GameId, GameType, MatchId, PlayerId}
 
 object LobbyMetadata {
 
@@ -33,6 +33,8 @@ object LobbyMetadata {
   * @param hostId UUID of the player who created and controls the lobby
   * @param status current lifecycle status of the game (e.g., waiting, in progress, completed)
   * @param createdAt server time the lobby was created; used to order the lobby list newest-first
+  * @param currentMatchId the match currently being played in this room, if any; links the room to the live (or
+  *                       most-recent) match so an in-progress game can be re-associated with its room after a restart
   */
 case class LobbyMetadata(
     gameId: GameId,
@@ -40,5 +42,6 @@ case class LobbyMetadata(
     players: Map[PlayerId, Player], // includes the host
     hostId: PlayerId,
     status: GameLifecycleStatus,
-    createdAt: Instant
+    createdAt: Instant,
+    currentMatchId: Option[MatchId] = None
 )

--- a/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyMetadata.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyMetadata.scala
@@ -3,7 +3,7 @@ package com.andy327.actor.lobby
 import java.time.Instant
 import java.util.UUID
 
-import com.andy327.model.core.{GameId, GameType, MatchId, PlayerId}
+import com.andy327.model.core.{GameType, MatchId, PlayerId, RoomId}
 
 object LobbyMetadata {
 
@@ -17,10 +17,10 @@ object LobbyMetadata {
     * @return a new LobbyMetadata instance representing the initialized lobby
     */
   def newLobby(gameType: GameType, host: Player): LobbyMetadata = {
-    val gameId = UUID.randomUUID()
+    val roomId = UUID.randomUUID()
     val players = Map(host.id -> host)
     val now = Instant.now()
-    LobbyMetadata(gameId, gameType, players, host.id, GameLifecycleStatus.WaitingForPlayers, now, lastActivityAt = now)
+    LobbyMetadata(roomId, gameType, players, host.id, GameLifecycleStatus.WaitingForPlayers, now, lastActivityAt = now)
   }
 }
 
@@ -28,7 +28,7 @@ object LobbyMetadata {
   *
   * This includes the game type, participating players, host identity, game ID, and current lifecycle status.
   *
-  * @param gameId unique UUID for the lobby/game
+  * @param roomId unique UUID for the lobby/game
   * @param gameType type of game being played (e.g., TicTacToe)
   * @param players map of player UUIDs to Player objects (includes host and any joined players)
   * @param hostId UUID of the player who created and controls the lobby
@@ -42,7 +42,7 @@ object LobbyMetadata {
   *                       idle post-game (Finished) rooms
   */
 case class LobbyMetadata(
-    gameId: GameId,
+    roomId: RoomId,
     gameType: GameType,
     players: Map[PlayerId, Player], // includes the host
     hostId: PlayerId,

--- a/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyRepository.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyRepository.scala
@@ -2,7 +2,7 @@ package com.andy327.actor.lobby
 
 import cats.effect.IO
 
-import com.andy327.model.core.GameId
+import com.andy327.model.core.RoomId
 
 /** Repository interface for persisting and restoring lobby state across server restarts.
   *
@@ -15,7 +15,7 @@ trait LobbyRepository {
   def saveLobby(metadata: LobbyMetadata): IO[Unit]
 
   /** Remove a lobby from persistent storage. Called when a lobby reaches a terminal state. */
-  def deleteLobby(gameId: GameId): IO[Unit]
+  def deleteLobby(roomId: RoomId): IO[Unit]
 
   /** Load all persisted active lobbies. Used once at startup to restore the in-memory lobby map. */
   def loadAllLobbies(): IO[List[LobbyMetadata]]

--- a/game-service-actor/src/main/scala/com/andy327/actor/lobby/RedisLobbyRepository.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/lobby/RedisLobbyRepository.scala
@@ -7,11 +7,11 @@ import cats.implicits._
 
 import dev.profunktor.redis4cats.RedisCommands
 
-import com.andy327.model.core.GameId
+import com.andy327.model.core.RoomId
 
 /** A [[LobbyRepository]] backed by Redis.
   *
-  * Each lobby is stored as a JSON string at key `lobby:{gameId}`. A Redis Set at `lobbies:active` tracks which game
+  * Each lobby is stored as a JSON string at key `lobby:{roomId}`. A Redis Set at `lobbies:active` tracks which game
   * IDs are currently active, allowing [[loadAllLobbies]] to enumerate all lobbies without a keyspace scan.
   *
   * Terminal lobbies (Completed, Cancelled) are removed from both the individual key and the active set via
@@ -24,15 +24,15 @@ class RedisLobbyRepository(redis: RedisCommands[IO, String, String]) extends Lob
   private val logger = LoggerFactory.getLogger(getClass)
   private val ActiveSetKey = "lobbies:active"
 
-  private def lobbyKey(gameId: GameId): String = s"lobby:$gameId"
+  private def lobbyKey(roomId: RoomId): String = s"lobby:$roomId"
 
   override def saveLobby(metadata: LobbyMetadata): IO[Unit] =
-    redis.set(lobbyKey(metadata.gameId), LobbyCodecs.serialize(metadata)) *>
-      redis.sAdd(ActiveSetKey, metadata.gameId.toString).void
+    redis.set(lobbyKey(metadata.roomId), LobbyCodecs.serialize(metadata)) *>
+      redis.sAdd(ActiveSetKey, metadata.roomId.toString).void
 
-  override def deleteLobby(gameId: GameId): IO[Unit] =
-    redis.del(lobbyKey(gameId)).void *>
-      redis.sRem(ActiveSetKey, gameId.toString).void
+  override def deleteLobby(roomId: RoomId): IO[Unit] =
+    redis.del(lobbyKey(roomId)).void *>
+      redis.sRem(ActiveSetKey, roomId.toString).void
 
   override def loadAllLobbies(): IO[List[LobbyMetadata]] =
     redis.sMembers(ActiveSetKey).flatMap { ids =>

--- a/game-service-actor/src/main/scala/com/andy327/actor/persistence/PersistActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/persistence/PersistActor.scala
@@ -9,7 +9,7 @@ import io.circe.Json
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
 import org.apache.pekko.actor.typed.{ActorRef, Behavior}
 
-import com.andy327.model.core.{Game, GameId, GameType, PlayerId}
+import com.andy327.model.core.{Game, GameType, MatchId, PlayerId}
 import com.andy327.persistence.db.PlayerHistoryRepository.GameResult
 
 object PersistActor {
@@ -20,10 +20,10 @@ object PersistActor {
   final case class Saved(replyTo: ActorRef[SnapshotSaved], result: Either[Throwable, Unit]) extends Command
 
   /** Internal wrapper for a finished move-append; logged but never replied to (append is fire-and-forget). */
-  final case class MoveAppended(gameId: GameId, seq: Int, result: Either[Throwable, Unit]) extends Command
+  final case class MoveAppended(matchId: MatchId, seq: Int, result: Either[Throwable, Unit]) extends Command
 
   /** Internal wrapper for a finished game-result record; logged but never replied to (recording is fire-and-forget). */
-  final case class GameResultRecorded(gameId: GameId, playerId: PlayerId, result: Either[Throwable, Unit])
+  final case class GameResultRecorded(matchId: MatchId, playerId: PlayerId, result: Either[Throwable, Unit])
       extends Command
 }
 
@@ -38,15 +38,15 @@ trait PersistActor {
   import PersistActor._
 
   /** Persist the current game snapshot, overwriting any previously saved state for the same ID. */
-  def saveToStore(gameId: GameId, gameType: GameType, game: Game[_, _, _, _, _]): IO[Unit]
+  def saveToStore(matchId: MatchId, gameType: GameType, game: Game[_, _, _, _, _]): IO[Unit]
 
   /** Append a single move to the game's history log. */
-  def appendMoveToStore(gameId: GameId, seq: Int, playerId: PlayerId, move: Json): IO[Unit]
+  def appendMoveToStore(matchId: MatchId, seq: Int, playerId: PlayerId, move: Json): IO[Unit]
 
   /** Record one participant's outcome for a completed game in their durable history. */
   def recordGameResultToStore(
       playerId: PlayerId,
-      gameId: GameId,
+      matchId: MatchId,
       gameType: GameType,
       result: GameResult,
       forfeit: Boolean
@@ -55,17 +55,17 @@ trait PersistActor {
   final def behavior(implicit runtime: IORuntime): Behavior[Command] =
     Behaviors.setup { context =>
       Behaviors.receiveMessage {
-        case SaveSnapshot(gameId, gameType, game, replyTo) =>
-          context.pipeToSelf(saveToStore(gameId, gameType, game).unsafeToFuture()) {
+        case SaveSnapshot(matchId, gameType, game, replyTo) =>
+          context.pipeToSelf(saveToStore(matchId, gameType, game).unsafeToFuture()) {
             case Success(value) => Saved(replyTo, Right(value))
             case Failure(ex)    => Saved(replyTo, Left(ex))
           }
           Behaviors.same
 
-        case AppendMove(gameId, seq, playerId, move) =>
-          context.pipeToSelf(appendMoveToStore(gameId, seq, playerId, move).unsafeToFuture()) {
-            case Success(value) => MoveAppended(gameId, seq, Right(value))
-            case Failure(ex)    => MoveAppended(gameId, seq, Left(ex))
+        case AppendMove(matchId, seq, playerId, move) =>
+          context.pipeToSelf(appendMoveToStore(matchId, seq, playerId, move).unsafeToFuture()) {
+            case Success(value) => MoveAppended(matchId, seq, Right(value))
+            case Failure(ex)    => MoveAppended(matchId, seq, Left(ex))
           }
           Behaviors.same
 
@@ -73,20 +73,22 @@ trait PersistActor {
           replyTo ! SnapshotSaved(result)
           Behaviors.same
 
-        case MoveAppended(gameId, seq, result) =>
-          result.left.foreach(ex => context.log.warn(s"Move append failed for game $gameId seq $seq: ${ex.getMessage}"))
+        case MoveAppended(matchId, seq, result) =>
+          result.left.foreach(ex =>
+            context.log.warn(s"Move append failed for game $matchId seq $seq: ${ex.getMessage}")
+          )
           Behaviors.same
 
-        case RecordGameResult(playerId, gameId, gameType, result, forfeit) =>
-          context.pipeToSelf(recordGameResultToStore(playerId, gameId, gameType, result, forfeit).unsafeToFuture()) {
-            case Success(value) => GameResultRecorded(gameId, playerId, Right(value))
-            case Failure(ex)    => GameResultRecorded(gameId, playerId, Left(ex))
+        case RecordGameResult(playerId, matchId, gameType, result, forfeit) =>
+          context.pipeToSelf(recordGameResultToStore(playerId, matchId, gameType, result, forfeit).unsafeToFuture()) {
+            case Success(value) => GameResultRecorded(matchId, playerId, Right(value))
+            case Failure(ex)    => GameResultRecorded(matchId, playerId, Left(ex))
           }
           Behaviors.same
 
-        case GameResultRecorded(gameId, playerId, result) =>
+        case GameResultRecorded(matchId, playerId, result) =>
           result.left.foreach(ex =>
-            context.log.warn(s"Game-result record failed for game $gameId player $playerId: ${ex.getMessage}")
+            context.log.warn(s"Game-result record failed for game $matchId player $playerId: ${ex.getMessage}")
           )
           Behaviors.same
       }

--- a/game-service-actor/src/main/scala/com/andy327/actor/persistence/PersistenceProtocol.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/persistence/PersistenceProtocol.scala
@@ -3,7 +3,7 @@ package com.andy327.actor.persistence
 import io.circe.Json
 import org.apache.pekko.actor.typed.ActorRef
 
-import com.andy327.model.core.{Game, GameId, GameType, PlayerId}
+import com.andy327.model.core.{Game, GameType, MatchId, PlayerId}
 import com.andy327.persistence.db.PlayerHistoryRepository.GameResult
 
 /** Commands and reply types for the persistence actor (e.g. [[PostgresActor]]).
@@ -21,7 +21,7 @@ object PersistenceProtocol {
 
   /** Persist (insert or update) the full game snapshot; replies with [[SnapshotSaved]]. */
   final case class SaveSnapshot(
-      gameId: GameId,
+      matchId: MatchId,
       gameType: GameType,
       game: Game[_, _, _, _, _],
       replyTo: ActorRef[SnapshotSaved]
@@ -34,7 +34,7 @@ object PersistenceProtocol {
     * correct, only its recorded history is lossy. If stronger guarantees are wanted later, this is the seam to add an
     * acknowledged, retried append (TODO: ack-and-retry; deferred while history is non-critical).
     */
-  final case class AppendMove(gameId: GameId, seq: Int, playerId: PlayerId, move: Json) extends Command
+  final case class AppendMove(matchId: MatchId, seq: Int, playerId: PlayerId, move: Json) extends Command
 
   /** Record one participant's outcome for a completed game in their durable history.
     *
@@ -43,7 +43,7 @@ object PersistenceProtocol {
     */
   final case class RecordGameResult(
       playerId: PlayerId,
-      gameId: GameId,
+      matchId: MatchId,
       gameType: GameType,
       result: GameResult,
       forfeit: Boolean

--- a/game-service-actor/src/main/scala/com/andy327/actor/persistence/PostgresActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/persistence/PostgresActor.scala
@@ -6,7 +6,7 @@ import cats.effect.unsafe.IORuntime
 import io.circe.Json
 import org.apache.pekko.actor.typed.Behavior
 
-import com.andy327.model.core.{Game, GameId, GameType, PlayerId}
+import com.andy327.model.core.{Game, GameType, MatchId, PlayerId}
 import com.andy327.persistence.db.PlayerHistoryRepository.GameResult
 import com.andy327.persistence.db.{
   GameRepository,
@@ -39,19 +39,19 @@ object PostgresActor {
       moveRepo: MoveHistoryRepository,
       playerHistoryRepo: PlayerHistoryRepository
   ) extends PersistActor {
-    def saveToStore(gameId: GameId, gameType: GameType, game: Game[_, _, _, _, _]): IO[Unit] =
-      gameRepo.saveGame(gameId, gameType, game)
+    def saveToStore(matchId: MatchId, gameType: GameType, game: Game[_, _, _, _, _]): IO[Unit] =
+      gameRepo.saveGame(matchId, gameType, game)
 
-    def appendMoveToStore(gameId: GameId, seq: Int, playerId: PlayerId, move: Json): IO[Unit] =
-      moveRepo.appendMove(gameId, seq, playerId, move)
+    def appendMoveToStore(matchId: MatchId, seq: Int, playerId: PlayerId, move: Json): IO[Unit] =
+      moveRepo.appendMove(matchId, seq, playerId, move)
 
     def recordGameResultToStore(
         playerId: PlayerId,
-        gameId: GameId,
+        matchId: MatchId,
         gameType: GameType,
         result: GameResult,
         forfeit: Boolean
     ): IO[Unit] =
-      playerHistoryRepo.record(playerId, gameId, gameType, result, forfeit)
+      playerHistoryRepo.record(playerId, matchId, gameType, result, forfeit)
   }
 }

--- a/game-service-actor/src/test/scala/com/andy327/actor/battleship/BattleshipActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/battleship/BattleshipActorSpec.scala
@@ -28,6 +28,7 @@ class BattleshipActorSpec extends AnyWordSpecLike with Matchers {
     val (_, behavior) =
       BattleshipActor.create(
         UUID.randomUUID(),
+        UUID.randomUUID(),
         Seq(alice, bob),
         persistProbe.ref,
         dummyGameManager,
@@ -39,7 +40,7 @@ class BattleshipActorSpec extends AnyWordSpecLike with Matchers {
   /** Receives the next pushed event and asserts it is a GameStateUpdated carrying a BattleshipState. */
   private def stateFrom(probe: TestProbe[PlayerActor.Command]): BattleshipState =
     probe.expectMessageType[PlayerActor.SendEvent].event match {
-      case PlayerEvent.GameStateUpdated(s: BattleshipState) => s
+      case PlayerEvent.GameStateUpdated(_, s: BattleshipState) => s
       case other => fail(s"expected GameStateUpdated(BattleshipState), got $other")
     }
 

--- a/game-service-actor/src/test/scala/com/andy327/actor/chat/RedisChatRepositorySpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/chat/RedisChatRepositorySpec.scala
@@ -15,7 +15,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.testcontainers.containers.wait.strategy.Wait
 
 import com.andy327.actor.core.PlayerEvent
-import com.andy327.model.core.GameId
+import com.andy327.model.core.RoomId
 import com.andy327.persistence.db.redis.RedisClientResource
 
 class RedisChatRepositorySpec extends AnyWordSpec with Matchers with ForAllTestContainer {
@@ -41,18 +41,18 @@ class RedisChatRepositorySpec extends AnyWordSpec with Matchers with ForAllTestC
       redis.flushAll *> f(new RedisChatRepository(redis, maxMessages))
     }.unsafeRunSync()
 
-  private def message(gameId: GameId, text: String): PlayerEvent.ChatMessage =
-    PlayerEvent.ChatMessage(gameId, UUID.randomUUID(), "alice", text, Instant.now())
+  private def message(roomId: RoomId, text: String): PlayerEvent.ChatMessage =
+    PlayerEvent.ChatMessage(roomId, UUID.randomUUID(), "alice", text, Instant.now())
 
   "RedisChatRepository.recent" should {
     "return appended messages in oldest-first order" in {
-      val gameId = UUID.randomUUID()
+      val roomId = UUID.randomUUID()
       withRepo() { repo =>
         for {
-          _ <- repo.append(message(gameId, "first"))
-          _ <- repo.append(message(gameId, "second"))
-          _ <- repo.append(message(gameId, "third"))
-          recent <- repo.recent(gameId)
+          _ <- repo.append(message(roomId, "first"))
+          _ <- repo.append(message(roomId, "second"))
+          _ <- repo.append(message(roomId, "third"))
+          recent <- repo.recent(roomId)
         } yield recent.map(_.text) shouldBe List("first", "second", "third")
       }
     }
@@ -75,13 +75,13 @@ class RedisChatRepositorySpec extends AnyWordSpec with Matchers with ForAllTestC
     }
 
     "skip corrupt entries rather than failing the whole read" in {
-      val gameId = UUID.randomUUID()
+      val roomId = UUID.randomUUID()
       RedisClientResource(redisConfig).use { redis =>
         val repo = new RedisChatRepository(redis)
         redis.flushAll *> (for {
-          _ <- repo.append(message(gameId, "good"))
-          _ <- redis.lPush(s"chat:$gameId", "{not valid json") // a non-JSON entry slipped into the buffer
-          recent <- repo.recent(gameId)
+          _ <- repo.append(message(roomId, "good"))
+          _ <- redis.lPush(s"chat:$roomId", "{not valid json") // a non-JSON entry slipped into the buffer
+          recent <- repo.recent(roomId)
         } yield recent.map(_.text) shouldBe List("good"))
       }.unsafeRunSync()
     }
@@ -89,11 +89,11 @@ class RedisChatRepositorySpec extends AnyWordSpec with Matchers with ForAllTestC
 
   "RedisChatRepository.append" should {
     "retain only the most recent messages once the buffer is full" in {
-      val gameId = UUID.randomUUID()
+      val roomId = UUID.randomUUID()
       withRepo(maxMessages = 3) { repo =>
         for {
-          _ <- List("m1", "m2", "m3", "m4", "m5").traverse_(t => repo.append(message(gameId, t)))
-          recent <- repo.recent(gameId)
+          _ <- List("m1", "m2", "m3", "m4", "m5").traverse_(t => repo.append(message(roomId, t)))
+          recent <- repo.recent(roomId)
         } yield recent.map(_.text) shouldBe List("m3", "m4", "m5")
       }
     }

--- a/game-service-actor/src/test/scala/com/andy327/actor/connectfour/ConnectFourActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/connectfour/ConnectFourActorSpec.scala
@@ -17,7 +17,7 @@ import com.andy327.actor.game.{GameState, GridGameState}
 import com.andy327.actor.lobby.GameLifecycleStatus
 import com.andy327.actor.persistence.PersistenceProtocol
 import com.andy327.model.connectfour.{ConnectFour, Drop, InvalidColumn, Red, Yellow}
-import com.andy327.model.core.{Game, GameError, GameId, PlayerId}
+import com.andy327.model.core.{Game, GameError, MatchId, PlayerId}
 
 class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
   private val testKit = ActorTestKit()
@@ -31,11 +31,11 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
   /** Spawn a fresh game actor backed by a new persist probe. */
   private def newActor(
       gmRef: ActorRef[GameManager.Command] = dummyGameManager,
-      gameId: GameId = UUID.randomUUID()
+      matchId: MatchId = UUID.randomUUID()
   ): (ActorRef[ConnectFourActor.Command], TestProbe[PersistenceProtocol.Command]) = {
     val persistProbe = createTestProbe[PersistenceProtocol.Command]()
     val (_, behavior) =
-      ConnectFourActor.create(gameId, gameId, Seq(alice, bob), persistProbe.ref, gmRef, NoOpEventPublisher)
+      ConnectFourActor.create(matchId, matchId, Seq(alice, bob), persistProbe.ref, gmRef, NoOpEventPublisher)
     (spawn(behavior), persistProbe)
   }
 
@@ -108,15 +108,15 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
     }
 
     "notify GameManager and stop when restored from a completed snapshot" in {
-      val gameId = UUID.randomUUID()
+      val matchId = UUID.randomUUID()
       val gameManagerProbe = createTestProbe[GameManager.Command]()
       val completedGame = playMoves(ConnectFour.empty(alice, bob), redWinsMoves)
 
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
       val actor = spawn(
         ConnectFourActor.fromSnapshot(
-          gameId,
-          gameId,
+          matchId,
+          matchId,
           completedGame,
           persistProbe.ref,
           gameManagerProbe.ref,
@@ -124,7 +124,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
         )
       )
 
-      gameManagerProbe.expectMessage(GameManager.GameCompleted(gameId, gameId, GameLifecycleStatus.Completed))
+      gameManagerProbe.expectMessage(GameManager.GameCompleted(matchId, matchId, GameLifecycleStatus.Completed))
       persistProbe.expectTerminated(actor)
     }
 
@@ -335,8 +335,8 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
 
     "notify the GameManager when a game completes" in {
       val gameManagerProbe = createTestProbe[GameManager.Command]()
-      val gameId: GameId = UUID.randomUUID()
-      val (actor, persistProbe) = newActor(gmRef = gameManagerProbe.ref, gameId = gameId)
+      val matchId: MatchId = UUID.randomUUID()
+      val (actor, persistProbe) = newActor(gmRef = gameManagerProbe.ref, matchId = matchId)
       val replyProbe = createTestProbe[Either[GameError, GameState]]()
 
       redWinsMoves.foreach { case (playerId, col) =>
@@ -346,8 +346,8 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
       }
 
       gameManagerProbe.receiveMessage() shouldBe GameManager.GameCompleted(
-        gameId,
-        gameId,
+        matchId,
+        matchId,
         GameLifecycleStatus.Completed
       )
     }

--- a/game-service-actor/src/test/scala/com/andy327/actor/connectfour/ConnectFourActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/connectfour/ConnectFourActorSpec.scala
@@ -314,7 +314,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
       persistProbe.expectTerminated(actor)
     }
 
-    "ignore non-SnapshotSaved messages in terminating state" in {
+    "reject a GetState landing in terminating state with GameOver instead of dropping it" in {
       val (actor, persistProbe) = newActor()
       val replyProbe = createTestProbe[Either[GameError, GameState]]()
 
@@ -324,9 +324,9 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
         expectMovePersisted(persistProbe)
       }
 
-      // GetState is ignored in terminating — no reply, actor stays alive
+      // a request landing in the terminating window gets a clean rejection rather than no reply at all
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
-      replyProbe.expectNoMessage()
+      replyProbe.expectMessage(Left(GameError.GameOver))
 
       // SnapshotSaved then stops the actor
       actor ! TurnBasedGameActor.SnapshotSaved(Right(()))

--- a/game-service-actor/src/test/scala/com/andy327/actor/connectfour/ConnectFourActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/connectfour/ConnectFourActorSpec.scala
@@ -35,7 +35,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
   ): (ActorRef[ConnectFourActor.Command], TestProbe[PersistenceProtocol.Command]) = {
     val persistProbe = createTestProbe[PersistenceProtocol.Command]()
     val (_, behavior) =
-      ConnectFourActor.create(gameId, Seq(alice, bob), persistProbe.ref, gmRef, NoOpEventPublisher)
+      ConnectFourActor.create(gameId, gameId, Seq(alice, bob), persistProbe.ref, gmRef, NoOpEventPublisher)
     (spawn(behavior), persistProbe)
   }
 
@@ -89,6 +89,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
       val behavior = ConnectFourActor.fromSnapshot(
         UUID.randomUUID(),
+        UUID.randomUUID(),
         snapshot,
         persistProbe.ref,
         dummyGameManager,
@@ -115,6 +116,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
       val actor = spawn(
         ConnectFourActor.fromSnapshot(
           gameId,
+          gameId,
           completedGame,
           persistProbe.ref,
           gameManagerProbe.ref,
@@ -122,7 +124,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
         )
       )
 
-      gameManagerProbe.expectMessage(GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed))
+      gameManagerProbe.expectMessage(GameManager.GameCompleted(gameId, gameId, GameLifecycleStatus.Completed))
       persistProbe.expectTerminated(actor)
     }
 
@@ -140,6 +142,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
 
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
       val behavior = ConnectFourActor.fromSnapshot(
+        UUID.randomUUID(),
         UUID.randomUUID(),
         dummyGame,
         persistProbe.ref,
@@ -342,7 +345,11 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
         expectMovePersisted(persistProbe)
       }
 
-      gameManagerProbe.receiveMessage() shouldBe GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed)
+      gameManagerProbe.receiveMessage() shouldBe GameManager.GameCompleted(
+        gameId,
+        gameId,
+        GameLifecycleStatus.Completed
+      )
     }
   }
 }

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
@@ -24,52 +24,52 @@ import com.andy327.actor.events.{EventPublisher, GameEvent}
 import com.andy327.actor.game.{GameOperation, GameStateConverters, GridGameState, MovePayload}
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyError, LobbyMetadata, LobbyRepository, Player}
 import com.andy327.actor.persistence.PersistenceProtocol
-import com.andy327.model.core.{Game, GameId, GameType, PlayerId}
+import com.andy327.model.core.{Game, GameType, MatchId, PlayerId, RoomId}
 import com.andy327.model.tictactoe.TicTacToe
 import com.andy327.persistence.db.{GameRepository, MoveHistoryRepository, MoveRecord}
 
 /** In-memory GameRepository for unit tests */
-class InMemRepo(initialGames: Map[GameId, (GameType, Game[_, _, _, _, _])] = Map.empty) extends GameRepository {
+class InMemRepo(initialGames: Map[MatchId, (GameType, Game[_, _, _, _, _])] = Map.empty) extends GameRepository {
   private val db = scala.collection.concurrent.TrieMap(initialGames.toSeq: _*)
 
   def initialize(): IO[Unit] = IO.unit
 
-  def saveGame(id: GameId, tpe: GameType, g: Game[_, _, _, _, _]): IO[Unit] =
+  def saveGame(id: MatchId, tpe: GameType, g: Game[_, _, _, _, _]): IO[Unit] =
     IO(db.update(id, (tpe, g)))
 
-  def loadGame(id: GameId, tpe: GameType): IO[Option[Game[_, _, _, _, _]]] =
+  def loadGame(id: MatchId, tpe: GameType): IO[Option[Game[_, _, _, _, _]]] =
     IO(db.get(id).collect { case (`tpe`, g) => g })
 
-  def loadAllGames(): IO[Map[GameId, (GameType, Game[_, _, _, _, _])]] =
+  def loadAllGames(): IO[Map[MatchId, (GameType, Game[_, _, _, _, _])]] =
     IO(db.toMap)
 }
 
 /** In-memory MoveHistoryRepository for unit tests; `loadFails` forces loadMoves to raise. */
-class InMemMoveRepo(initial: Map[GameId, List[MoveRecord]] = Map.empty, loadFails: Boolean = false)
+class InMemMoveRepo(initial: Map[MatchId, List[MoveRecord]] = Map.empty, loadFails: Boolean = false)
     extends MoveHistoryRepository {
   private val db = scala.collection.concurrent.TrieMap(initial.toSeq: _*)
 
   def initialize(): IO[Unit] = IO.unit
 
-  def appendMove(gameId: GameId, seq: Int, playerId: PlayerId, move: Json): IO[Unit] =
-    IO(db.update(gameId, db.getOrElse(gameId, Nil) :+ MoveRecord(seq, playerId, move, Instant.EPOCH)))
+  def appendMove(matchId: MatchId, seq: Int, playerId: PlayerId, move: Json): IO[Unit] =
+    IO(db.update(matchId, db.getOrElse(matchId, Nil) :+ MoveRecord(seq, playerId, move, Instant.EPOCH)))
 
-  def loadMoves(gameId: GameId): IO[List[MoveRecord]] =
+  def loadMoves(matchId: MatchId): IO[List[MoveRecord]] =
     if (loadFails) IO.raiseError(new RuntimeException("move load failure") with NoStackTrace)
-    else IO.pure(db.getOrElse(gameId, Nil))
+    else IO.pure(db.getOrElse(matchId, Nil))
 }
 
 /** In-memory ChatRepository for unit tests; records appends and `loadFails` forces recent to raise. */
-class InMemChatRepo(initial: Map[GameId, List[PlayerEvent.ChatMessage]] = Map.empty, loadFails: Boolean = false)
+class InMemChatRepo(initial: Map[RoomId, List[PlayerEvent.ChatMessage]] = Map.empty, loadFails: Boolean = false)
     extends ChatRepository {
   private val db = scala.collection.concurrent.TrieMap(initial.toSeq: _*)
 
   def append(message: PlayerEvent.ChatMessage): IO[Unit] =
-    IO(db.update(message.gameId, db.getOrElse(message.gameId, Nil) :+ message))
+    IO(db.update(message.roomId, db.getOrElse(message.roomId, Nil) :+ message))
 
-  def recent(gameId: GameId): IO[List[PlayerEvent.ChatMessage]] =
+  def recent(roomId: RoomId): IO[List[PlayerEvent.ChatMessage]] =
     if (loadFails) IO.raiseError(new RuntimeException("chat load failure") with NoStackTrace)
-    else IO.pure(db.getOrElse(gameId, Nil))
+    else IO.pure(db.getOrElse(roomId, Nil))
 }
 
 class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
@@ -80,7 +80,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
   private val noOpLobbyRepo: LobbyRepository = new LobbyRepository {
     override def saveLobby(metadata: LobbyMetadata): IO[Unit] = IO.unit
-    override def deleteLobby(gameId: GameId): IO[Unit] = IO.unit
+    override def deleteLobby(roomId: RoomId): IO[Unit] = IO.unit
     override def loadAllLobbies(): IO[List[LobbyMetadata]] = IO.pure(Nil)
   }
 
@@ -93,9 +93,9 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val readyProbe = TestProbe[GameManager.Ready.type]()
       val failingRepo = new GameRepository {
         def initialize(): IO[Unit] = IO.unit
-        def saveGame(id: GameId, tpe: GameType, g: Game[_, _, _, _, _]): IO[Unit] = IO.unit
-        def loadGame(id: GameId, tpe: GameType): IO[Option[Game[_, _, _, _, _]]] = IO.pure(None)
-        def loadAllGames(): IO[Map[GameId, (GameType, Game[_, _, _, _, _])]] =
+        def saveGame(id: MatchId, tpe: GameType, g: Game[_, _, _, _, _]): IO[Unit] = IO.unit
+        def loadGame(id: MatchId, tpe: GameType): IO[Option[Game[_, _, _, _, _]]] = IO.pure(None)
+        def loadAllGames(): IO[Map[MatchId, (GameType, Game[_, _, _, _, _])]] =
           IO.raiseError(new RuntimeException("DB failure") with NoStackTrace)
       }
 
@@ -108,9 +108,9 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val responseProbe = TestProbe[GameManager.GameResponse]()
       val slowRepo = new GameRepository {
         def initialize(): IO[Unit] = IO.unit
-        def saveGame(id: GameId, tpe: GameType, g: Game[_, _, _, _, _]): IO[Unit] = IO.unit
-        def loadGame(id: GameId, tpe: GameType): IO[Option[Game[_, _, _, _, _]]] = IO.pure(None)
-        def loadAllGames(): IO[Map[GameId, (GameType, Game[_, _, _, _, _])]] = IO.sleep(1.second) *> IO.pure(Map.empty)
+        def saveGame(id: MatchId, tpe: GameType, g: Game[_, _, _, _, _]): IO[Unit] = IO.unit
+        def loadGame(id: MatchId, tpe: GameType): IO[Option[Game[_, _, _, _, _]]] = IO.pure(None)
+        def loadAllGames(): IO[Map[MatchId, (GameType, Game[_, _, _, _, _])]] = IO.sleep(1.second) *> IO.pure(Map.empty)
       }
       val alice = Player("alice")
 
@@ -124,20 +124,20 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       // Eventually, after restore, the stashed message is processed
       val response = responseProbe.expectMessageType[GameManager.LobbyCreated](2.seconds)
-      response.gameId.toString should not be empty
+      response.roomId.toString should not be empty
     }
 
     "restore saved games from the game repository on startup" in {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
-      val gameId: GameId = UUID.randomUUID()
+      val roomId: RoomId = UUID.randomUUID()
       val restoredGame = TicTacToe.empty(alice, bob)
-      val gameRepo = new InMemRepo(Map(gameId -> (GameType.TicTacToe, restoredGame)))
+      val gameRepo = new InMemRepo(Map(roomId -> (GameType.TicTacToe, restoredGame)))
 
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
 
       val gameResponseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.RunGameOperation(gameId, GameOperation.GetState, gameResponseProbe.ref)
+      gm ! GameManager.RunGameOperation(roomId, GameOperation.GetState, gameResponseProbe.ref)
       val response = gameResponseProbe.expectMessageType[GameManager.GameResponse]
       response shouldBe GameManager.GameStatus(GameStateConverters.serializeGame(restoredGame, None))
     }
@@ -170,9 +170,9 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
 
       val response = responseProbe.expectMessageType[GameManager.LobbyCreated]
-      response.gameId.toString should not be empty
+      response.roomId.toString should not be empty
 
-      gm ! GameManager.GetLobbyInfo(response.gameId, responseProbe.ref)
+      gm ! GameManager.GetLobbyInfo(response.roomId, responseProbe.ref)
       val GameManager.LobbyInfo(metadata) = responseProbe.expectMessageType[GameManager.LobbyInfo]
 
       metadata.status shouldBe GameLifecycleStatus.WaitingForPlayers
@@ -181,15 +181,15 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
     "return an error when retrieving metadata for a nonexistent lobby" in {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
       val gameRepo = new InMemRepo
-      val nonexistentGameId: GameId = UUID.randomUUID()
+      val nonexistentRoomId: RoomId = UUID.randomUUID()
 
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.GetLobbyInfo(nonexistentGameId, responseProbe.ref)
+      gm ! GameManager.GetLobbyInfo(nonexistentRoomId, responseProbe.ref)
       val error = responseProbe.expectMessageType[GameManager.LobbyErrorResponse]
-      error.error shouldBe LobbyError.LobbyNotFound(nonexistentGameId)
+      error.error shouldBe LobbyError.LobbyNotFound(nonexistentRoomId)
     }
 
     "allow a second player to join a lobby and change its status to ReadyToStart" in {
@@ -202,9 +202,9 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
+      val GameManager.LobbyCreated(roomId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
 
-      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       val response = responseProbe.expectMessageType[GameManager.LobbyJoined]
       response.metadata.status shouldBe GameLifecycleStatus.ReadyToStart
     }
@@ -218,13 +218,13 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
+      val GameManager.LobbyCreated(roomId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
 
-      gm ! GameManager.JoinLobby(gameId, alice, responseProbe.ref)
+      gm ! GameManager.JoinLobby(roomId, alice, responseProbe.ref)
       val error = responseProbe.expectMessageType[GameManager.LobbyErrorResponse]
-      error.error shouldBe LobbyError.AlreadyInLobby(gameId)
+      error.error shouldBe LobbyError.AlreadyInLobby(roomId)
 
-      gm ! GameManager.GetLobbyInfo(gameId, responseProbe.ref)
+      gm ! GameManager.GetLobbyInfo(roomId, responseProbe.ref)
       val GameManager.LobbyInfo(metadata) = responseProbe.expectMessageType[GameManager.LobbyInfo]
 
       metadata.status shouldBe GameLifecycleStatus.WaitingForPlayers
@@ -234,15 +234,15 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
       val gameRepo = new InMemRepo
       val alice = Player("alice")
-      val nonexistentGameId: GameId = UUID.randomUUID()
+      val nonexistentRoomId: RoomId = UUID.randomUUID()
 
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
-      gm ! GameManager.JoinLobby(nonexistentGameId, alice, responseProbe.ref)
+      gm ! GameManager.JoinLobby(nonexistentRoomId, alice, responseProbe.ref)
 
       val error = responseProbe.expectMessageType[GameManager.LobbyErrorResponse]
-      error.error shouldBe LobbyError.LobbyNotFound(nonexistentGameId)
+      error.error shouldBe LobbyError.LobbyNotFound(nonexistentRoomId)
     }
 
     "prevent too many players from joining a lobby" in {
@@ -258,16 +258,16 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       // Alice creates the lobby
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, _) = responseProbe.receiveMessage()
+      val GameManager.LobbyCreated(roomId, _) = responseProbe.receiveMessage()
 
       // Bob joins
-      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
 
       // Carl tries to join - should be rejected
-      gm ! GameManager.JoinLobby(gameId, carl, responseProbe.ref)
+      gm ! GameManager.JoinLobby(roomId, carl, responseProbe.ref)
       val error = responseProbe.expectMessageType[GameManager.LobbyErrorResponse]
-      error.error shouldBe LobbyError.LobbyFull(gameId)
+      error.error shouldBe LobbyError.LobbyFull(roomId)
     }
 
     "prevent a player from joining a lobby of a game that's already started" in {
@@ -283,20 +283,20 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       // Alice creates the lobby
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, host) = responseProbe.receiveMessage()
+      val GameManager.LobbyCreated(roomId, host) = responseProbe.receiveMessage()
 
       // Bob joins
-      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
 
       // Game bgeins
-      gm ! GameManager.StartGame(gameId, host.id, responseProbe.ref)
+      gm ! GameManager.StartGame(roomId, host.id, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.GameStarted]
 
       // Carl tries to join - should be rejected
-      gm ! GameManager.JoinLobby(gameId, carl, responseProbe.ref)
+      gm ! GameManager.JoinLobby(roomId, carl, responseProbe.ref)
       val error = responseProbe.expectMessageType[GameManager.LobbyErrorResponse]
-      error.error shouldBe LobbyError.LobbyNotJoinable(gameId)
+      error.error shouldBe LobbyError.LobbyNotJoinable(roomId)
     }
 
     "allow a host to start a game from a ready lobby and persist the snapshot" in {
@@ -310,17 +310,17 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, host) = responseProbe.receiveMessage()
+      val GameManager.LobbyCreated(roomId, host) = responseProbe.receiveMessage()
 
-      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
 
-      gm ! GameManager.StartGame(gameId, host.id, responseProbe.ref)
-      responseProbe.expectMessage(GameManager.GameStarted(gameId))
+      gm ! GameManager.StartGame(roomId, host.id, responseProbe.ref)
+      responseProbe.expectMessage(GameManager.GameStarted(roomId))
 
       val snapshot = persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
       // the snapshot is keyed by the match id (minted fresh, distinct from the stable room id)
-      snapshot.gameId should not be gameId
+      snapshot.matchId should not be roomId
       snapshot.gameType shouldBe GameType.TicTacToe
     }
 
@@ -335,30 +335,30 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, _) = responseProbe.receiveMessage()
+      val GameManager.LobbyCreated(roomId, _) = responseProbe.receiveMessage()
 
-      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       val GameManager.LobbyJoined(_, _, joinedPlayer) = responseProbe.expectMessageType[GameManager.LobbyJoined]
 
       // Bob tries to start the game
-      gm ! GameManager.StartGame(gameId, joinedPlayer.id, responseProbe.ref)
+      gm ! GameManager.StartGame(roomId, joinedPlayer.id, responseProbe.ref)
       val error = responseProbe.expectMessageType[GameManager.LobbyErrorResponse]
-      error.error shouldBe LobbyError.NotHostError(gameId)
+      error.error shouldBe LobbyError.NotHostError(roomId)
     }
 
     "prevent a player from starting a nonexistent game" in {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
       val gameRepo = new InMemRepo
       val alice = Player("alice")
-      val nonexistentGameId: GameId = UUID.randomUUID()
+      val nonexistentRoomId: RoomId = UUID.randomUUID()
 
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.StartGame(nonexistentGameId, alice.id, responseProbe.ref)
+      gm ! GameManager.StartGame(nonexistentRoomId, alice.id, responseProbe.ref)
       val error = responseProbe.expectMessageType[GameManager.LobbyErrorResponse]
-      error.error shouldBe LobbyError.LobbyNotFound(nonexistentGameId)
+      error.error shouldBe LobbyError.LobbyNotFound(nonexistentRoomId)
     }
 
     "list available lobbies" in {
@@ -373,25 +373,25 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       // Game 1: InProgress
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId1, _) = responseProbe.receiveMessage()
-      gm ! GameManager.JoinLobby(gameId1, bob, responseProbe.ref)
+      val GameManager.LobbyCreated(roomId1, _) = responseProbe.receiveMessage()
+      gm ! GameManager.JoinLobby(roomId1, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
-      gm ! GameManager.StartGame(gameId1, alice.id, responseProbe.ref)
+      gm ! GameManager.StartGame(roomId1, alice.id, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.GameStarted]
 
       // Game 2: ReadyToStart
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId2, _) = responseProbe.receiveMessage()
-      gm ! GameManager.JoinLobby(gameId2, bob, responseProbe.ref)
+      val GameManager.LobbyCreated(roomId2, _) = responseProbe.receiveMessage()
+      gm ! GameManager.JoinLobby(roomId2, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
 
       // Game 2: WaitingForPlayers
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId3, _) = responseProbe.receiveMessage()
+      val GameManager.LobbyCreated(roomId3, _) = responseProbe.receiveMessage()
 
       gm ! GameManager.ListLobbies(None, 1, 20, responseProbe.ref)
       val response = responseProbe.expectMessageType[GameManager.LobbiesListed]
-      response.lobbies.map(_.gameId) should contain only (gameId2, gameId3)
+      response.lobbies.map(_.roomId) should contain only (roomId2, roomId3)
     }
 
     "report a player's joined lobbies and active games via GetPlayerSessions" in {
@@ -418,7 +418,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       gm ! GameManager.GetPlayerSessions(alice.id, responseProbe.ref)
       val sessions = responseProbe.expectMessageType[GameManager.PlayerSessions]
-      sessions.lobbies.map(_.gameId) should contain only lobbyA
+      sessions.lobbies.map(_.roomId) should contain only lobbyA
       sessions.games should contain only GameManager.ActiveGameSummary(gameB, GameType.TicTacToe)
     }
 
@@ -431,16 +431,16 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, host) = responseProbe.receiveMessage()
-      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      val GameManager.LobbyCreated(roomId, host) = responseProbe.receiveMessage()
+      gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
-      gm ! GameManager.StartGame(gameId, host.id, responseProbe.ref)
+      gm ! GameManager.StartGame(roomId, host.id, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.GameStarted]
 
       gm ! GameManager.GetPlayerSessions(alice.id, responseProbe.ref)
-      responseProbe.expectMessageType[GameManager.PlayerSessions].games.map(_.gameId) should contain(gameId)
+      responseProbe.expectMessageType[GameManager.PlayerSessions].games.map(_.roomId) should contain(roomId)
 
-      gm ! GameManager.GameCompleted(gameId, gameId, GameLifecycleStatus.Completed)
+      gm ! GameManager.GameCompleted(roomId, roomId, GameLifecycleStatus.Completed)
 
       gm ! GameManager.GetPlayerSessions(alice.id, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.PlayerSessions].games shouldBe empty
@@ -449,9 +449,9 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
     "rebuild the active-game index for restored games so GetPlayerSessions survives a restart" in {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
       val readyProbe = TestProbe[GameManager.Ready.type]()
-      val gameId: GameId = UUID.randomUUID()
+      val roomId: RoomId = UUID.randomUUID()
       val game = TicTacToe.empty(alice, bob)
-      val gameRepo = new InMemRepo(Map(gameId -> (GameType.TicTacToe, game)))
+      val gameRepo = new InMemRepo(Map(roomId -> (GameType.TicTacToe, game)))
 
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo, onReady = Some(readyProbe.ref)))
       readyProbe.expectMessage(5.seconds, GameManager.Ready)
@@ -459,7 +459,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val responseProbe = TestProbe[GameManager.GameResponse]()
       gm ! GameManager.GetPlayerSessions(alice, responseProbe.ref)
       val sessions = responseProbe.expectMessageType[GameManager.PlayerSessions]
-      sessions.games should contain only GameManager.ActiveGameSummary(gameId, GameType.TicTacToe)
+      sessions.games should contain only GameManager.ActiveGameSummary(roomId, GameType.TicTacToe)
     }
 
     "return empty sessions for a player who is in nothing" in {
@@ -486,7 +486,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       responseProbe.expectMessageType[GameManager.LobbyJoined]
       gm ! GameManager.StartGame(roomId, host.id, responseProbe.ref)
       responseProbe.expectMessage(GameManager.GameStarted(roomId))
-      val matchId = persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot].gameId
+      val matchId = persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot].matchId
 
       // seed the move log under the match id the room now points at
       moveRepo.appendMove(matchId, 0, alice, Json.obj("col" -> 3.asJson)).unsafeRunSync()
@@ -502,13 +502,13 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
     "return an empty move history for a game with no recorded moves" in {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
-      val gameId: GameId = UUID.randomUUID()
+      val roomId: RoomId = UUID.randomUUID()
       val gm = spawn(GameManager(persistProbe.ref, new InMemRepo, noOpLobbyRepo, moveRepo = new InMemMoveRepo))
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
-      gm ! GameManager.GetMoveHistory(gameId, responseProbe.ref)
+      gm ! GameManager.GetMoveHistory(roomId, responseProbe.ref)
 
-      responseProbe.expectMessage(GameManager.MoveHistory(gameId, Nil))
+      responseProbe.expectMessage(GameManager.MoveHistory(roomId, Nil))
     }
 
     "return an error when the move history load fails" in {
@@ -534,19 +534,19 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, host) = responseProbe.receiveMessage()
+      val GameManager.LobbyCreated(roomId, host) = responseProbe.receiveMessage()
 
-      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
 
-      gm ! GameManager.StartGame(gameId, host.id, responseProbe.ref)
+      gm ! GameManager.StartGame(roomId, host.id, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.GameStarted]
 
       // game actor sends a GameCompleted message to the GameManager
-      gm ! GameManager.GameCompleted(gameId, gameId, GameLifecycleStatus.Completed)
+      gm ! GameManager.GameCompleted(roomId, roomId, GameLifecycleStatus.Completed)
 
       // the room survives the match as a post-game room, now in the Finished state
-      gm ! GameManager.GetLobbyInfo(gameId, responseProbe.ref)
+      gm ! GameManager.GetLobbyInfo(roomId, responseProbe.ref)
       val GameManager.LobbyInfo(metadata) = responseProbe.expectMessageType[GameManager.LobbyInfo]
       metadata.status shouldBe GameLifecycleStatus.Finished
     }
@@ -557,25 +557,25 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       // the room must move to Finished and its stale in-progress record be deleted from persistent storage.
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
       val readyProbe = TestProbe[GameManager.Ready.type]()
-      val gameId: GameId = UUID.randomUUID()
+      val roomId: RoomId = UUID.randomUUID()
       val host = Player("alice")
       val guest = Player("bob")
       val game = TicTacToe.empty(host.id, guest.id)
-      val gameRepo = new InMemRepo(Map(gameId -> (GameType.TicTacToe, game)))
+      val gameRepo = new InMemRepo(Map(roomId -> (GameType.TicTacToe, game)))
 
       val restoredLobby = LobbyMetadata(
-        gameId,
+        roomId,
         GameType.TicTacToe,
         Map(host.id -> host, guest.id -> guest),
         host.id,
         GameLifecycleStatus.InProgress,
         Instant.now(),
-        currentMatchId = Some(gameId) // links the restored room to its in-progress match (keyed by gameId in gameRepo)
+        currentMatchId = Some(roomId) // links the restored room to its in-progress match (keyed by roomId in gameRepo)
       )
-      val deletedLobbies = scala.collection.concurrent.TrieMap.empty[GameId, Unit]
+      val deletedLobbies = scala.collection.concurrent.TrieMap.empty[RoomId, Unit]
       val restoringLobbyRepo: LobbyRepository = new LobbyRepository {
         override def saveLobby(metadata: LobbyMetadata): IO[Unit] = IO.unit
-        override def deleteLobby(gameId: GameId): IO[Unit] = IO(deletedLobbies.update(gameId, ()))
+        override def deleteLobby(roomId: RoomId): IO[Unit] = IO(deletedLobbies.update(roomId, ()))
         override def loadAllLobbies(): IO[List[LobbyMetadata]] = IO.pure(List(restoredLobby))
       }
 
@@ -585,36 +585,36 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       // sanity check: the restored lobby is known and InProgress
-      gm ! GameManager.GetLobbyInfo(gameId, responseProbe.ref)
+      gm ! GameManager.GetLobbyInfo(roomId, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.status shouldBe GameLifecycleStatus.InProgress
 
       // the restored game completes
-      gm ! GameManager.GameCompleted(gameId, gameId, GameLifecycleStatus.Completed)
+      gm ! GameManager.GameCompleted(roomId, roomId, GameLifecycleStatus.Completed)
 
-      gm ! GameManager.GetLobbyInfo(gameId, responseProbe.ref)
+      gm ! GameManager.GetLobbyInfo(roomId, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.status shouldBe GameLifecycleStatus.Finished
 
       // the fire-and-forget Redis delete is eventually dispatched
-      responseProbe.awaitAssert(deletedLobbies.keySet should contain(gameId))
+      responseProbe.awaitAssert(deletedLobbies.keySet should contain(roomId))
     }
 
     "serve game state from DB after the game actor is stopped on completion" in {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
       val readyProbe = TestProbe[GameManager.Ready.type]()
-      val gameId: GameId = UUID.randomUUID()
+      val roomId: RoomId = UUID.randomUUID()
       val playerX: PlayerId = UUID.randomUUID()
       val playerO: PlayerId = UUID.randomUUID()
       val game = TicTacToe.empty(playerX, playerO)
-      val gameRepo = new InMemRepo(Map(gameId -> (GameType.TicTacToe, game)))
+      val gameRepo = new InMemRepo(Map(roomId -> (GameType.TicTacToe, game)))
 
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo, onReady = Some(readyProbe.ref)))
       readyProbe.expectMessage(5.seconds, GameManager.Ready)
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.GameCompleted(gameId, gameId, GameLifecycleStatus.Completed)
+      gm ! GameManager.GameCompleted(roomId, roomId, GameLifecycleStatus.Completed)
 
-      gm ! GameManager.RunGameOperation(gameId, GameOperation.GetState, responseProbe.ref)
+      gm ! GameManager.RunGameOperation(roomId, GameOperation.GetState, responseProbe.ref)
       val response = responseProbe.expectMessageType[GameManager.GameStatus]
       response.state shouldBe GameStateConverters.serializeGame(game, None)
     }
@@ -622,46 +622,46 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
     "drop the completedMatch entry on RoomClosed, so a later operation reports GameNotFound" in {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
       val readyProbe = TestProbe[GameManager.Ready.type]()
-      val gameId: GameId = UUID.randomUUID()
+      val roomId: RoomId = UUID.randomUUID()
       val playerX: PlayerId = UUID.randomUUID()
       val playerO: PlayerId = UUID.randomUUID()
       val game = TicTacToe.empty(playerX, playerO)
-      val gameRepo = new InMemRepo(Map(gameId -> (GameType.TicTacToe, game)))
+      val gameRepo = new InMemRepo(Map(roomId -> (GameType.TicTacToe, game)))
 
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo, onReady = Some(readyProbe.ref)))
       readyProbe.expectMessage(5.seconds, GameManager.Ready)
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.GameCompleted(gameId, gameId, GameLifecycleStatus.Completed)
+      gm ! GameManager.GameCompleted(roomId, roomId, GameLifecycleStatus.Completed)
       // sanity check: the completedMatch entry serves GetState from the DB while the room is still known
-      gm ! GameManager.RunGameOperation(gameId, GameOperation.GetState, responseProbe.ref)
+      gm ! GameManager.RunGameOperation(roomId, GameOperation.GetState, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.GameStatus]
 
-      gm ! GameManager.RoomClosed(gameId) // the room is retired for good (cancelled or evicted)
+      gm ! GameManager.RoomClosed(roomId) // the room is retired for good (cancelled or evicted)
 
-      gm ! GameManager.RunGameOperation(gameId, GameOperation.GetState, responseProbe.ref)
-      responseProbe.expectMessageType[GameManager.GameNotFound].gameId shouldBe gameId
+      gm ! GameManager.RunGameOperation(roomId, GameOperation.GetState, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.GameNotFound].roomId shouldBe roomId
     }
 
     "return an error when forwarding a move to a completed game" in {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
       val readyProbe = TestProbe[GameManager.Ready.type]()
-      val gameId: GameId = UUID.randomUUID()
+      val roomId: RoomId = UUID.randomUUID()
       val playerX: PlayerId = UUID.randomUUID()
       val playerO: PlayerId = UUID.randomUUID()
       val game = TicTacToe.empty(playerX, playerO)
-      val gameRepo = new InMemRepo(Map(gameId -> (GameType.TicTacToe, game)))
+      val gameRepo = new InMemRepo(Map(roomId -> (GameType.TicTacToe, game)))
 
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo, onReady = Some(readyProbe.ref)))
       readyProbe.expectMessage(5.seconds, GameManager.Ready)
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.GameCompleted(gameId, gameId, GameLifecycleStatus.Completed)
+      gm ! GameManager.GameCompleted(roomId, roomId, GameLifecycleStatus.Completed)
 
       gm ! GameManager.RunGameOperation(
-        gameId,
+        roomId,
         GameOperation.MakeMove(playerX, MovePayload.TicTacToeMove(0, 0)),
         responseProbe.ref
       )
@@ -672,16 +672,16 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
     "return GameNotFound when DB has no record for a completed game" in {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
       val readyProbe = TestProbe[GameManager.Ready.type]()
-      val gameId: GameId = UUID.randomUUID()
+      val roomId: RoomId = UUID.randomUUID()
       val playerX: PlayerId = UUID.randomUUID()
       val playerO: PlayerId = UUID.randomUUID()
       val game = TicTacToe.empty(playerX, playerO)
       val gameRepo = new GameRepository {
         def initialize(): IO[Unit] = IO.unit
-        def saveGame(id: GameId, tpe: GameType, g: Game[_, _, _, _, _]): IO[Unit] = IO.unit
-        def loadGame(id: GameId, tpe: GameType): IO[Option[Game[_, _, _, _, _]]] = IO.pure(None)
-        def loadAllGames(): IO[Map[GameId, (GameType, Game[_, _, _, _, _])]] =
-          IO.pure(Map(gameId -> (GameType.TicTacToe, game)))
+        def saveGame(id: MatchId, tpe: GameType, g: Game[_, _, _, _, _]): IO[Unit] = IO.unit
+        def loadGame(id: MatchId, tpe: GameType): IO[Option[Game[_, _, _, _, _]]] = IO.pure(None)
+        def loadAllGames(): IO[Map[MatchId, (GameType, Game[_, _, _, _, _])]] =
+          IO.pure(Map(roomId -> (GameType.TicTacToe, game)))
       }
 
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo, onReady = Some(readyProbe.ref)))
@@ -689,26 +689,26 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.GameCompleted(gameId, gameId, GameLifecycleStatus.Completed)
+      gm ! GameManager.GameCompleted(roomId, roomId, GameLifecycleStatus.Completed)
 
-      gm ! GameManager.RunGameOperation(gameId, GameOperation.GetState, responseProbe.ref)
-      responseProbe.expectMessageType[GameManager.GameNotFound].gameId shouldBe gameId
+      gm ! GameManager.RunGameOperation(roomId, GameOperation.GetState, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.GameNotFound].roomId shouldBe roomId
     }
 
     "return an error when the DB call fails for a completed game" in {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
       val readyProbe = TestProbe[GameManager.Ready.type]()
-      val gameId: GameId = UUID.randomUUID()
+      val roomId: RoomId = UUID.randomUUID()
       val playerX: PlayerId = UUID.randomUUID()
       val playerO: PlayerId = UUID.randomUUID()
       val game = TicTacToe.empty(playerX, playerO)
       val gameRepo = new GameRepository {
         def initialize(): IO[Unit] = IO.unit
-        def saveGame(id: GameId, tpe: GameType, g: Game[_, _, _, _, _]): IO[Unit] = IO.unit
-        def loadGame(id: GameId, tpe: GameType): IO[Option[Game[_, _, _, _, _]]] =
+        def saveGame(id: MatchId, tpe: GameType, g: Game[_, _, _, _, _]): IO[Unit] = IO.unit
+        def loadGame(id: MatchId, tpe: GameType): IO[Option[Game[_, _, _, _, _]]] =
           IO.raiseError(new RuntimeException("DB load failed") with NoStackTrace)
-        def loadAllGames(): IO[Map[GameId, (GameType, Game[_, _, _, _, _])]] =
-          IO.pure(Map(gameId -> (GameType.TicTacToe, game)))
+        def loadAllGames(): IO[Map[MatchId, (GameType, Game[_, _, _, _, _])]] =
+          IO.pure(Map(roomId -> (GameType.TicTacToe, game)))
       }
 
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo, onReady = Some(readyProbe.ref)))
@@ -716,9 +716,9 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.GameCompleted(gameId, gameId, GameLifecycleStatus.Completed)
+      gm ! GameManager.GameCompleted(roomId, roomId, GameLifecycleStatus.Completed)
 
-      gm ! GameManager.RunGameOperation(gameId, GameOperation.GetState, responseProbe.ref)
+      gm ! GameManager.RunGameOperation(roomId, GameOperation.GetState, responseProbe.ref)
       val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
       error.message should include("Failed to retrieve game state")
     }
@@ -726,14 +726,14 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
     "handle trying to mark a nonexistent game as completed" in {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
       val gameRepo = new InMemRepo
-      val nonexistentGameId: GameId = UUID.randomUUID()
+      val nonexistentRoomId: RoomId = UUID.randomUUID()
 
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       // game actor sends a GameCompleted message to the GameManager
-      gm ! GameManager.GameCompleted(nonexistentGameId, nonexistentGameId, GameLifecycleStatus.Completed)
+      gm ! GameManager.GameCompleted(nonexistentRoomId, nonexistentRoomId, GameLifecycleStatus.Completed)
 
       // no-op: behavior remains the same and GameManager can continue receiving messages
       gm ! GameManager.ListLobbies(None, 1, 20, responseProbe.ref)
@@ -753,24 +753,24 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       // Alice creates the lobby
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, _) = responseProbe.receiveMessage()
+      val GameManager.LobbyCreated(roomId, _) = responseProbe.receiveMessage()
 
       // Bob joins
-      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
 
       // Bob leaves
-      gm ! GameManager.LeaveLobby(gameId, bob, responseProbe.ref)
+      gm ! GameManager.LeaveLobby(roomId, bob, responseProbe.ref)
       val bobLeft = responseProbe.expectMessageType[GameManager.LobbyLeft]
       bobLeft.message should include("left lobby")
 
       // Bob tries to leave again
-      gm ! GameManager.LeaveLobby(gameId, bob, responseProbe.ref)
+      gm ! GameManager.LeaveLobby(roomId, bob, responseProbe.ref)
       val bobLeft2 = responseProbe.expectMessageType[GameManager.LobbyLeft]
       bobLeft2.message should include("already absent")
 
       // Alice leaves
-      gm ! GameManager.LeaveLobby(gameId, alice, responseProbe.ref)
+      gm ! GameManager.LeaveLobby(roomId, alice, responseProbe.ref)
       val aliceLeft = responseProbe.expectMessageType[GameManager.LobbyLeft]
       aliceLeft.message should include("host left")
     }
@@ -785,20 +785,20 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, host) = responseProbe.receiveMessage()
-      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      val GameManager.LobbyCreated(roomId, host) = responseProbe.receiveMessage()
+      gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
-      gm ! GameManager.StartGame(gameId, host.id, responseProbe.ref)
+      gm ! GameManager.StartGame(roomId, host.id, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.GameStarted]
 
       // Bob (O) leaves the in-progress game — Alice (X) wins by forfeit
-      gm ! GameManager.LeaveLobby(gameId, bob, responseProbe.ref)
+      gm ! GameManager.LeaveLobby(roomId, bob, responseProbe.ref)
       val forfeited = responseProbe.expectMessageType[GameManager.GameForfeited]
       forfeited.state.asInstanceOf[GridGameState].winner shouldBe Some("X")
 
       // the room has moved to Finished (post-game) via the GameCompleted -> MatchEnded flow
       eventually {
-        gm ! GameManager.GetLobbyInfo(gameId, responseProbe.ref)
+        gm ! GameManager.GetLobbyInfo(roomId, responseProbe.ref)
         responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.status shouldBe GameLifecycleStatus.Finished
       }
     }
@@ -814,17 +814,17 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, host) = responseProbe.receiveMessage()
-      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      val GameManager.LobbyCreated(roomId, host) = responseProbe.receiveMessage()
+      gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
-      gm ! GameManager.StartGame(gameId, host.id, responseProbe.ref)
+      gm ! GameManager.StartGame(roomId, host.id, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.GameStarted]
 
       // Carol is not seated in the game; her leave is rejected and the game stays live
-      gm ! GameManager.LeaveLobby(gameId, carol, responseProbe.ref)
+      gm ! GameManager.LeaveLobby(roomId, carol, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.MoveRejected]
 
-      gm ! GameManager.GetLobbyInfo(gameId, responseProbe.ref)
+      gm ! GameManager.GetLobbyInfo(roomId, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.status shouldBe GameLifecycleStatus.InProgress
     }
 
@@ -832,15 +832,15 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
       val gameRepo = new InMemRepo
       val alice = Player("alice")
-      val nonexistentGameId: GameId = UUID.randomUUID()
+      val nonexistentRoomId: RoomId = UUID.randomUUID()
 
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.LeaveLobby(nonexistentGameId, alice, responseProbe.ref)
+      gm ! GameManager.LeaveLobby(nonexistentRoomId, alice, responseProbe.ref)
       val error = responseProbe.expectMessageType[GameManager.LobbyErrorResponse]
-      error.error shouldBe LobbyError.LobbyNotFound(nonexistentGameId)
+      error.error shouldBe LobbyError.LobbyNotFound(nonexistentRoomId)
     }
 
     "forward a valid move to a game" in {
@@ -854,17 +854,17 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, host) = responseProbe.receiveMessage()
+      val GameManager.LobbyCreated(roomId, host) = responseProbe.receiveMessage()
 
       // Bob joins
-      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
 
-      gm ! GameManager.StartGame(gameId, host.id, responseProbe.ref)
+      gm ! GameManager.StartGame(roomId, host.id, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.GameStarted]
 
       val validMove = MovePayload.TicTacToeMove(0, 0)
-      gm ! GameManager.RunGameOperation(gameId, GameOperation.MakeMove(alice.id, validMove), responseProbe.ref)
+      gm ! GameManager.RunGameOperation(roomId, GameOperation.MakeMove(alice.id, validMove), responseProbe.ref)
 
       val updatedState = responseProbe.expectMessageType[GameManager.GameStatus]
 
@@ -884,17 +884,17 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, host) = responseProbe.receiveMessage()
+      val GameManager.LobbyCreated(roomId, host) = responseProbe.receiveMessage()
 
       // Bob joins
-      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
 
-      gm ! GameManager.StartGame(gameId, host.id, responseProbe.ref)
+      gm ! GameManager.StartGame(roomId, host.id, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.GameStarted]
 
       val invalidMove = MovePayload.TicTacToeMove(99, 99)
-      gm ! GameManager.RunGameOperation(gameId, GameOperation.MakeMove(alice.id, invalidMove), responseProbe.ref)
+      gm ! GameManager.RunGameOperation(roomId, GameOperation.MakeMove(alice.id, invalidMove), responseProbe.ref)
 
       val error = responseProbe.expectMessageType[GameManager.MoveRejected]
       error.message should include("out of bounds")
@@ -951,13 +951,13 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       // Alice creates a lobby
       val responseProbe = TestProbe[GameManager.GameResponse]()
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
+      val GameManager.LobbyCreated(roomId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       // Auto-subscribe fires: alice's PlayerActor receives SendEvent(LobbyUpdated) and forwards it as a SessionEvent
       wsProbe.expectMessageType[PlayerActor.SessionEvent]
 
       // Bob joins — alice should receive another push event as she is subscribed
-      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
       wsProbe.expectMessageType[PlayerActor.SessionEvent]
     }
@@ -972,7 +972,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       // Alice creates a lobby without a WebSocket connection — no auto-subscribe for alice
       val responseProbe = TestProbe[GameManager.GameResponse]()
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
+      val GameManager.LobbyCreated(roomId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       // Bob connects via WebSocket, then joins
       val wsProbe = TestProbe[PlayerActor.SessionOutput]()
@@ -980,7 +980,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       gm ! GameManager.RegisterPlayer(bob, wsProbe.ref, playerRefProbe.ref)
       playerRefProbe.expectMessageType[ActorRef[PlayerActor.Command]]
 
-      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
 
       // Auto-subscribe fires: bob's PlayerActor receives SendEvent(LobbyUpdated) and forwards it as a SessionEvent
@@ -1004,15 +1004,15 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       // Alice creates a lobby
       val responseProbe = TestProbe[GameManager.GameResponse]()
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
+      val GameManager.LobbyCreated(roomId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       // Spectator subscribes to lobby events
-      gm ! GameManager.SubscribePlayerToLobby(gameId, spectator.id, responseProbe.ref)
-      responseProbe.expectMessage(GameManager.SubscribeAcknowledged(gameId))
+      gm ! GameManager.SubscribePlayerToLobby(roomId, spectator.id, responseProbe.ref)
+      responseProbe.expectMessage(GameManager.SubscribeAcknowledged(roomId))
 
       // Initial lobby state push arrives on subscribe; bob joining triggers another
       wsProbe.expectMessageType[PlayerActor.SessionEvent]
-      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
       wsProbe.expectMessageType[PlayerActor.SessionEvent]
     }
@@ -1025,10 +1025,10 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
+      val GameManager.LobbyCreated(roomId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       // Alice has no WebSocket connection
-      gm ! GameManager.SubscribePlayerToLobby(gameId, alice.id, responseProbe.ref)
+      gm ! GameManager.SubscribePlayerToLobby(roomId, alice.id, responseProbe.ref)
       val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
       error.message should include("not connected")
     }
@@ -1042,10 +1042,10 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, host) = responseProbe.expectMessageType[GameManager.LobbyCreated]
-      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      val GameManager.LobbyCreated(roomId, host) = responseProbe.expectMessageType[GameManager.LobbyCreated]
+      gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
-      gm ! GameManager.StartGame(gameId, host.id, responseProbe.ref)
+      gm ! GameManager.StartGame(roomId, host.id, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.GameStarted]
 
       val wsProbe = TestProbe[PlayerActor.SessionOutput]()
@@ -1053,7 +1053,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       gm ! GameManager.RegisterPlayer(alice, wsProbe.ref, playerRefProbe.ref)
       playerRefProbe.expectMessageType[ActorRef[PlayerActor.Command]]
 
-      gm ! GameManager.SubscribePlayerToLobby(gameId, alice.id, responseProbe.ref)
+      gm ! GameManager.SubscribePlayerToLobby(roomId, alice.id, responseProbe.ref)
       val error = responseProbe.expectMessageType[GameManager.LobbyErrorResponse]
       error.error shouldBe a[LobbyError.GameAlreadyStarted]
     }
@@ -1075,19 +1075,19 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       // Start a game
       val responseProbe = TestProbe[GameManager.GameResponse]()
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, host) = responseProbe.expectMessageType[GameManager.LobbyCreated]
-      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      val GameManager.LobbyCreated(roomId, host) = responseProbe.expectMessageType[GameManager.LobbyCreated]
+      gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
-      gm ! GameManager.StartGame(gameId, host.id, responseProbe.ref)
+      gm ! GameManager.StartGame(roomId, host.id, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.GameStarted]
 
       // Spectator subscribes to game events
-      gm ! GameManager.SubscribePlayerToGame(gameId, spectator.id, responseProbe.ref)
-      responseProbe.expectMessage(GameManager.SubscribeAcknowledged(gameId))
+      gm ! GameManager.SubscribePlayerToGame(roomId, spectator.id, responseProbe.ref)
+      responseProbe.expectMessage(GameManager.SubscribeAcknowledged(roomId))
 
       // A move is made — spectator should receive a push event
       gm ! GameManager.RunGameOperation(
-        gameId,
+        roomId,
         GameOperation.MakeMove(alice.id, MovePayload.TicTacToeMove(0, 0)),
         responseProbe.ref
       )
@@ -1104,14 +1104,14 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, host) = responseProbe.expectMessageType[GameManager.LobbyCreated]
-      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      val GameManager.LobbyCreated(roomId, host) = responseProbe.expectMessageType[GameManager.LobbyCreated]
+      gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
-      gm ! GameManager.StartGame(gameId, host.id, responseProbe.ref)
+      gm ! GameManager.StartGame(roomId, host.id, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.GameStarted]
 
       // Alice has no WebSocket connection
-      gm ! GameManager.SubscribePlayerToGame(gameId, alice.id, responseProbe.ref)
+      gm ! GameManager.SubscribePlayerToGame(roomId, alice.id, responseProbe.ref)
       val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
       error.message should include("not connected")
     }
@@ -1144,12 +1144,12 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, host) = responseProbe.receiveMessage()
+      val GameManager.LobbyCreated(roomId, host) = responseProbe.receiveMessage()
 
-      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
 
-      gm ! GameManager.StartGame(gameId, host.id, responseProbe.ref)
+      gm ! GameManager.StartGame(roomId, host.id, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.GameStarted]
 
       // alice connects and subscribes to the in-progress game
@@ -1158,13 +1158,13 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       gm ! GameManager.RegisterPlayer(alice, wsProbe.ref, playerRefProbe.ref)
       playerRefProbe.expectMessageType[ActorRef[PlayerActor.Command]]
 
-      gm ! GameManager.SubscribePlayerToGame(gameId, alice.id, responseProbe.ref)
-      responseProbe.expectMessage(GameManager.SubscribeAcknowledged(gameId))
+      gm ! GameManager.SubscribePlayerToGame(roomId, alice.id, responseProbe.ref)
+      responseProbe.expectMessage(GameManager.SubscribeAcknowledged(roomId))
       wsProbe.expectMessageType[PlayerActor.SessionEvent] // initial game state on subscribe
 
       // a move while subscribed is delivered to alice's session
       gm ! GameManager.RunGameOperation(
-        gameId,
+        roomId,
         GameOperation.MakeMove(alice.id, MovePayload.TicTacToeMove(0, 0)),
         responseProbe.ref
       )
@@ -1172,11 +1172,11 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       wsProbe.expectMessageType[PlayerActor.SessionEvent] // GameStateUpdated
 
       // after unsubscribing, a subsequent move is no longer delivered to alice
-      gm ! GameManager.UnsubscribePlayerFromGame(gameId, alice.id, responseProbe.ref)
-      responseProbe.expectMessage(GameManager.UnsubscribeAcknowledged(gameId))
+      gm ! GameManager.UnsubscribePlayerFromGame(roomId, alice.id, responseProbe.ref)
+      responseProbe.expectMessage(GameManager.UnsubscribeAcknowledged(roomId))
 
       gm ! GameManager.RunGameOperation(
-        gameId,
+        roomId,
         GameOperation.MakeMove(bob.id, MovePayload.TicTacToeMove(1, 1)),
         responseProbe.ref
       )
@@ -1209,15 +1209,15 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
+      val GameManager.LobbyCreated(roomId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       val wsProbe = TestProbe[PlayerActor.SessionOutput]()
       val playerRefProbe = TestProbe[ActorRef[PlayerActor.Command]]()
       gm ! GameManager.RegisterPlayer(alice, wsProbe.ref, playerRefProbe.ref)
       playerRefProbe.expectMessageType[ActorRef[PlayerActor.Command]]
 
-      gm ! GameManager.SubscribePlayerToLobby(gameId, alice.id, responseProbe.ref)
-      responseProbe.expectMessage(GameManager.SubscribeAcknowledged(gameId))
+      gm ! GameManager.SubscribePlayerToLobby(roomId, alice.id, responseProbe.ref)
+      responseProbe.expectMessage(GameManager.SubscribeAcknowledged(roomId))
 
       // subscriber receives initial lobby state immediately via WebSocket
       wsProbe.expectMessageType[PlayerActor.SessionEvent]
@@ -1235,10 +1235,10 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       gm ! GameManager.CreateLobby(GameType.TicTacToe, host, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, _) = responseProbe.receiveMessage()
-      gm ! GameManager.JoinLobby(gameId, guest, responseProbe.ref)
+      val GameManager.LobbyCreated(roomId, _) = responseProbe.receiveMessage()
+      gm ! GameManager.JoinLobby(roomId, guest, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
-      gm ! GameManager.StartGame(gameId, host.id, responseProbe.ref)
+      gm ! GameManager.StartGame(roomId, host.id, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.GameStarted]
 
       // connect the host and subscribe their session to the in-progress game as a spectator
@@ -1247,11 +1247,11 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       gm ! GameManager.RegisterPlayer(host, wsProbe.ref, playerRefProbe.ref)
       playerRefProbe.expectMessageType[ActorRef[PlayerActor.Command]]
 
-      gm ! GameManager.SubscribePlayerToGame(gameId, host.id, responseProbe.ref)
-      responseProbe.expectMessage(GameManager.SubscribeAcknowledged(gameId))
+      gm ! GameManager.SubscribePlayerToGame(roomId, host.id, responseProbe.ref)
+      responseProbe.expectMessage(GameManager.SubscribeAcknowledged(roomId))
       wsProbe.expectMessageType[PlayerActor.SessionEvent] // initial game state on subscribe
 
-      gm ! GameManager.SendChat(gameId, host, "gg")
+      gm ! GameManager.SendChat(roomId, host, "gg")
 
       val chat = wsProbe.expectMessageType[PlayerActor.SessionEvent].event.asInstanceOf[PlayerEvent.ChatMessage]
       chat.senderId shouldBe host.id
@@ -1260,7 +1260,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       // the send is also recorded for analytics, tagged with the in-progress game's type
       wsProbe.awaitAssert {
         val chatEvents = published.iterator().asScala.collect { case c: GameEvent.ChatSent => c }.toList
-        chatEvents.map(_.gameId) shouldBe List(gameId)
+        chatEvents.map(_.roomId) shouldBe List(roomId)
         chatEvents.head.gameType shouldBe Some(GameType.TicTacToe)
       }
     }
@@ -1278,10 +1278,10 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       playerRefProbe.expectMessageType[ActorRef[PlayerActor.Command]]
 
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
+      val GameManager.LobbyCreated(roomId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
       wsProbe.expectMessageType[PlayerActor.SessionEvent] // initial lobby state from the auto-subscribe
 
-      gm ! GameManager.SendChat(gameId, alice, "hello")
+      gm ! GameManager.SendChat(roomId, alice, "hello")
       val chat = wsProbe.expectMessageType[PlayerActor.SessionEvent].event.asInstanceOf[PlayerEvent.ChatMessage]
       chat.text shouldBe "hello"
     }
@@ -1291,14 +1291,14 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val chatRepo = new InMemChatRepo()
       val gm = spawn(GameManager(persistProbe.ref, new InMemRepo, noOpLobbyRepo, chatRepo = chatRepo))
       val responseProbe = TestProbe[GameManager.GameResponse]()
-      val gameId: GameId = UUID.randomUUID()
+      val roomId: RoomId = UUID.randomUUID()
       val sender = Player("alice")
 
-      gm ! GameManager.SendChat(gameId, sender, "hello all")
+      gm ! GameManager.SendChat(roomId, sender, "hello all")
 
       // append is fire-and-forget, so poll the history until the message lands
       responseProbe.awaitAssert {
-        gm ! GameManager.GetChatHistory(gameId, responseProbe.ref)
+        gm ! GameManager.GetChatHistory(roomId, responseProbe.ref)
         val history = responseProbe.expectMessageType[GameManager.ChatHistory]
         history.messages.map(_.text) shouldBe List("hello all")
       }
@@ -1306,18 +1306,18 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
     "return the recorded chat history on GetChatHistory" in {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
-      val gameId: GameId = UUID.randomUUID()
+      val roomId: RoomId = UUID.randomUUID()
       val seeded = List(
-        PlayerEvent.ChatMessage(gameId, alice, "alice", "hi", Instant.EPOCH),
-        PlayerEvent.ChatMessage(gameId, bob, "bob", "hey", Instant.EPOCH)
+        PlayerEvent.ChatMessage(roomId, alice, "alice", "hi", Instant.EPOCH),
+        PlayerEvent.ChatMessage(roomId, bob, "bob", "hey", Instant.EPOCH)
       )
-      val chatRepo = new InMemChatRepo(Map(gameId -> seeded))
+      val chatRepo = new InMemChatRepo(Map(roomId -> seeded))
       val gm = spawn(GameManager(persistProbe.ref, new InMemRepo, noOpLobbyRepo, chatRepo = chatRepo))
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.GetChatHistory(gameId, responseProbe.ref)
+      gm ! GameManager.GetChatHistory(roomId, responseProbe.ref)
       val history = responseProbe.expectMessageType[GameManager.ChatHistory]
-      history.gameId shouldBe gameId
+      history.roomId shouldBe roomId
       history.messages shouldBe seeded
     }
 
@@ -1341,7 +1341,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, host) = responseProbe.expectMessageType[GameManager.LobbyCreated]
+      val GameManager.LobbyCreated(roomId, host) = responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       // Alice connects via WebSocket and subscribes before the game starts
       val wsProbe = TestProbe[PlayerActor.SessionOutput]()
@@ -1349,21 +1349,21 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       gm ! GameManager.RegisterPlayer(alice, wsProbe.ref, playerRefProbe.ref)
       playerRefProbe.expectMessageType[ActorRef[PlayerActor.Command]]
 
-      gm ! GameManager.SubscribePlayerToLobby(gameId, alice.id, responseProbe.ref)
-      responseProbe.expectMessage(GameManager.SubscribeAcknowledged(gameId))
+      gm ! GameManager.SubscribePlayerToLobby(roomId, alice.id, responseProbe.ref)
+      responseProbe.expectMessage(GameManager.SubscribeAcknowledged(roomId))
       wsProbe.expectMessageType[PlayerActor.SessionEvent] // initial LobbyUpdated snapshot
 
-      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
       wsProbe.expectMessageType[PlayerActor.SessionEvent] // LobbyUpdated on join
 
       // Start the game — LobbyManager passes Alice's PlayerActor ref in SpawnGame
-      gm ! GameManager.StartGame(gameId, host.id, responseProbe.ref)
+      gm ! GameManager.StartGame(roomId, host.id, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.GameStarted]
 
       // Make a move; Alice's WebSocket should receive GameStateUpdated from the game actor
       gm ! GameManager.RunGameOperation(
-        gameId,
+        roomId,
         GameOperation.MakeMove(alice.id, MovePayload.TicTacToeMove(0, 0)),
         responseProbe.ref
       )
@@ -1376,16 +1376,16 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
       val gameRepo = new InMemRepo
       val alice = Player("alice")
-      val nonexistentGameId: GameId = UUID.randomUUID()
+      val nonexistentRoomId: RoomId = UUID.randomUUID()
 
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       val move = MovePayload.TicTacToeMove(0, 0)
-      gm ! GameManager.RunGameOperation(nonexistentGameId, GameOperation.MakeMove(alice.id, move), responseProbe.ref)
+      gm ! GameManager.RunGameOperation(nonexistentRoomId, GameOperation.MakeMove(alice.id, move), responseProbe.ref)
 
-      responseProbe.expectMessageType[GameManager.GameNotFound].gameId shouldBe nonexistentGameId
+      responseProbe.expectMessageType[GameManager.GameNotFound].roomId shouldBe nonexistentRoomId
     }
 
     "return an ErrorResponse when the move payload does not match the game type" in {
@@ -1396,16 +1396,16 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, host) = responseProbe.receiveMessage()
-      gm ! GameManager.JoinLobby(gameId, bob, responseProbe.ref)
+      val GameManager.LobbyCreated(roomId, host) = responseProbe.receiveMessage()
+      gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
-      gm ! GameManager.StartGame(gameId, host.id, responseProbe.ref)
+      gm ! GameManager.StartGame(roomId, host.id, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.GameStarted]
 
       // a ConnectFour move sent to a TicTacToe game can't be converted by the module, so RunGameOperation replies
       // with an ErrorResponse rather than forwarding anything to the game actor
       gm ! GameManager.RunGameOperation(
-        gameId,
+        roomId,
         GameOperation.MakeMove(host.id, MovePayload.ConnectFourMove(0)),
         responseProbe.ref
       )
@@ -1415,12 +1415,12 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
     "return an error when SpawnGame is sent with the wrong number of players" in {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
       val gameRepo = new InMemRepo
-      val gameId: GameId = UUID.randomUUID()
+      val roomId: RoomId = UUID.randomUUID()
 
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
-      gm ! GameManager.SpawnGame(gameId, UUID.randomUUID(), GameType.TicTacToe, Seq(alice), responseProbe.ref)
+      gm ! GameManager.SpawnGame(roomId, UUID.randomUUID(), GameType.TicTacToe, Seq(alice), responseProbe.ref)
 
       val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
       error.message should include("players required")

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
@@ -438,7 +438,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       gm ! GameManager.GetPlayerSessions(alice.id, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.PlayerSessions].games.map(_.gameId) should contain(gameId)
 
-      gm ! GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed)
+      gm ! GameManager.GameCompleted(gameId, gameId, GameLifecycleStatus.Completed)
 
       gm ! GameManager.GetPlayerSessions(alice.id, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.PlayerSessions].games shouldBe empty
@@ -530,7 +530,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       responseProbe.expectMessageType[GameManager.GameStarted]
 
       // game actor sends a GameCompleted message to the GameManager
-      gm ! GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed)
+      gm ! GameManager.GameCompleted(gameId, gameId, GameLifecycleStatus.Completed)
 
       gm ! GameManager.GetLobbyInfo(gameId, responseProbe.ref)
       val GameManager.LobbyInfo(metadata) = responseProbe.expectMessageType[GameManager.LobbyInfo]
@@ -574,7 +574,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.status shouldBe GameLifecycleStatus.InProgress
 
       // the restored game completes
-      gm ! GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed)
+      gm ! GameManager.GameCompleted(gameId, gameId, GameLifecycleStatus.Completed)
 
       gm ! GameManager.GetLobbyInfo(gameId, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.status shouldBe GameLifecycleStatus.Completed
@@ -597,7 +597,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed)
+      gm ! GameManager.GameCompleted(gameId, gameId, GameLifecycleStatus.Completed)
 
       gm ! GameManager.RunGameOperation(gameId, GameOperation.GetState, responseProbe.ref)
       val response = responseProbe.expectMessageType[GameManager.GameStatus]
@@ -618,7 +618,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed)
+      gm ! GameManager.GameCompleted(gameId, gameId, GameLifecycleStatus.Completed)
 
       gm ! GameManager.RunGameOperation(
         gameId,
@@ -649,7 +649,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed)
+      gm ! GameManager.GameCompleted(gameId, gameId, GameLifecycleStatus.Completed)
 
       gm ! GameManager.RunGameOperation(gameId, GameOperation.GetState, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.GameNotFound].gameId shouldBe gameId
@@ -676,7 +676,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed)
+      gm ! GameManager.GameCompleted(gameId, gameId, GameLifecycleStatus.Completed)
 
       gm ! GameManager.RunGameOperation(gameId, GameOperation.GetState, responseProbe.ref)
       val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
@@ -693,7 +693,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       // game actor sends a GameCompleted message to the GameManager
-      gm ! GameManager.GameCompleted(nonexistentGameId, GameLifecycleStatus.Completed)
+      gm ! GameManager.GameCompleted(nonexistentGameId, nonexistentGameId, GameLifecycleStatus.Completed)
 
       // no-op: behavior remains the same and GameManager can continue receiving messages
       gm ! GameManager.ListLobbies(None, 1, 20, responseProbe.ref)

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
@@ -554,7 +554,8 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
         GameType.TicTacToe,
         Map(host.id -> host, guest.id -> guest),
         host.id,
-        GameLifecycleStatus.InProgress
+        GameLifecycleStatus.InProgress,
+        Instant.now()
       )
       val deletedLobbies = scala.collection.concurrent.TrieMap.empty[GameId, Unit]
       val restoringLobbyRepo: LobbyRepository = new LobbyRepository {

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
@@ -619,6 +619,31 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       response.state shouldBe GameStateConverters.serializeGame(game, None)
     }
 
+    "drop the completedMatch entry on RoomClosed, so a later operation reports GameNotFound" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val readyProbe = TestProbe[GameManager.Ready.type]()
+      val gameId: GameId = UUID.randomUUID()
+      val playerX: PlayerId = UUID.randomUUID()
+      val playerO: PlayerId = UUID.randomUUID()
+      val game = TicTacToe.empty(playerX, playerO)
+      val gameRepo = new InMemRepo(Map(gameId -> (GameType.TicTacToe, game)))
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo, onReady = Some(readyProbe.ref)))
+      readyProbe.expectMessage(5.seconds, GameManager.Ready)
+
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+
+      gm ! GameManager.GameCompleted(gameId, gameId, GameLifecycleStatus.Completed)
+      // sanity check: the completedMatch entry serves GetState from the DB while the room is still known
+      gm ! GameManager.RunGameOperation(gameId, GameOperation.GetState, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.GameStatus]
+
+      gm ! GameManager.RoomClosed(gameId) // the room is retired for good (cancelled or evicted)
+
+      gm ! GameManager.RunGameOperation(gameId, GameOperation.GetState, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.GameNotFound].gameId shouldBe gameId
+    }
+
     "return an error when forwarding a move to a completed game" in {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
       val readyProbe = TestProbe[GameManager.Ready.type]()

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
@@ -319,7 +319,9 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       responseProbe.expectMessage(GameManager.GameStarted(gameId))
 
       val snapshot = persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
-      snapshot.gameId shouldBe gameId
+      // the snapshot is keyed by the match id (minted fresh, distinct from the stable room id)
+      snapshot.gameId should not be gameId
+      snapshot.gameType shouldBe GameType.TicTacToe
     }
 
     "prevent a non-host player from starting the game" in {
@@ -473,18 +475,29 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
     "return the recorded move history for a game" in {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
-      val gameId: GameId = UUID.randomUUID()
+      val moveRepo = new InMemMoveRepo()
+      val gm = spawn(GameManager(persistProbe.ref, new InMemRepo, noOpLobbyRepo, moveRepo = moveRepo))
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+
+      // start a game so the room resolves to a live match (the move log is keyed by match id, not room id)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, Player("alice"), responseProbe.ref)
+      val GameManager.LobbyCreated(roomId, host) = responseProbe.receiveMessage()
+      gm ! GameManager.JoinLobby(roomId, Player("bob"), responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbyJoined]
+      gm ! GameManager.StartGame(roomId, host.id, responseProbe.ref)
+      responseProbe.expectMessage(GameManager.GameStarted(roomId))
+      val matchId = persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot].gameId
+
+      // seed the move log under the match id the room now points at
+      moveRepo.appendMove(matchId, 0, alice, Json.obj("col" -> 3.asJson)).unsafeRunSync()
+      moveRepo.appendMove(matchId, 1, bob, Json.obj("col" -> 4.asJson)).unsafeRunSync()
       val moves = List(
         MoveRecord(0, alice, Json.obj("col" -> 3.asJson), Instant.EPOCH),
         MoveRecord(1, bob, Json.obj("col" -> 4.asJson), Instant.EPOCH)
       )
-      val moveRepo = new InMemMoveRepo(Map(gameId -> moves))
-      val gm = spawn(GameManager(persistProbe.ref, new InMemRepo, noOpLobbyRepo, moveRepo = moveRepo))
 
-      val responseProbe = TestProbe[GameManager.GameResponse]()
-      gm ! GameManager.GetMoveHistory(gameId, responseProbe.ref)
-
-      responseProbe.expectMessage(GameManager.MoveHistory(gameId, moves))
+      gm ! GameManager.GetMoveHistory(roomId, responseProbe.ref)
+      responseProbe.expectMessage(GameManager.MoveHistory(roomId, moves))
     }
 
     "return an empty move history for a game with no recorded moves" in {
@@ -555,7 +568,8 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
         Map(host.id -> host, guest.id -> guest),
         host.id,
         GameLifecycleStatus.InProgress,
-        Instant.now()
+        Instant.now(),
+        currentMatchId = Some(gameId) // links the restored room to its in-progress match (keyed by gameId in gameRepo)
       )
       val deletedLobbies = scala.collection.concurrent.TrieMap.empty[GameId, Unit]
       val restoringLobbyRepo: LobbyRepository = new LobbyRepository {
@@ -1380,7 +1394,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
-      gm ! GameManager.SpawnGame(gameId, GameType.TicTacToe, Set(alice), responseProbe.ref)
+      gm ! GameManager.SpawnGame(gameId, UUID.randomUUID(), GameType.TicTacToe, Set(alice), responseProbe.ref)
 
       val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
       error.message should include("players required")

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
@@ -1395,7 +1395,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
-      gm ! GameManager.SpawnGame(gameId, UUID.randomUUID(), GameType.TicTacToe, Set(alice), responseProbe.ref)
+      gm ! GameManager.SpawnGame(gameId, UUID.randomUUID(), GameType.TicTacToe, Seq(alice), responseProbe.ref)
 
       val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
       error.message should include("players required")

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
@@ -523,7 +523,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       error.message should include("Failed to retrieve move history")
     }
 
-    "mark game as completed when receiving GameCompleted message" in {
+    "move the room to Finished when receiving GameCompleted message" in {
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
       val gameRepo = new InMemRepo
       val alice = Player("alice")
@@ -545,15 +545,16 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       // game actor sends a GameCompleted message to the GameManager
       gm ! GameManager.GameCompleted(gameId, gameId, GameLifecycleStatus.Completed)
 
+      // the room survives the match as a post-game room, now in the Finished state
       gm ! GameManager.GetLobbyInfo(gameId, responseProbe.ref)
       val GameManager.LobbyInfo(metadata) = responseProbe.expectMessageType[GameManager.LobbyInfo]
-      metadata.status shouldBe GameLifecycleStatus.Completed
+      metadata.status shouldBe GameLifecycleStatus.Finished
     }
 
-    "mark a restored lobby as completed when its restored game finishes" in {
+    "move a restored room to Finished when its restored game finishes" in {
       // Simulates a restart mid-game: the game comes back from the game repository and its
       // InProgress lobby comes back from the lobby repository. When the game later completes,
-      // the lobby must still be marked completed and deleted from persistent storage.
+      // the room must move to Finished and its stale in-progress record be deleted from persistent storage.
       val persistProbe = TestProbe[PersistenceProtocol.Command]()
       val readyProbe = TestProbe[GameManager.Ready.type]()
       val gameId: GameId = UUID.randomUUID()
@@ -591,7 +592,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       gm ! GameManager.GameCompleted(gameId, gameId, GameLifecycleStatus.Completed)
 
       gm ! GameManager.GetLobbyInfo(gameId, responseProbe.ref)
-      responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.status shouldBe GameLifecycleStatus.Completed
+      responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.status shouldBe GameLifecycleStatus.Finished
 
       // the fire-and-forget Redis delete is eventually dispatched
       responseProbe.awaitAssert(deletedLobbies.keySet should contain(gameId))
@@ -770,10 +771,10 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val forfeited = responseProbe.expectMessageType[GameManager.GameForfeited]
       forfeited.state.asInstanceOf[GridGameState].winner shouldBe Some("X")
 
-      // the lobby has been moved to Completed by the GameCompleted -> MarkCompleted flow
+      // the room has moved to Finished (post-game) via the GameCompleted -> MatchEnded flow
       eventually {
         gm ! GameManager.GetLobbyInfo(gameId, responseProbe.ref)
-        responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.status shouldBe GameLifecycleStatus.Completed
+        responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.status shouldBe GameLifecycleStatus.Finished
       }
     }
 

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
@@ -89,32 +89,51 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       metadata.status shouldBe GameLifecycleStatus.InProgress
     }
 
-    "update lobby status when MarkCompleted is received" in {
+    "move the room to Finished when its match ends" in {
       val f = newLobby()
       val (gameId, _) = startGame(f)
 
-      f.lm ! LobbyManager.MarkCompleted(gameId, GameLifecycleStatus.Completed)
+      f.lm ! LobbyManager.MatchEnded(gameId, Map.empty)
 
       f.lm ! LobbyManager.GetLobbyInfo(gameId, f.responseProbe.ref)
       val GameManager.LobbyInfo(metadata) = f.responseProbe.expectMessageType[GameManager.LobbyInfo]
-      metadata.status shouldBe GameLifecycleStatus.Completed
+      metadata.status shouldBe GameLifecycleStatus.Finished
     }
 
-    "serve lobby metadata from cache after MarkCompleted removes it from active lobbies" in {
+    "keep a finished room out of the joinable list but still queryable" in {
       val f = newLobby()
       val listProbe = TestProbe[LobbyManager.LobbiesListed]()
       val (gameId, _) = startGame(f)
 
-      f.lm ! LobbyManager.MarkCompleted(gameId, GameLifecycleStatus.Completed)
+      f.lm ! LobbyManager.MatchEnded(gameId, Map.empty)
 
-      // lobby is no longer in active map, so it must not appear in ListLobbies
+      // a Finished room is not joinable, so it must not appear in ListLobbies
       f.lm ! LobbyManager.ListLobbies(None, 1, 20, listProbe.ref)
       listProbe.expectMessageType[LobbyManager.LobbiesListed].lobbies.map(_.gameId) should not contain gameId
 
-      // but GetLobbyInfo should still find it via the cache
+      // but the room survives in memory (for chat/rematch), so GetLobbyInfo still finds it
       f.lm ! LobbyManager.GetLobbyInfo(gameId, f.responseProbe.ref)
       val GameManager.LobbyInfo(metadata) = f.responseProbe.expectMessageType[GameManager.LobbyInfo]
-      metadata.status shouldBe GameLifecycleStatus.Completed
+      metadata.status shouldBe GameLifecycleStatus.Finished
+    }
+
+    "return match subscribers to the room so post-game chat reaches them" in {
+      val f = newLobby()
+      val (gameId, _) = startGame(f)
+      val sub = TestProbe[PlayerActor.Command]()
+
+      f.lm ! LobbyManager.MatchEnded(gameId, Map(alice.id -> sub.ref))
+
+      // the returned subscriber is told the room is now in its post-game (Finished) state
+      sub.expectMessageType[PlayerActor.SendEvent].event match {
+        case PlayerEvent.LobbyUpdated(m) => m.status shouldBe GameLifecycleStatus.Finished
+        case other                       => fail(s"expected LobbyUpdated(Finished), got $other")
+      }
+
+      // and a chat broadcast to the room now reaches the returned subscriber (chat-after-end)
+      val chat = PlayerEvent.ChatMessage(gameId, alice.id, "alice", "gg", Instant.now())
+      f.lm ! LobbyManager.BroadcastChat(gameId, chat)
+      sub.expectMessage(PlayerActor.SendEvent(chat))
     }
 
     "revert lobby status to WaitingForPlayers when a non-host player leaves" in {
@@ -432,11 +451,11 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       listed.lobbies.map(l => l.players(l.hostId).name) shouldBe List("carol", "bob", "alice")
     }
 
-    "ignore MarkCompleted for an unknown lobby" in {
+    "ignore MatchEnded for an unknown lobby" in {
       val LobbyFixture(lm, _, _) = newLobby()
       val listProbe = TestProbe[LobbyManager.LobbiesListed]()
 
-      lm ! LobbyManager.MarkCompleted(UUID.randomUUID(), GameLifecycleStatus.Completed)
+      lm ! LobbyManager.MatchEnded(UUID.randomUUID(), Map.empty)
 
       // sanity check: LobbyManager is still responsive
       lm ! LobbyManager.ListLobbies(None, 1, 20, listProbe.ref)

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
@@ -118,6 +118,31 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       spawn2.players.head should not be alice.id // rematch: the seating rotates so the other player leads
     }
 
+    "evict an empty finished room and serve it from the recently-ended cache as Cancelled" in {
+      val f = newLobby()
+      val (gameId, _) = startGame(f)
+      f.lm ! LobbyManager.MatchEnded(gameId, Map.empty) // Finished with no connected players
+
+      f.lm ! LobbyManager.EvictIdleRooms
+
+      f.lm ! LobbyManager.GetLobbyInfo(gameId, f.responseProbe.ref)
+      val GameManager.LobbyInfo(metadata) = f.responseProbe.expectMessageType[GameManager.LobbyInfo]
+      metadata.status shouldBe GameLifecycleStatus.Cancelled
+    }
+
+    "keep a finished room with a connected, recently-active player" in {
+      val f = newLobby()
+      val (gameId, _) = startGame(f)
+      val sub = TestProbe[PlayerActor.Command]()
+      f.lm ! LobbyManager.MatchEnded(gameId, Map(alice.id -> sub.ref)) // re-owned subscriber, activity = now
+      sub.expectMessageType[PlayerActor.SendEvent] // LobbyUpdated(Finished)
+
+      f.lm ! LobbyManager.EvictIdleRooms
+
+      f.lm ! LobbyManager.GetLobbyInfo(gameId, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.status shouldBe GameLifecycleStatus.Finished
+    }
+
     "reject a rematch attempt from a non-host" in {
       val f = newLobby()
       val (gameId, _) = startGame(f)

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
@@ -89,6 +89,44 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       metadata.status shouldBe GameLifecycleStatus.InProgress
     }
 
+    "seat the host first on the initial start" in {
+      val f = newLobby()
+      val (_, spawnMsg) = startGame(f)
+      spawnMsg.players.head shouldBe alice.id // alice hosts; seat 0 moves first
+    }
+
+    "let the host start a rematch from a finished room with a fresh match id" in {
+      val f = newLobby()
+      val (gameId, spawn1) = startGame(f)
+      f.lm ! LobbyManager.MatchEnded(gameId, Map.empty) // the match ends → room becomes Finished
+
+      f.lm ! LobbyManager.StartGame(gameId, alice.id, f.responseProbe.ref) // same StartGame command = rematch
+      val spawn2 = f.gmProbe.expectMessageType[GameManager.SpawnGame]
+      spawn2.roomId shouldBe gameId
+      spawn2.matchId should not be spawn1.matchId
+      spawn2.players.toSet shouldBe spawn1.players.toSet // same roster
+    }
+
+    "rotate the first-move seat on a rematch" in {
+      val f = newLobby()
+      val (gameId, spawn1) = startGame(f)
+      f.lm ! LobbyManager.MatchEnded(gameId, Map.empty)
+
+      f.lm ! LobbyManager.StartGame(gameId, alice.id, f.responseProbe.ref)
+      val spawn2 = f.gmProbe.expectMessageType[GameManager.SpawnGame]
+      spawn1.players.head shouldBe alice.id // first match: host leads
+      spawn2.players.head should not be alice.id // rematch: the seating rotates so the other player leads
+    }
+
+    "reject a rematch attempt from a non-host" in {
+      val f = newLobby()
+      val (gameId, _) = startGame(f)
+      f.lm ! LobbyManager.MatchEnded(gameId, Map.empty)
+
+      f.lm ! LobbyManager.StartGame(gameId, bob.id, f.responseProbe.ref) // bob is not the host
+      f.responseProbe.expectMessageType[GameManager.LobbyErrorResponse].error shouldBe LobbyError.NotHostError(gameId)
+    }
+
     "move the room to Finished when its match ends" in {
       val f = newLobby()
       val (gameId, _) = startGame(f)

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
@@ -15,7 +15,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyError, LobbyMetadata, LobbyRepository, Player}
-import com.andy327.model.core.{GameId, GameType}
+import com.andy327.model.core.{GameType, RoomId}
 
 class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
   private val testKit = ActorTestKit()
@@ -25,7 +25,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
 
   private val noOpLobbyRepo: LobbyRepository = new LobbyRepository {
     override def saveLobby(metadata: LobbyMetadata): IO[Unit] = IO.unit
-    override def deleteLobby(gameId: GameId): IO[Unit] = IO.unit
+    override def deleteLobby(roomId: RoomId): IO[Unit] = IO.unit
     override def loadAllLobbies(): IO[List[LobbyMetadata]] = IO.pure(Nil)
   }
 
@@ -46,21 +46,21 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
     LobbyFixture(spawn(LobbyManager(gmProbe.ref, noOpLobbyRepo, emptyRoomGrace)), gmProbe, responseProbe)
   }
 
-  /** Create a lobby with alice as host and have bob join. Returns (gameId, host). */
-  private def createReadyLobby(f: LobbyFixture): (GameId, Player) = {
+  /** Create a lobby with alice as host and have bob join. Returns (roomId, host). */
+  private def createReadyLobby(f: LobbyFixture): (RoomId, Player) = {
     f.lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, f.responseProbe.ref)
-    val GameManager.LobbyCreated(gameId, host) = f.responseProbe.expectMessageType[GameManager.LobbyCreated]
-    f.lm ! LobbyManager.JoinLobby(gameId, bob, f.responseProbe.ref)
+    val GameManager.LobbyCreated(roomId, host) = f.responseProbe.expectMessageType[GameManager.LobbyCreated]
+    f.lm ! LobbyManager.JoinLobby(roomId, bob, f.responseProbe.ref)
     f.responseProbe.expectMessageType[GameManager.LobbyJoined]
-    (gameId, host)
+    (roomId, host)
   }
 
-  /** Create a ready lobby and start the game. Returns (gameId, spawnMsg) for further assertions. */
-  private def startGame(f: LobbyFixture): (GameId, GameManager.SpawnGame) = {
-    val (gameId, host) = createReadyLobby(f)
-    f.lm ! LobbyManager.StartGame(gameId, host.id, f.responseProbe.ref)
+  /** Create a ready lobby and start the game. Returns (roomId, spawnMsg) for further assertions. */
+  private def startGame(f: LobbyFixture): (RoomId, GameManager.SpawnGame) = {
+    val (roomId, host) = createReadyLobby(f)
+    f.lm ! LobbyManager.StartGame(roomId, host.id, f.responseProbe.ref)
     val spawnMsg = f.gmProbe.expectMessageType[GameManager.SpawnGame]
-    (gameId, spawnMsg)
+    (roomId, spawnMsg)
   }
 
   "LobbyManager" should {
@@ -69,26 +69,26 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
 
       lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
 
-      val GameManager.LobbyCreated(gameId, host) = responseProbe.expectMessageType[GameManager.LobbyCreated]
-      gameId.toString should not be empty
+      val GameManager.LobbyCreated(roomId, host) = responseProbe.expectMessageType[GameManager.LobbyCreated]
+      roomId.toString should not be empty
       host shouldBe alice
     }
 
     "forward a SpawnGame to GameManager when StartGame is valid" in {
       val f = newLobby()
-      val (gameId, spawnMsg) = startGame(f)
+      val (roomId, spawnMsg) = startGame(f)
 
-      spawnMsg.roomId shouldBe gameId
-      spawnMsg.matchId should not be gameId // a fresh match id, distinct from the stable room id
+      spawnMsg.roomId shouldBe roomId
+      spawnMsg.matchId should not be roomId // a fresh match id, distinct from the stable room id
       spawnMsg.gameType shouldBe GameType.TicTacToe
       (spawnMsg.players should contain).allOf(alice.id, bob.id)
     }
 
     "update lobby status to InProgress after a valid StartGame" in {
       val f = newLobby()
-      val (gameId, _) = startGame(f)
+      val (roomId, _) = startGame(f)
 
-      f.lm ! LobbyManager.GetLobbyInfo(gameId, f.responseProbe.ref)
+      f.lm ! LobbyManager.GetLobbyInfo(roomId, f.responseProbe.ref)
       val GameManager.LobbyInfo(metadata) = f.responseProbe.expectMessageType[GameManager.LobbyInfo]
       metadata.status shouldBe GameLifecycleStatus.InProgress
     }
@@ -101,22 +101,22 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
 
     "let the host start a rematch from a finished room with a fresh match id" in {
       val f = newLobby()
-      val (gameId, spawn1) = startGame(f)
-      f.lm ! LobbyManager.MatchEnded(gameId, Map.empty) // the match ends → room becomes Finished
+      val (roomId, spawn1) = startGame(f)
+      f.lm ! LobbyManager.MatchEnded(roomId, Map.empty) // the match ends → room becomes Finished
 
-      f.lm ! LobbyManager.StartGame(gameId, alice.id, f.responseProbe.ref) // same StartGame command = rematch
+      f.lm ! LobbyManager.StartGame(roomId, alice.id, f.responseProbe.ref) // same StartGame command = rematch
       val spawn2 = f.gmProbe.expectMessageType[GameManager.SpawnGame]
-      spawn2.roomId shouldBe gameId
+      spawn2.roomId shouldBe roomId
       spawn2.matchId should not be spawn1.matchId
       spawn2.players.toSet shouldBe spawn1.players.toSet // same roster
     }
 
     "rotate the first-move seat on a rematch" in {
       val f = newLobby()
-      val (gameId, spawn1) = startGame(f)
-      f.lm ! LobbyManager.MatchEnded(gameId, Map.empty)
+      val (roomId, spawn1) = startGame(f)
+      f.lm ! LobbyManager.MatchEnded(roomId, Map.empty)
 
-      f.lm ! LobbyManager.StartGame(gameId, alice.id, f.responseProbe.ref)
+      f.lm ! LobbyManager.StartGame(roomId, alice.id, f.responseProbe.ref)
       val spawn2 = f.gmProbe.expectMessageType[GameManager.SpawnGame]
       spawn1.players.head shouldBe alice.id // first match: host leads
       spawn2.players.head should not be alice.id // rematch: the seating rotates so the other player leads
@@ -124,13 +124,13 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
 
     "evict an empty finished room past its grace period and serve it from the recently-ended cache as Cancelled" in {
       val f = newLobby() // Duration.Zero grace: empty is immediately stale
-      val (gameId, _) = startGame(f)
-      f.lm ! LobbyManager.MatchEnded(gameId, Map.empty) // Finished with no connected players
+      val (roomId, _) = startGame(f)
+      f.lm ! LobbyManager.MatchEnded(roomId, Map.empty) // Finished with no connected players
 
       f.lm ! LobbyManager.EvictIdleRooms
-      f.gmProbe.expectMessage(GameManager.RoomClosed(gameId)) // lets GameManager drop its completedMatch entry
+      f.gmProbe.expectMessage(GameManager.RoomClosed(roomId)) // lets GameManager drop its completedMatch entry
 
-      f.lm ! LobbyManager.GetLobbyInfo(gameId, f.responseProbe.ref)
+      f.lm ! LobbyManager.GetLobbyInfo(roomId, f.responseProbe.ref)
       val GameManager.LobbyInfo(metadata) = f.responseProbe.expectMessageType[GameManager.LobbyInfo]
       metadata.status shouldBe GameLifecycleStatus.Cancelled
     }
@@ -138,44 +138,44 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
     "not evict an empty finished room within its grace period" in {
       // a real-world momentary disconnect (e.g. a browser refresh) shouldn't cost the room on the very next tick
       val f = newLobby(emptyRoomGrace = 1.hour)
-      val (gameId, _) = startGame(f)
-      f.lm ! LobbyManager.MatchEnded(gameId, Map.empty) // Finished with no connected players, activity = now
+      val (roomId, _) = startGame(f)
+      f.lm ! LobbyManager.MatchEnded(roomId, Map.empty) // Finished with no connected players, activity = now
 
       f.lm ! LobbyManager.EvictIdleRooms
 
-      f.lm ! LobbyManager.GetLobbyInfo(gameId, f.responseProbe.ref)
+      f.lm ! LobbyManager.GetLobbyInfo(roomId, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.status shouldBe GameLifecycleStatus.Finished
     }
 
     "keep a finished room with a connected, recently-active player" in {
       val f = newLobby()
-      val (gameId, _) = startGame(f)
+      val (roomId, _) = startGame(f)
       val sub = TestProbe[PlayerActor.Command]()
-      f.lm ! LobbyManager.MatchEnded(gameId, Map(alice.id -> sub.ref)) // re-owned subscriber, activity = now
+      f.lm ! LobbyManager.MatchEnded(roomId, Map(alice.id -> sub.ref)) // re-owned subscriber, activity = now
       sub.expectMessageType[PlayerActor.SendEvent] // LobbyUpdated(Finished)
 
       f.lm ! LobbyManager.EvictIdleRooms
 
-      f.lm ! LobbyManager.GetLobbyInfo(gameId, f.responseProbe.ref)
+      f.lm ! LobbyManager.GetLobbyInfo(roomId, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.status shouldBe GameLifecycleStatus.Finished
     }
 
     "reject a rematch attempt from a non-host" in {
       val f = newLobby()
-      val (gameId, _) = startGame(f)
-      f.lm ! LobbyManager.MatchEnded(gameId, Map.empty)
+      val (roomId, _) = startGame(f)
+      f.lm ! LobbyManager.MatchEnded(roomId, Map.empty)
 
-      f.lm ! LobbyManager.StartGame(gameId, bob.id, f.responseProbe.ref) // bob is not the host
-      f.responseProbe.expectMessageType[GameManager.LobbyErrorResponse].error shouldBe LobbyError.NotHostError(gameId)
+      f.lm ! LobbyManager.StartGame(roomId, bob.id, f.responseProbe.ref) // bob is not the host
+      f.responseProbe.expectMessageType[GameManager.LobbyErrorResponse].error shouldBe LobbyError.NotHostError(roomId)
     }
 
     "move the room to Finished when its match ends" in {
       val f = newLobby()
-      val (gameId, _) = startGame(f)
+      val (roomId, _) = startGame(f)
 
-      f.lm ! LobbyManager.MatchEnded(gameId, Map.empty)
+      f.lm ! LobbyManager.MatchEnded(roomId, Map.empty)
 
-      f.lm ! LobbyManager.GetLobbyInfo(gameId, f.responseProbe.ref)
+      f.lm ! LobbyManager.GetLobbyInfo(roomId, f.responseProbe.ref)
       val GameManager.LobbyInfo(metadata) = f.responseProbe.expectMessageType[GameManager.LobbyInfo]
       metadata.status shouldBe GameLifecycleStatus.Finished
     }
@@ -183,26 +183,26 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
     "keep a finished room out of the joinable list but still queryable" in {
       val f = newLobby()
       val listProbe = TestProbe[LobbyManager.LobbiesListed]()
-      val (gameId, _) = startGame(f)
+      val (roomId, _) = startGame(f)
 
-      f.lm ! LobbyManager.MatchEnded(gameId, Map.empty)
+      f.lm ! LobbyManager.MatchEnded(roomId, Map.empty)
 
       // a Finished room is not joinable, so it must not appear in ListLobbies
       f.lm ! LobbyManager.ListLobbies(None, 1, 20, listProbe.ref)
-      listProbe.expectMessageType[LobbyManager.LobbiesListed].lobbies.map(_.gameId) should not contain gameId
+      listProbe.expectMessageType[LobbyManager.LobbiesListed].lobbies.map(_.roomId) should not contain roomId
 
       // but the room survives in memory (for chat/rematch), so GetLobbyInfo still finds it
-      f.lm ! LobbyManager.GetLobbyInfo(gameId, f.responseProbe.ref)
+      f.lm ! LobbyManager.GetLobbyInfo(roomId, f.responseProbe.ref)
       val GameManager.LobbyInfo(metadata) = f.responseProbe.expectMessageType[GameManager.LobbyInfo]
       metadata.status shouldBe GameLifecycleStatus.Finished
     }
 
     "return match subscribers to the room so post-game chat reaches them" in {
       val f = newLobby()
-      val (gameId, _) = startGame(f)
+      val (roomId, _) = startGame(f)
       val sub = TestProbe[PlayerActor.Command]()
 
-      f.lm ! LobbyManager.MatchEnded(gameId, Map(alice.id -> sub.ref))
+      f.lm ! LobbyManager.MatchEnded(roomId, Map(alice.id -> sub.ref))
 
       // the returned subscriber is told the room is now in its post-game (Finished) state
       sub.expectMessageType[PlayerActor.SendEvent].event match {
@@ -211,39 +211,39 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       }
 
       // and a chat broadcast to the room now reaches the returned subscriber (chat-after-end)
-      val chat = PlayerEvent.ChatMessage(gameId, alice.id, "alice", "gg", Instant.now())
-      f.lm ! LobbyManager.BroadcastChat(gameId, chat)
+      val chat = PlayerEvent.ChatMessage(roomId, alice.id, "alice", "gg", Instant.now())
+      f.lm ! LobbyManager.BroadcastChat(roomId, chat)
       sub.expectMessage(PlayerActor.SendEvent(chat))
     }
 
     "revert lobby status to WaitingForPlayers when a non-host player leaves" in {
       val f = newLobby()
-      val (gameId, _) = createReadyLobby(f)
+      val (roomId, _) = createReadyLobby(f)
 
-      f.lm ! LobbyManager.LeaveLobby(gameId, bob, f.responseProbe.ref)
+      f.lm ! LobbyManager.LeaveLobby(roomId, bob, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.LobbyLeft]
 
-      f.lm ! LobbyManager.GetLobbyInfo(gameId, f.responseProbe.ref)
+      f.lm ! LobbyManager.GetLobbyInfo(roomId, f.responseProbe.ref)
       val GameManager.LobbyInfo(metadata) = f.responseProbe.expectMessageType[GameManager.LobbyInfo]
       metadata.status shouldBe GameLifecycleStatus.WaitingForPlayers
     }
 
     "reject LeaveLobby with GameInProgress once the game has started" in {
       val f = newLobby()
-      val (gameId, _) = startGame(f)
+      val (roomId, _) = startGame(f)
 
       // a non-host player cannot leave an in-progress game
-      f.lm ! LobbyManager.LeaveLobby(gameId, bob, f.responseProbe.ref)
+      f.lm ! LobbyManager.LeaveLobby(roomId, bob, f.responseProbe.ref)
       val nonHostError = f.responseProbe.expectMessageType[GameManager.LobbyErrorResponse]
-      nonHostError.error shouldBe LobbyError.GameInProgress(gameId)
+      nonHostError.error shouldBe LobbyError.GameInProgress(roomId)
 
       // neither can the host — the lobby must not be cancelled out from under the running game
-      f.lm ! LobbyManager.LeaveLobby(gameId, alice, f.responseProbe.ref)
+      f.lm ! LobbyManager.LeaveLobby(roomId, alice, f.responseProbe.ref)
       val hostError = f.responseProbe.expectMessageType[GameManager.LobbyErrorResponse]
-      hostError.error shouldBe LobbyError.GameInProgress(gameId)
+      hostError.error shouldBe LobbyError.GameInProgress(roomId)
 
       // lobby is untouched: still present and still InProgress
-      f.lm ! LobbyManager.GetLobbyInfo(gameId, f.responseProbe.ref)
+      f.lm ! LobbyManager.GetLobbyInfo(roomId, f.responseProbe.ref)
       val GameManager.LobbyInfo(metadata) = f.responseProbe.expectMessageType[GameManager.LobbyInfo]
       metadata.status shouldBe GameLifecycleStatus.InProgress
       (metadata.players.keySet should contain).allOf(alice.id, bob.id)
@@ -253,20 +253,20 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val f = newLobby()
       val carol = Player("carol")
       val subscriberProbe = TestProbe[PlayerActor.Command]()
-      val (gameId, _) = createReadyLobby(f)
+      val (roomId, _) = createReadyLobby(f)
 
       // Bob subscribes to lobby events
-      f.lm ! LobbyManager.SubscribeToLobby(gameId, bob.id, subscriberProbe.ref, f.responseProbe.ref)
+      f.lm ! LobbyManager.SubscribeToLobby(roomId, bob.id, subscriberProbe.ref, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.SubscribeAcknowledged]
       subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial lobby state
 
       // Bob leaves — he receives LobbyUpdated for his own departure, then is removed from subscribers
-      f.lm ! LobbyManager.LeaveLobby(gameId, bob, f.responseProbe.ref)
+      f.lm ! LobbyManager.LeaveLobby(roomId, bob, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.LobbyLeft]
       subscriberProbe.expectMessageType[PlayerActor.SendEvent] // LobbyUpdated from own leave
 
       // Carol joins — lobby state changes, but Bob is no longer subscribed
-      f.lm ! LobbyManager.JoinLobby(gameId, carol, f.responseProbe.ref)
+      f.lm ! LobbyManager.JoinLobby(roomId, carol, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.LobbyJoined]
 
       subscriberProbe.expectNoMessage()
@@ -277,14 +277,14 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val subscriberProbe = TestProbe[PlayerActor.Command]()
 
       f.lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, f.responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, _) = f.responseProbe.expectMessageType[GameManager.LobbyCreated]
+      val GameManager.LobbyCreated(roomId, _) = f.responseProbe.expectMessageType[GameManager.LobbyCreated]
 
-      f.lm ! LobbyManager.SubscribeToLobby(gameId, alice.id, subscriberProbe.ref, f.responseProbe.ref)
+      f.lm ! LobbyManager.SubscribeToLobby(roomId, alice.id, subscriberProbe.ref, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.SubscribeAcknowledged]
       subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial lobby state on subscribe
 
-      val chat = PlayerEvent.ChatMessage(gameId, alice.id, "alice", "hi", Instant.EPOCH)
-      f.lm ! LobbyManager.BroadcastChat(gameId, chat)
+      val chat = PlayerEvent.ChatMessage(roomId, alice.id, "alice", "hi", Instant.EPOCH)
+      f.lm ! LobbyManager.BroadcastChat(roomId, chat)
       subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe chat
     }
 
@@ -293,13 +293,13 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val subscriberProbe = TestProbe[PlayerActor.Command]()
 
       f.lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, f.responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, _) = f.responseProbe.expectMessageType[GameManager.LobbyCreated]
+      val GameManager.LobbyCreated(roomId, _) = f.responseProbe.expectMessageType[GameManager.LobbyCreated]
 
-      f.lm ! LobbyManager.SubscribeToLobby(gameId, alice.id, subscriberProbe.ref, f.responseProbe.ref)
+      f.lm ! LobbyManager.SubscribeToLobby(roomId, alice.id, subscriberProbe.ref, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.SubscribeAcknowledged]
       subscriberProbe.expectMessageType[PlayerActor.SendEvent] // immediate push of current state on subscribe
 
-      f.lm ! LobbyManager.JoinLobby(gameId, bob, f.responseProbe.ref)
+      f.lm ! LobbyManager.JoinLobby(roomId, bob, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.LobbyJoined]
 
       subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe a[PlayerEvent.LobbyUpdated]
@@ -310,13 +310,13 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val subscriberProbe = TestProbe[PlayerActor.Command]()
 
       f.lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, f.responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, _) = f.responseProbe.expectMessageType[GameManager.LobbyCreated]
+      val GameManager.LobbyCreated(roomId, _) = f.responseProbe.expectMessageType[GameManager.LobbyCreated]
 
-      f.lm ! LobbyManager.SubscribeToLobby(gameId, alice.id, subscriberProbe.ref, f.responseProbe.ref)
+      f.lm ! LobbyManager.SubscribeToLobby(roomId, alice.id, subscriberProbe.ref, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.SubscribeAcknowledged]
       subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial state
 
-      f.lm ! LobbyManager.LeaveLobby(gameId, alice, f.responseProbe.ref)
+      f.lm ! LobbyManager.LeaveLobby(roomId, alice, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.LobbyLeft]
 
       subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe
@@ -326,14 +326,14 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
     "migrate the host to a remaining member when the host leaves a populated lobby" in {
       val f = newLobby()
       val subscriberProbe = TestProbe[PlayerActor.Command]()
-      val (gameId, host) = createReadyLobby(f) // alice hosts, bob has joined
+      val (roomId, host) = createReadyLobby(f) // alice hosts, bob has joined
 
-      f.lm ! LobbyManager.SubscribeToLobby(gameId, host.id, subscriberProbe.ref, f.responseProbe.ref)
+      f.lm ! LobbyManager.SubscribeToLobby(roomId, host.id, subscriberProbe.ref, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.SubscribeAcknowledged]
       subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial state
 
       // host (alice) leaves while bob remains — the host role migrates to bob and the lobby survives
-      f.lm ! LobbyManager.LeaveLobby(gameId, host, f.responseProbe.ref)
+      f.lm ! LobbyManager.LeaveLobby(roomId, host, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.LobbyLeft].message should include("host transferred")
 
       subscriberProbe.expectMessageType[PlayerActor.SendEvent].event match {
@@ -344,7 +344,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       }
 
       // the lobby is still present and queryable, now hosted by bob
-      f.lm ! LobbyManager.GetLobbyInfo(gameId, f.responseProbe.ref)
+      f.lm ! LobbyManager.GetLobbyInfo(roomId, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.hostId shouldBe bob.id
     }
 
@@ -353,13 +353,13 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val listProbe = TestProbe[LobbyManager.LobbiesListed]()
       val subscriberProbe = TestProbe[PlayerActor.Command]()
 
-      val (gameId, _) = createReadyLobby(f)
+      val (roomId, _) = createReadyLobby(f)
 
-      f.lm ! LobbyManager.SubscribeToLobby(gameId, alice.id, subscriberProbe.ref, f.responseProbe.ref)
+      f.lm ! LobbyManager.SubscribeToLobby(roomId, alice.id, subscriberProbe.ref, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.SubscribeAcknowledged]
       subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial state
 
-      f.lm ! LobbyManager.StartGame(gameId, alice.id, f.responseProbe.ref)
+      f.lm ! LobbyManager.StartGame(roomId, alice.id, f.responseProbe.ref)
       val spawnMsg = f.gmProbe.expectMessageType[GameManager.SpawnGame]
       spawnMsg.subscribers shouldBe Map(alice.id -> subscriberProbe.ref)
 
@@ -372,9 +372,9 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
     "reject SubscribeToLobby with GameAlreadyStarted when the game is InProgress" in {
       val f = newLobby()
       val subscriberProbe = TestProbe[PlayerActor.Command]()
-      val (gameId, _) = startGame(f)
+      val (roomId, _) = startGame(f)
 
-      f.lm ! LobbyManager.SubscribeToLobby(gameId, alice.id, subscriberProbe.ref, f.responseProbe.ref)
+      f.lm ! LobbyManager.SubscribeToLobby(roomId, alice.id, subscriberProbe.ref, f.responseProbe.ref)
       val error = f.responseProbe.expectMessageType[GameManager.LobbyErrorResponse]
       error.error shouldBe a[LobbyError.GameAlreadyStarted]
       subscriberProbe.expectNoMessage()
@@ -395,44 +395,44 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val subscriberProbe = TestProbe[PlayerActor.Command]()
 
       f.lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, f.responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, _) = f.responseProbe.expectMessageType[GameManager.LobbyCreated]
+      val GameManager.LobbyCreated(roomId, _) = f.responseProbe.expectMessageType[GameManager.LobbyCreated]
 
-      f.lm ! LobbyManager.SubscribeToLobby(gameId, alice.id, subscriberProbe.ref, f.responseProbe.ref)
+      f.lm ! LobbyManager.SubscribeToLobby(roomId, alice.id, subscriberProbe.ref, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.SubscribeAcknowledged]
       subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial lobby state
 
-      f.lm ! LobbyManager.UnsubscribeFromLobby(gameId, alice.id, f.responseProbe.ref)
-      f.responseProbe.expectMessage(GameManager.UnsubscribeAcknowledged(gameId))
+      f.lm ! LobbyManager.UnsubscribeFromLobby(roomId, alice.id, f.responseProbe.ref)
+      f.responseProbe.expectMessage(GameManager.UnsubscribeAcknowledged(roomId))
 
       // a later state change is no longer pushed to the unsubscribed player
-      f.lm ! LobbyManager.JoinLobby(gameId, bob, f.responseProbe.ref)
+      f.lm ! LobbyManager.JoinLobby(roomId, bob, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.LobbyJoined]
       subscriberProbe.expectNoMessage()
     }
 
     "acknowledge UnsubscribeFromLobby idempotently for an unknown lobby" in {
       val f = newLobby()
-      val gameId = UUID.randomUUID()
+      val roomId = UUID.randomUUID()
 
-      f.lm ! LobbyManager.UnsubscribeFromLobby(gameId, alice.id, f.responseProbe.ref)
-      f.responseProbe.expectMessage(GameManager.UnsubscribeAcknowledged(gameId))
+      f.lm ! LobbyManager.UnsubscribeFromLobby(roomId, alice.id, f.responseProbe.ref)
+      f.responseProbe.expectMessage(GameManager.UnsubscribeAcknowledged(roomId))
     }
 
     "cancel a lobby on the host's request and push GameEnded(Cancelled) to subscribers" in {
       val f = newLobby()
       val subscriberProbe = TestProbe[PlayerActor.Command]()
-      val (gameId, host) = createReadyLobby(f)
+      val (roomId, host) = createReadyLobby(f)
 
-      f.lm ! LobbyManager.SubscribeToLobby(gameId, bob.id, subscriberProbe.ref, f.responseProbe.ref)
+      f.lm ! LobbyManager.SubscribeToLobby(roomId, bob.id, subscriberProbe.ref, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.SubscribeAcknowledged]
       subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial state
 
-      f.lm ! LobbyManager.CancelLobby(gameId, host.id, f.responseProbe.ref)
+      f.lm ! LobbyManager.CancelLobby(roomId, host.id, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.LobbyLeft]
       subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe
         PlayerEvent.GameEnded(GameLifecycleStatus.Cancelled)
       // sent even though this lobby never started a match — a harmless no-op for GameManager's completedMatch map
-      f.gmProbe.expectMessage(GameManager.RoomClosed(gameId))
+      f.gmProbe.expectMessage(GameManager.RoomClosed(roomId))
 
       // the lobby is gone from the joinable list
       val listProbe = TestProbe[LobbyManager.LobbiesListed]()
@@ -442,22 +442,22 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
 
     "send RoomClosed when the host disbands a Finished room by leaving it last" in {
       val f = newLobby()
-      val (gameId, _) = startGame(f)
-      f.lm ! LobbyManager.MatchEnded(gameId, Map.empty)
+      val (roomId, _) = startGame(f)
+      f.lm ! LobbyManager.MatchEnded(roomId, Map.empty)
 
-      f.lm ! LobbyManager.LeaveLobby(gameId, bob, f.responseProbe.ref) // bob leaves first
+      f.lm ! LobbyManager.LeaveLobby(roomId, bob, f.responseProbe.ref) // bob leaves first
       f.responseProbe.expectMessageType[GameManager.LobbyLeft]
 
-      f.lm ! LobbyManager.LeaveLobby(gameId, alice, f.responseProbe.ref) // host leaves last — disbands the room
+      f.lm ! LobbyManager.LeaveLobby(roomId, alice, f.responseProbe.ref) // host leaves last — disbands the room
       f.responseProbe.expectMessageType[GameManager.LobbyLeft]
-      f.gmProbe.expectMessage(GameManager.RoomClosed(gameId))
+      f.gmProbe.expectMessage(GameManager.RoomClosed(roomId))
     }
 
     "reject CancelLobby from a non-host with NotHostError" in {
       val f = newLobby()
-      val (gameId, _) = createReadyLobby(f)
+      val (roomId, _) = createReadyLobby(f)
 
-      f.lm ! LobbyManager.CancelLobby(gameId, bob.id, f.responseProbe.ref)
+      f.lm ! LobbyManager.CancelLobby(roomId, bob.id, f.responseProbe.ref)
       val error = f.responseProbe.expectMessageType[GameManager.LobbyErrorResponse]
       error.error shouldBe a[LobbyError.NotHostError]
     }
@@ -476,16 +476,16 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val dyingSubscriber = spawn(Behaviors.empty[PlayerActor.Command])
 
       f.lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, f.responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, _) = f.responseProbe.expectMessageType[GameManager.LobbyCreated]
+      val GameManager.LobbyCreated(roomId, _) = f.responseProbe.expectMessageType[GameManager.LobbyCreated]
 
-      f.lm ! LobbyManager.SubscribeToLobby(gameId, alice.id, dyingSubscriber, f.responseProbe.ref)
+      f.lm ! LobbyManager.SubscribeToLobby(roomId, alice.id, dyingSubscriber, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.SubscribeAcknowledged]
 
       testKit.stop(dyingSubscriber)
 
       // without a Terminated handler the watching LobbyManager would crash with a DeathPactException; instead it stays
       // responsive and serves a subsequent command
-      f.lm ! LobbyManager.JoinLobby(gameId, bob, f.responseProbe.ref)
+      f.lm ! LobbyManager.JoinLobby(roomId, bob, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.LobbyJoined]
     }
 
@@ -495,17 +495,17 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
 
       lm ! LobbyManager.RestoreLobbies(List(lobby))
 
-      lm ! LobbyManager.GetLobbyInfo(lobby.gameId, responseProbe.ref)
+      lm ! LobbyManager.GetLobbyInfo(lobby.roomId, responseProbe.ref)
       val GameManager.LobbyInfo(metadata) = responseProbe.expectMessageType[GameManager.LobbyInfo]
-      metadata.gameId shouldBe lobby.gameId
+      metadata.roomId shouldBe lobby.roomId
       metadata.status shouldBe GameLifecycleStatus.InProgress
     }
 
     "drop and delete dead pre-game lobbies on restore, keeping only in-progress ones" in {
-      val deleted = scala.collection.concurrent.TrieMap.empty[GameId, Unit]
+      val deleted = scala.collection.concurrent.TrieMap.empty[RoomId, Unit]
       val trackingRepo: LobbyRepository = new LobbyRepository {
         override def saveLobby(metadata: LobbyMetadata): IO[Unit] = IO.unit
-        override def deleteLobby(gameId: GameId): IO[Unit] = IO(deleted.update(gameId, ()))
+        override def deleteLobby(roomId: RoomId): IO[Unit] = IO(deleted.update(roomId, ()))
         override def loadAllLobbies(): IO[List[LobbyMetadata]] = IO.pure(Nil)
       }
       val gmProbe = TestProbe[GameManager.Command]()
@@ -518,14 +518,14 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       lm ! LobbyManager.RestoreLobbies(List(inProgress, waiting))
 
       // the in-progress lobby is restored and queryable
-      lm ! LobbyManager.GetLobbyInfo(inProgress.gameId, responseProbe.ref)
+      lm ! LobbyManager.GetLobbyInfo(inProgress.roomId, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.status shouldBe GameLifecycleStatus.InProgress
 
       // the pre-game lobby is gone from the active map and deleted from persistent storage
-      lm ! LobbyManager.GetLobbyInfo(waiting.gameId, responseProbe.ref)
+      lm ! LobbyManager.GetLobbyInfo(waiting.roomId, responseProbe.ref)
       val err = responseProbe.expectMessageType[GameManager.LobbyErrorResponse].error
-      err shouldBe LobbyError.LobbyNotFound(waiting.gameId)
-      responseProbe.awaitAssert(deleted.keySet should contain(waiting.gameId))
+      err shouldBe LobbyError.LobbyNotFound(waiting.roomId)
+      responseProbe.awaitAssert(deleted.keySet should contain(waiting.roomId))
     }
 
     "list joinable lobbies newest-first" in {
@@ -604,7 +604,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val playerLobbiesProbe = TestProbe[LobbyManager.PlayerLobbies]()
 
       // alice hosts a lobby bob joins (both are participants)
-      val (joinedGameId, _) = createReadyLobby(f)
+      val (joinedRoomId, _) = createReadyLobby(f)
 
       // a separate lobby hosted by carol that alice is not part of
       f.lm ! LobbyManager.CreateLobby(GameType.TicTacToe, carol, f.responseProbe.ref)
@@ -612,21 +612,21 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
 
       f.lm ! LobbyManager.ListLobbiesForPlayer(alice.id, playerLobbiesProbe.ref)
       val aliceLobbies = playerLobbiesProbe.expectMessageType[LobbyManager.PlayerLobbies].lobbies
-      aliceLobbies.map(_.gameId) should contain only joinedGameId
+      aliceLobbies.map(_.roomId) should contain only joinedRoomId
 
       f.lm ! LobbyManager.ListLobbiesForPlayer(bob.id, playerLobbiesProbe.ref)
-      playerLobbiesProbe.expectMessageType[LobbyManager.PlayerLobbies].lobbies.map(_.gameId) should contain only
-        joinedGameId
+      playerLobbiesProbe.expectMessageType[LobbyManager.PlayerLobbies].lobbies.map(_.roomId) should contain only
+        joinedRoomId
     }
 
     "exclude in-progress lobbies from ListLobbiesForPlayer" in {
       val f = newLobby()
       val playerLobbiesProbe = TestProbe[LobbyManager.PlayerLobbies]()
-      val (gameId, _) = startGame(f) // alice + bob, now InProgress
+      val (roomId, _) = startGame(f) // alice + bob, now InProgress
 
       // the InProgress lobby still lives in the map, but is not a pre-game lobby and must not be reported here
       f.lm ! LobbyManager.ListLobbiesForPlayer(alice.id, playerLobbiesProbe.ref)
-      playerLobbiesProbe.expectMessageType[LobbyManager.PlayerLobbies].lobbies.map(_.gameId) should not contain gameId
+      playerLobbiesProbe.expectMessageType[LobbyManager.PlayerLobbies].lobbies.map(_.roomId) should not contain roomId
     }
 
     "return an empty list from ListLobbiesForPlayer for a player in no lobbies" in {
@@ -640,11 +640,11 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
 
     "return NotHostError when a non-host tries to start the game" in {
       val f = newLobby()
-      val (gameId, _) = createReadyLobby(f)
+      val (roomId, _) = createReadyLobby(f)
 
-      f.lm ! LobbyManager.StartGame(gameId, bob.id, f.responseProbe.ref)
+      f.lm ! LobbyManager.StartGame(roomId, bob.id, f.responseProbe.ref)
       val error = f.responseProbe.expectMessageType[GameManager.LobbyErrorResponse]
-      error.error shouldBe LobbyError.NotHostError(gameId)
+      error.error shouldBe LobbyError.NotHostError(roomId)
       f.gmProbe.expectNoMessage()
     }
 
@@ -652,11 +652,11 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val LobbyFixture(lm, gmProbe, responseProbe) = newLobby()
 
       lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val GameManager.LobbyCreated(gameId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
+      val GameManager.LobbyCreated(roomId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
 
-      lm ! LobbyManager.StartGame(gameId, alice.id, responseProbe.ref)
+      lm ! LobbyManager.StartGame(roomId, alice.id, responseProbe.ref)
       val error = responseProbe.expectMessageType[GameManager.LobbyErrorResponse]
-      error.error shouldBe LobbyError.LobbyNotReady(gameId)
+      error.error shouldBe LobbyError.LobbyNotReady(roomId)
       gmProbe.expectNoMessage()
     }
   }

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
@@ -374,16 +374,61 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       f.responseProbe.expectMessageType[GameManager.LobbyJoined]
     }
 
-    "restore lobbies from a RestoreLobbies message" in {
+    "restore in-progress lobbies from a RestoreLobbies message" in {
       val LobbyFixture(lm, _, responseProbe) = newLobby()
-      val lobby = LobbyMetadata.newLobby(GameType.TicTacToe, alice)
+      val lobby = LobbyMetadata.newLobby(GameType.TicTacToe, alice).copy(status = GameLifecycleStatus.InProgress)
 
       lm ! LobbyManager.RestoreLobbies(List(lobby))
 
       lm ! LobbyManager.GetLobbyInfo(lobby.gameId, responseProbe.ref)
       val GameManager.LobbyInfo(metadata) = responseProbe.expectMessageType[GameManager.LobbyInfo]
       metadata.gameId shouldBe lobby.gameId
-      metadata.status shouldBe lobby.status
+      metadata.status shouldBe GameLifecycleStatus.InProgress
+    }
+
+    "drop and delete dead pre-game lobbies on restore, keeping only in-progress ones" in {
+      val deleted = scala.collection.concurrent.TrieMap.empty[GameId, Unit]
+      val trackingRepo: LobbyRepository = new LobbyRepository {
+        override def saveLobby(metadata: LobbyMetadata): IO[Unit] = IO.unit
+        override def deleteLobby(gameId: GameId): IO[Unit] = IO(deleted.update(gameId, ()))
+        override def loadAllLobbies(): IO[List[LobbyMetadata]] = IO.pure(Nil)
+      }
+      val gmProbe = TestProbe[GameManager.Command]()
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+      val lm = spawn(LobbyManager(gmProbe.ref, trackingRepo))
+
+      val inProgress = LobbyMetadata.newLobby(GameType.TicTacToe, alice).copy(status = GameLifecycleStatus.InProgress)
+      val waiting = LobbyMetadata.newLobby(GameType.TicTacToe, bob) // WaitingForPlayers — dead across a restart
+
+      lm ! LobbyManager.RestoreLobbies(List(inProgress, waiting))
+
+      // the in-progress lobby is restored and queryable
+      lm ! LobbyManager.GetLobbyInfo(inProgress.gameId, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.status shouldBe GameLifecycleStatus.InProgress
+
+      // the pre-game lobby is gone from the active map and deleted from persistent storage
+      lm ! LobbyManager.GetLobbyInfo(waiting.gameId, responseProbe.ref)
+      val err = responseProbe.expectMessageType[GameManager.LobbyErrorResponse].error
+      err shouldBe LobbyError.LobbyNotFound(waiting.gameId)
+      responseProbe.awaitAssert(deleted.keySet should contain(waiting.gameId))
+    }
+
+    "list joinable lobbies newest-first" in {
+      val LobbyFixture(lm, _, responseProbe) = newLobby()
+      val listProbe = TestProbe[LobbyManager.LobbiesListed]()
+      val carol = Player("carol")
+
+      // created oldest-to-newest; the high-resolution creation clock makes each createdAt strictly later
+      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbyCreated]
+      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, bob, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbyCreated]
+      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, carol, responseProbe.ref)
+      responseProbe.expectMessageType[GameManager.LobbyCreated]
+
+      lm ! LobbyManager.ListLobbies(None, 1, 20, listProbe.ref)
+      val listed = listProbe.expectMessageType[LobbyManager.LobbiesListed]
+      listed.lobbies.map(l => l.players(l.hostId).name) shouldBe List("carol", "bob", "alice")
     }
 
     "ignore MarkCompleted for an unknown lobby" in {

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
@@ -74,7 +74,8 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val f = newLobby()
       val (gameId, spawnMsg) = startGame(f)
 
-      spawnMsg.gameId shouldBe gameId
+      spawnMsg.roomId shouldBe gameId
+      spawnMsg.matchId should not be gameId // a fresh match id, distinct from the stable room id
       spawnMsg.gameType shouldBe GameType.TicTacToe
       (spawnMsg.players should contain).allOf(alice.id, bob.id)
     }

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
@@ -3,6 +3,8 @@ package com.andy327.actor.core
 import java.time.Instant
 import java.util.UUID
 
+import scala.concurrent.duration._
+
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 
@@ -36,10 +38,12 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       responseProbe: TestProbe[GameManager.GameResponse]
   )
 
-  private def newLobby(): LobbyFixture = {
+  // Duration.Zero by default so tests can assert eviction without waiting out the real grace period; tests checking
+  // that the grace period actually withholds eviction pass a long-enough override explicitly.
+  private def newLobby(emptyRoomGrace: FiniteDuration = Duration.Zero): LobbyFixture = {
     val gmProbe = TestProbe[GameManager.Command]()
     val responseProbe = TestProbe[GameManager.GameResponse]()
-    LobbyFixture(spawn(LobbyManager(gmProbe.ref, noOpLobbyRepo)), gmProbe, responseProbe)
+    LobbyFixture(spawn(LobbyManager(gmProbe.ref, noOpLobbyRepo, emptyRoomGrace)), gmProbe, responseProbe)
   }
 
   /** Create a lobby with alice as host and have bob join. Returns (gameId, host). */
@@ -118,8 +122,8 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       spawn2.players.head should not be alice.id // rematch: the seating rotates so the other player leads
     }
 
-    "evict an empty finished room and serve it from the recently-ended cache as Cancelled" in {
-      val f = newLobby()
+    "evict an empty finished room past its grace period and serve it from the recently-ended cache as Cancelled" in {
+      val f = newLobby() // Duration.Zero grace: empty is immediately stale
       val (gameId, _) = startGame(f)
       f.lm ! LobbyManager.MatchEnded(gameId, Map.empty) // Finished with no connected players
 
@@ -128,6 +132,18 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       f.lm ! LobbyManager.GetLobbyInfo(gameId, f.responseProbe.ref)
       val GameManager.LobbyInfo(metadata) = f.responseProbe.expectMessageType[GameManager.LobbyInfo]
       metadata.status shouldBe GameLifecycleStatus.Cancelled
+    }
+
+    "not evict an empty finished room within its grace period" in {
+      // a real-world momentary disconnect (e.g. a browser refresh) shouldn't cost the room on the very next tick
+      val f = newLobby(emptyRoomGrace = 1.hour)
+      val (gameId, _) = startGame(f)
+      f.lm ! LobbyManager.MatchEnded(gameId, Map.empty) // Finished with no connected players, activity = now
+
+      f.lm ! LobbyManager.EvictIdleRooms
+
+      f.lm ! LobbyManager.GetLobbyInfo(gameId, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.status shouldBe GameLifecycleStatus.Finished
     }
 
     "keep a finished room with a connected, recently-active player" in {

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
@@ -128,6 +128,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       f.lm ! LobbyManager.MatchEnded(gameId, Map.empty) // Finished with no connected players
 
       f.lm ! LobbyManager.EvictIdleRooms
+      f.gmProbe.expectMessage(GameManager.RoomClosed(gameId)) // lets GameManager drop its completedMatch entry
 
       f.lm ! LobbyManager.GetLobbyInfo(gameId, f.responseProbe.ref)
       val GameManager.LobbyInfo(metadata) = f.responseProbe.expectMessageType[GameManager.LobbyInfo]
@@ -430,11 +431,26 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       f.responseProbe.expectMessageType[GameManager.LobbyLeft]
       subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe
         PlayerEvent.GameEnded(GameLifecycleStatus.Cancelled)
+      // sent even though this lobby never started a match — a harmless no-op for GameManager's completedMatch map
+      f.gmProbe.expectMessage(GameManager.RoomClosed(gameId))
 
       // the lobby is gone from the joinable list
       val listProbe = TestProbe[LobbyManager.LobbiesListed]()
       f.lm ! LobbyManager.ListLobbies(None, 1, 20, listProbe.ref)
       listProbe.expectMessageType[LobbyManager.LobbiesListed].lobbies shouldBe empty
+    }
+
+    "send RoomClosed when the host disbands a Finished room by leaving it last" in {
+      val f = newLobby()
+      val (gameId, _) = startGame(f)
+      f.lm ! LobbyManager.MatchEnded(gameId, Map.empty)
+
+      f.lm ! LobbyManager.LeaveLobby(gameId, bob, f.responseProbe.ref) // bob leaves first
+      f.responseProbe.expectMessageType[GameManager.LobbyLeft]
+
+      f.lm ! LobbyManager.LeaveLobby(gameId, alice, f.responseProbe.ref) // host leaves last — disbands the room
+      f.responseProbe.expectMessageType[GameManager.LobbyLeft]
+      f.gmProbe.expectMessage(GameManager.RoomClosed(gameId))
     }
 
     "reject CancelLobby from a non-host with NotHostError" in {

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/PlayerActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/PlayerActorSpec.scala
@@ -1,5 +1,7 @@
 package com.andy327.actor.core
 
+import java.util.UUID
+
 import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -23,7 +25,7 @@ class PlayerActorSpec extends AnyWordSpecLike with Matchers {
         winner = None,
         draw = false
       )
-      val event = PlayerEvent.GameStateUpdated(dummyState)
+      val event = PlayerEvent.GameStateUpdated(UUID.randomUUID(), dummyState)
 
       actor ! PlayerActor.SendEvent(event)
       sessionProbe.expectMessage(PlayerActor.SessionEvent(event))

--- a/game-service-actor/src/test/scala/com/andy327/actor/lobby/LobbyCodecsSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/lobby/LobbyCodecsSpec.scala
@@ -25,6 +25,11 @@ class LobbyCodecsSpec extends AnyWordSpec with Matchers {
       LobbyCodecs.deserialize(LobbyCodecs.serialize(lobby)) shouldBe Right(lobby)
     }
 
+    "round-trip a lobby with Finished status" in {
+      val lobby = baseLobby.copy(status = GameLifecycleStatus.Finished)
+      LobbyCodecs.deserialize(LobbyCodecs.serialize(lobby)) shouldBe Right(lobby)
+    }
+
     "round-trip a lobby with Completed status" in {
       val lobby = baseLobby.copy(status = GameLifecycleStatus.Completed)
       LobbyCodecs.deserialize(LobbyCodecs.serialize(lobby)) shouldBe Right(lobby)

--- a/game-service-actor/src/test/scala/com/andy327/actor/lobby/RedisLobbyRepositorySpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/lobby/RedisLobbyRepositorySpec.scala
@@ -47,7 +47,7 @@ class RedisLobbyRepositorySpec extends AnyWordSpec with Matchers with ForAllTest
         for {
           _ <- repo.saveLobby(lobby)
           lobbies <- repo.loadAllLobbies()
-        } yield lobbies.map(_.gameId) should contain(lobby.gameId)
+        } yield lobbies.map(_.roomId) should contain(lobby.roomId)
       }
     }
 
@@ -60,7 +60,7 @@ class RedisLobbyRepositorySpec extends AnyWordSpec with Matchers with ForAllTest
           _ <- repo.saveLobby(updated)
           lobbies <- repo.loadAllLobbies()
         } yield {
-          val found = lobbies.find(_.gameId == lobby.gameId)
+          val found = lobbies.find(_.roomId == lobby.roomId)
           found.map(_.status) shouldBe Some(GameLifecycleStatus.ReadyToStart)
         }
       }
@@ -73,9 +73,9 @@ class RedisLobbyRepositorySpec extends AnyWordSpec with Matchers with ForAllTest
       withRepo { repo =>
         for {
           _ <- repo.saveLobby(lobby)
-          _ <- repo.deleteLobby(lobby.gameId)
+          _ <- repo.deleteLobby(lobby.roomId)
           lobbies <- repo.loadAllLobbies()
-        } yield lobbies.map(_.gameId) should not contain lobby.gameId
+        } yield lobbies.map(_.roomId) should not contain lobby.roomId
       }
     }
   }
@@ -89,7 +89,7 @@ class RedisLobbyRepositorySpec extends AnyWordSpec with Matchers with ForAllTest
           _ <- repo.saveLobby(lobby1)
           _ <- repo.saveLobby(lobby2)
           lobbies <- repo.loadAllLobbies()
-        } yield (lobbies.map(_.gameId) should contain).allOf(lobby1.gameId, lobby2.gameId)
+        } yield (lobbies.map(_.roomId) should contain).allOf(lobby1.roomId, lobby2.roomId)
       }
     }
 

--- a/game-service-actor/src/test/scala/com/andy327/actor/persistence/PostgresActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/persistence/PostgresActorSpec.scala
@@ -14,7 +14,7 @@ import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
-import com.andy327.model.core.{Game, GameId, GameType, PlayerId}
+import com.andy327.model.core.{Game, GameType, MatchId, PlayerId}
 import com.andy327.model.tictactoe.TicTacToe
 import com.andy327.persistence.db.PlayerHistoryRepository.GameResult
 import com.andy327.persistence.db.{
@@ -30,32 +30,32 @@ class PostgresActorSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike w
 
   class DummyRepo(saveResult: Either[Throwable, Unit] = Right(())) extends GameRepository {
     def initialize(): IO[Unit] = IO.unit
-    def loadGame(gameId: GameId, gameType: GameType): IO[Option[Game[_, _, _, _, _]]] = IO.pure(None)
-    def saveGame(gameId: GameId, gameType: GameType, game: Game[_, _, _, _, _]): IO[Unit] = IO.fromEither(saveResult)
-    def loadAllGames(): IO[Map[GameId, (GameType, Game[_, _, _, _, _])]] = IO.pure(Map.empty)
+    def loadGame(matchId: MatchId, gameType: GameType): IO[Option[Game[_, _, _, _, _]]] = IO.pure(None)
+    def saveGame(matchId: MatchId, gameType: GameType, game: Game[_, _, _, _, _]): IO[Unit] = IO.fromEither(saveResult)
+    def loadAllGames(): IO[Map[MatchId, (GameType, Game[_, _, _, _, _])]] = IO.pure(Map.empty)
   }
 
   /** Records each appended move; `appendResult` lets a test force the append IO to fail. */
   class RecordingMoveRepo(appendResult: Either[Throwable, Unit] = Right(())) extends MoveHistoryRepository {
-    val appended = new ConcurrentLinkedQueue[(GameId, Int, PlayerId, Json)]()
+    val appended = new ConcurrentLinkedQueue[(MatchId, Int, PlayerId, Json)]()
     def initialize(): IO[Unit] = IO.unit
-    def appendMove(gameId: GameId, seq: Int, playerId: PlayerId, move: Json): IO[Unit] =
-      IO(appended.add((gameId, seq, playerId, move))) *> IO.fromEither(appendResult)
-    def loadMoves(gameId: GameId): IO[List[MoveRecord]] = IO.pure(Nil)
+    def appendMove(matchId: MatchId, seq: Int, playerId: PlayerId, move: Json): IO[Unit] =
+      IO(appended.add((matchId, seq, playerId, move))) *> IO.fromEither(appendResult)
+    def loadMoves(matchId: MatchId): IO[List[MoveRecord]] = IO.pure(Nil)
   }
 
   /** Records each game-result write; `recordResult` lets a test force the record IO to fail. */
   class RecordingPlayerHistoryRepo(recordResult: Either[Throwable, Unit] = Right(())) extends PlayerHistoryRepository {
-    val recorded = new ConcurrentLinkedQueue[(PlayerId, GameId, GameType, GameResult, Boolean)]()
+    val recorded = new ConcurrentLinkedQueue[(PlayerId, MatchId, GameType, GameResult, Boolean)]()
     def initialize(): IO[Unit] = IO.unit
     def record(
         playerId: PlayerId,
-        gameId: GameId,
+        matchId: MatchId,
         gameType: GameType,
         result: GameResult,
         forfeit: Boolean
     ): IO[Unit] =
-      IO(recorded.add((playerId, gameId, gameType, result, forfeit))) *> IO.fromEither(recordResult)
+      IO(recorded.add((playerId, matchId, gameType, result, forfeit))) *> IO.fromEither(recordResult)
     def findByPlayer(playerId: PlayerId): IO[List[PlayerGameRecord]] = IO.pure(Nil)
   }
 
@@ -90,13 +90,13 @@ class PostgresActorSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike w
     "append a move to the move repository on AppendMove" in {
       val moveRepo = new RecordingMoveRepo
       val persistActor = spawn(PostgresActor(new DummyRepo(), moveRepo))
-      val gameId = UUID.randomUUID()
+      val matchId = UUID.randomUUID()
       val move = Json.obj("col" -> 3.asJson)
 
-      persistActor ! PersistenceProtocol.AppendMove(gameId, 0, alice, move)
+      persistActor ! PersistenceProtocol.AppendMove(matchId, 0, alice, move)
 
       createTestProbe().awaitAssert(moveRepo.appended should have size 1)
-      moveRepo.appended.peek() shouldBe ((gameId, 0, alice, move))
+      moveRepo.appended.peek() shouldBe ((matchId, 0, alice, move))
     }
 
     "stay alive when a move append fails" in {
@@ -113,12 +113,12 @@ class PostgresActorSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike w
     "record a game result to the player-history repository on RecordGameResult" in {
       val historyRepo = new RecordingPlayerHistoryRepo
       val persistActor = spawn(PostgresActor(new DummyRepo(), new RecordingMoveRepo, historyRepo))
-      val gameId = UUID.randomUUID()
+      val matchId = UUID.randomUUID()
 
-      persistActor ! PersistenceProtocol.RecordGameResult(alice, gameId, GameType.TicTacToe, GameResult.Win, false)
+      persistActor ! PersistenceProtocol.RecordGameResult(alice, matchId, GameType.TicTacToe, GameResult.Win, false)
 
       createTestProbe().awaitAssert(historyRepo.recorded should have size 1)
-      historyRepo.recorded.peek() shouldBe ((alice, gameId, GameType.TicTacToe, GameResult.Win, false))
+      historyRepo.recorded.peek() shouldBe ((alice, matchId, GameType.TicTacToe, GameResult.Win, false))
     }
 
     "stay alive when a game-result record fails" in {

--- a/game-service-actor/src/test/scala/com/andy327/actor/tictactoe/TicTacToeActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/tictactoe/TicTacToeActorSpec.scala
@@ -461,14 +461,16 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       )
       persistProbe.expectNoMessage()
 
-      // the subscriber sees the finished state then the game-ended event; GameManager is notified
+      // the subscriber sees the finished state then the game-ended event; GameManager is notified and the subscriber
+      // set is handed back to the room (keyed by playerId) so the room survives the match
       subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe a[PlayerEvent.GameStateUpdated]
       subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe
         PlayerEvent.GameEnded(GameLifecycleStatus.Completed)
       gameManagerProbe.receiveMessage() shouldBe GameManager.GameCompleted(
         gameId,
         gameId,
-        GameLifecycleStatus.Completed
+        GameLifecycleStatus.Completed,
+        Map(alice -> subscriberProbe.ref)
       )
     }
 

--- a/game-service-actor/src/test/scala/com/andy327/actor/tictactoe/TicTacToeActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/tictactoe/TicTacToeActorSpec.scala
@@ -41,7 +41,8 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       gameId: GameId = UUID.randomUUID()
   ): (ActorRef[TicTacToeActor.Command], TestProbe[PersistenceProtocol.Command]) = {
     val persistProbe = createTestProbe[PersistenceProtocol.Command]()
-    val (_, behavior) = TicTacToeActor.create(gameId, Seq(alice, bob), persistProbe.ref, gmRef, NoOpEventPublisher)
+    val (_, behavior) =
+      TicTacToeActor.create(gameId, gameId, Seq(alice, bob), persistProbe.ref, gmRef, NoOpEventPublisher)
     (spawn(behavior), persistProbe)
   }
 
@@ -107,6 +108,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
       val behavior = TicTacToeActor.fromSnapshot(
         UUID.randomUUID(),
+        UUID.randomUUID(),
         snapshotState,
         persistProbe.ref,
         dummyGameManager,
@@ -145,6 +147,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       val actor = spawn(
         TicTacToeActor.fromSnapshot(
           gameId,
+          gameId,
           completedGame,
           persistProbe.ref,
           gameManagerProbe.ref,
@@ -152,7 +155,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
         )
       )
 
-      gameManagerProbe.expectMessage(GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed))
+      gameManagerProbe.expectMessage(GameManager.GameCompleted(gameId, gameId, GameLifecycleStatus.Completed))
       persistProbe.expectTerminated(actor)
     }
 
@@ -170,6 +173,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
       val behavior = TicTacToeActor.fromSnapshot(
+        UUID.randomUUID(),
         UUID.randomUUID(),
         dummyGame,
         persistProbe.ref,
@@ -424,7 +428,11 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
         expectMovePersisted(persistProbe)
       }
 
-      gameManagerProbe.receiveMessage() shouldBe GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed)
+      gameManagerProbe.receiveMessage() shouldBe GameManager.GameCompleted(
+        gameId,
+        gameId,
+        GameLifecycleStatus.Completed
+      )
     }
 
     "forfeit the game to the opponent when a player leaves, appending no move but recording the result" in {
@@ -457,7 +465,11 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe a[PlayerEvent.GameStateUpdated]
       subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe
         PlayerEvent.GameEnded(GameLifecycleStatus.Completed)
-      gameManagerProbe.receiveMessage() shouldBe GameManager.GameCompleted(gameId, GameLifecycleStatus.Completed)
+      gameManagerProbe.receiveMessage() shouldBe GameManager.GameCompleted(
+        gameId,
+        gameId,
+        GameLifecycleStatus.Completed
+      )
     }
 
     "record a Win for the winner and a Loss for the loser when the game completes" in {
@@ -515,7 +527,8 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       }
       val gameId: GameId = UUID.randomUUID()
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
-      val (_, behavior) = TicTacToeActor.create(gameId, Seq(alice, bob), persistProbe.ref, dummyGameManager, capturing)
+      val (_, behavior) =
+        TicTacToeActor.create(gameId, gameId, Seq(alice, bob), persistProbe.ref, dummyGameManager, capturing)
       val actor = spawn(behavior)
       val replyProbe = createTestProbe[Either[GameError, GameState]]()
 

--- a/game-service-actor/src/test/scala/com/andy327/actor/tictactoe/TicTacToeActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/tictactoe/TicTacToeActorSpec.scala
@@ -20,7 +20,7 @@ import com.andy327.actor.events.{EventPublisher, GameEvent, NoOpEventPublisher}
 import com.andy327.actor.game.{GameState, GridGameState}
 import com.andy327.actor.lobby.GameLifecycleStatus
 import com.andy327.actor.persistence.PersistenceProtocol
-import com.andy327.model.core.{Game, GameError, GameId, GameType, PlayerId}
+import com.andy327.model.core.{Game, GameError, GameType, MatchId, PlayerId}
 import com.andy327.model.tictactoe.{Location, O, OutOfBounds, TicTacToe, X}
 import com.andy327.persistence.db.PlayerHistoryRepository.GameResult
 
@@ -34,15 +34,15 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
   private val dummyGameManager: ActorRef[GameManager.Command] = createTestProbe[GameManager.Command]().ref
 
   /** Spawn a fresh game actor backed by a new persist probe.
-    * Optionally override the GameManager ref or supply a specific gameId.
+    * Optionally override the GameManager ref or supply a specific matchId.
     */
   private def newActor(
       gmRef: ActorRef[GameManager.Command] = dummyGameManager,
-      gameId: GameId = UUID.randomUUID()
+      matchId: MatchId = UUID.randomUUID()
   ): (ActorRef[TicTacToeActor.Command], TestProbe[PersistenceProtocol.Command]) = {
     val persistProbe = createTestProbe[PersistenceProtocol.Command]()
     val (_, behavior) =
-      TicTacToeActor.create(gameId, gameId, Seq(alice, bob), persistProbe.ref, gmRef, NoOpEventPublisher)
+      TicTacToeActor.create(matchId, matchId, Seq(alice, bob), persistProbe.ref, gmRef, NoOpEventPublisher)
     (spawn(behavior), persistProbe)
   }
 
@@ -128,7 +128,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
     }
 
     "notify GameManager and stop when restored from a completed snapshot" in {
-      val gameId = UUID.randomUUID()
+      val matchId = UUID.randomUUID()
       val gameManagerProbe = createTestProbe[GameManager.Command]()
       val completedGame = TicTacToe(
         playerX = alice,
@@ -146,8 +146,8 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
       val actor = spawn(
         TicTacToeActor.fromSnapshot(
-          gameId,
-          gameId,
+          matchId,
+          matchId,
           completedGame,
           persistProbe.ref,
           gameManagerProbe.ref,
@@ -155,7 +155,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
         )
       )
 
-      gameManagerProbe.expectMessage(GameManager.GameCompleted(gameId, gameId, GameLifecycleStatus.Completed))
+      gameManagerProbe.expectMessage(GameManager.GameCompleted(matchId, matchId, GameLifecycleStatus.Completed))
       persistProbe.expectTerminated(actor)
     }
 
@@ -475,8 +475,8 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
     "notify the GameManager when a game completes" in {
       val gameManagerProbe = createTestProbe[GameManager.Command]()
-      val gameId: GameId = UUID.randomUUID()
-      val (actor, persistProbe) = newActor(gmRef = gameManagerProbe.ref, gameId = gameId)
+      val matchId: MatchId = UUID.randomUUID()
+      val (actor, persistProbe) = newActor(gmRef = gameManagerProbe.ref, matchId = matchId)
       val replyProbe = createTestProbe[Either[GameError, GameState]]()
 
       xWinsMoves.foreach { case (player, loc) =>
@@ -486,16 +486,16 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       }
 
       gameManagerProbe.receiveMessage() shouldBe GameManager.GameCompleted(
-        gameId,
-        gameId,
+        matchId,
+        matchId,
         GameLifecycleStatus.Completed
       )
     }
 
     "forfeit the game to the opponent when a player leaves, appending no move but recording the result" in {
       val gameManagerProbe = createTestProbe[GameManager.Command]()
-      val gameId: GameId = UUID.randomUUID()
-      val (actor, persistProbe) = newActor(gmRef = gameManagerProbe.ref, gameId = gameId)
+      val matchId: MatchId = UUID.randomUUID()
+      val (actor, persistProbe) = newActor(gmRef = gameManagerProbe.ref, matchId = matchId)
       val subscriberProbe = createTestProbe[PlayerActor.Command]()
       val replyProbe = createTestProbe[Either[GameError, GameState]]()
 
@@ -511,10 +511,10 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       // appends nothing to the history log
       persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
       persistProbe.expectMessage(
-        PersistenceProtocol.RecordGameResult(alice, gameId, GameType.TicTacToe, GameResult.Win, forfeit = true)
+        PersistenceProtocol.RecordGameResult(alice, matchId, GameType.TicTacToe, GameResult.Win, forfeit = true)
       )
       persistProbe.expectMessage(
-        PersistenceProtocol.RecordGameResult(bob, gameId, GameType.TicTacToe, GameResult.Loss, forfeit = true)
+        PersistenceProtocol.RecordGameResult(bob, matchId, GameType.TicTacToe, GameResult.Loss, forfeit = true)
       )
       persistProbe.expectNoMessage()
 
@@ -524,16 +524,16 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe
         PlayerEvent.GameEnded(GameLifecycleStatus.Completed)
       gameManagerProbe.receiveMessage() shouldBe GameManager.GameCompleted(
-        gameId,
-        gameId,
+        matchId,
+        matchId,
         GameLifecycleStatus.Completed,
         Map(alice -> subscriberProbe.ref)
       )
     }
 
     "record a Win for the winner and a Loss for the loser when the game completes" in {
-      val gameId: GameId = UUID.randomUUID()
-      val (actor, persistProbe) = newActor(gameId = gameId)
+      val matchId: MatchId = UUID.randomUUID()
+      val (actor, persistProbe) = newActor(matchId = matchId)
       val replyProbe = createTestProbe[Either[GameError, GameState]]()
 
       xWinsMoves.foreach { case (player, loc) =>
@@ -544,16 +544,16 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
       // the winning transition records each participant's outcome in seat order: X (alice) won, O (bob) lost
       persistProbe.expectMessage(
-        PersistenceProtocol.RecordGameResult(alice, gameId, GameType.TicTacToe, GameResult.Win, forfeit = false)
+        PersistenceProtocol.RecordGameResult(alice, matchId, GameType.TicTacToe, GameResult.Win, forfeit = false)
       )
       persistProbe.expectMessage(
-        PersistenceProtocol.RecordGameResult(bob, gameId, GameType.TicTacToe, GameResult.Loss, forfeit = false)
+        PersistenceProtocol.RecordGameResult(bob, matchId, GameType.TicTacToe, GameResult.Loss, forfeit = false)
       )
     }
 
     "record a Draw for both players when the game ends in a draw" in {
-      val gameId: GameId = UUID.randomUUID()
-      val (actor, persistProbe) = newActor(gameId = gameId)
+      val matchId: MatchId = UUID.randomUUID()
+      val (actor, persistProbe) = newActor(matchId = matchId)
       val replyProbe = createTestProbe[Either[GameError, GameState]]()
 
       drawMoves.foreach { case (player, loc) =>
@@ -563,10 +563,10 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       }
 
       persistProbe.expectMessage(
-        PersistenceProtocol.RecordGameResult(alice, gameId, GameType.TicTacToe, GameResult.Draw, forfeit = false)
+        PersistenceProtocol.RecordGameResult(alice, matchId, GameType.TicTacToe, GameResult.Draw, forfeit = false)
       )
       persistProbe.expectMessage(
-        PersistenceProtocol.RecordGameResult(bob, gameId, GameType.TicTacToe, GameResult.Draw, forfeit = false)
+        PersistenceProtocol.RecordGameResult(bob, matchId, GameType.TicTacToe, GameResult.Draw, forfeit = false)
       )
     }
 
@@ -584,10 +584,10 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       val capturing = new EventPublisher {
         def publish(event: GameEvent): Unit = { published.add(event); () }
       }
-      val gameId: GameId = UUID.randomUUID()
+      val matchId: MatchId = UUID.randomUUID()
       val persistProbe = createTestProbe[PersistenceProtocol.Command]()
       val (_, behavior) =
-        TicTacToeActor.create(gameId, gameId, Seq(alice, bob), persistProbe.ref, dummyGameManager, capturing)
+        TicTacToeActor.create(matchId, matchId, Seq(alice, bob), persistProbe.ref, dummyGameManager, capturing)
       val actor = spawn(behavior)
       val replyProbe = createTestProbe[Either[GameError, GameState]]()
 
@@ -600,7 +600,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       createTestProbe[Any]().awaitAssert {
         val completed = published.iterator().asScala.collect { case c: GameEvent.GameCompleted => c }.toList
         completed.map(_.outcome) shouldBe List(GameEvent.Outcome.Draw)
-        completed.head.gameId shouldBe gameId
+        completed.head.matchId shouldBe matchId
         completed.head.moveCount shouldBe 9
       }
     }

--- a/game-service-actor/src/test/scala/com/andy327/actor/tictactoe/TicTacToeActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/tictactoe/TicTacToeActorSpec.scala
@@ -372,7 +372,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       persistProbe.expectTerminated(actor)
     }
 
-    "ignore non-SnapshotSaved messages in terminating state" in {
+    "reject a GetState landing in terminating state with GameOver instead of dropping it" in {
       val (actor, persistProbe) = newActor()
       val replyProbe = createTestProbe[Either[GameError, GameState]]()
 
@@ -382,11 +382,68 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
         expectMovePersisted(persistProbe)
       }
 
-      // GetState is ignored in terminating — no reply, actor stays alive
+      // a request landing in the terminating window gets a clean rejection rather than no reply at all
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
-      replyProbe.expectNoMessage()
+      replyProbe.expectMessage(Left(GameError.GameOver))
 
       // SnapshotSaved then stops the actor
+      actor ! TurnBasedGameActor.SnapshotSaved(Right(()))
+      persistProbe.expectTerminated(actor)
+    }
+
+    "reject a MakeMove landing in terminating state with GameOver instead of dropping it" in {
+      val (actor, persistProbe) = newActor()
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+
+      xWinsMoves.foreach { case (player, loc) =>
+        actor ! TurnBasedGameActor.MakeMove(player, loc, replyProbe.ref)
+        replyProbe.receiveMessage()
+        expectMovePersisted(persistProbe)
+      }
+
+      actor ! TurnBasedGameActor.MakeMove(bob, Location(2, 2), replyProbe.ref)
+      replyProbe.expectMessage(Left(GameError.GameOver))
+
+      actor ! TurnBasedGameActor.SnapshotSaved(Right(()))
+      persistProbe.expectTerminated(actor)
+    }
+
+    "reject a PlayerLeft landing in terminating state with GameOver instead of dropping it" in {
+      val (actor, persistProbe) = newActor()
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+
+      xWinsMoves.foreach { case (player, loc) =>
+        actor ! TurnBasedGameActor.MakeMove(player, loc, replyProbe.ref)
+        replyProbe.receiveMessage()
+        expectMovePersisted(persistProbe)
+      }
+
+      actor ! TurnBasedGameActor.PlayerLeft(bob, replyProbe.ref)
+      replyProbe.expectMessage(Left(GameError.GameOver))
+
+      actor ! TurnBasedGameActor.SnapshotSaved(Right(()))
+      persistProbe.expectTerminated(actor)
+    }
+
+    "silently ignore Subscribe and Broadcast landing in terminating state" in {
+      val (actor, persistProbe) = newActor()
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val subscriberProbe = createTestProbe[PlayerActor.Command]()
+
+      xWinsMoves.foreach { case (player, loc) =>
+        actor ! TurnBasedGameActor.MakeMove(player, loc, replyProbe.ref)
+        replyProbe.receiveMessage()
+        expectMovePersisted(persistProbe)
+      }
+
+      // these have no GameError/GameState reply to give, so — unlike MakeMove/PlayerLeft/GetState — they are dropped
+      // exactly as before: no push to the would-be subscriber, and the actor stays alive awaiting SnapshotSaved
+      actor ! TurnBasedGameActor.Subscribe(subscriberProbe.ref, alice)
+      actor ! TurnBasedGameActor.Broadcast(
+        PlayerEvent.ChatMessage(UUID.randomUUID(), alice, "Alice", "hi", Instant.now())
+      )
+      subscriberProbe.expectNoMessage()
+
       actor ! TurnBasedGameActor.SnapshotSaved(Right(()))
       persistProbe.expectTerminated(actor)
     }

--- a/game-service-model/src/main/scala/com/andy327/model/core/package.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/core/package.scala
@@ -12,11 +12,6 @@ package object core {
     */
   type MatchId = UUID
 
-  /** Unique identifier for a game instance. Transitional: prefer [[RoomId]] or [[MatchId]], which distinguish the
-    * durable room from a single match.
-    */
-  type GameId = UUID
-
   /** Unique identifier for a player. */
   type PlayerId = UUID
 }

--- a/game-service-model/src/main/scala/com/andy327/model/core/package.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/core/package.scala
@@ -4,7 +4,17 @@ import java.util.UUID
 
 package object core {
 
-  /** Unique identifier for a game instance. */
+  /** Identifier for a room: a durable context that can host a sequence of matches over its lifetime. */
+  type RoomId = UUID
+
+  /** Identifier for a single match — one playthrough. Minted fresh per match, so each match's records stay distinct
+    * from earlier matches in the same room.
+    */
+  type MatchId = UUID
+
+  /** Unique identifier for a game instance. Transitional: prefer [[RoomId]] or [[MatchId]], which distinguish the
+    * durable room from a single match.
+    */
   type GameId = UUID
 
   /** Unique identifier for a player. */

--- a/game-service-persistence/src/main/scala/com/andy327/persistence/db/GameRepository.scala
+++ b/game-service-persistence/src/main/scala/com/andy327/persistence/db/GameRepository.scala
@@ -2,7 +2,7 @@ package com.andy327.persistence.db
 
 import cats.effect.IO
 
-import com.andy327.model.core.{Game, GameId, GameType}
+import com.andy327.model.core.{Game, GameType, MatchId}
 
 /** Trait representing a repository interface for saving and loading game state from a persistent database.
   *
@@ -15,14 +15,14 @@ trait GameRepository {
   def initialize(): IO[Unit]
 
   /** Persist the current state of a game to the database. */
-  def saveGame(gameId: GameId, gameType: GameType, game: Game[_, _, _, _, _]): IO[Unit]
+  def saveGame(matchId: MatchId, gameType: GameType, game: Game[_, _, _, _, _]): IO[Unit]
 
   /** Load a game from the database using its ID and GameType. */
-  def loadGame(gameId: GameId, gameType: GameType): IO[Option[Game[_, _, _, _, _]]]
+  def loadGame(matchId: MatchId, gameType: GameType): IO[Option[Game[_, _, _, _, _]]]
 
   /** Load all saved games from the database.
     *
     * This may be used during server startup to rehydrate all active games into memory.
     */
-  def loadAllGames(): IO[Map[GameId, (GameType, Game[_, _, _, _, _])]]
+  def loadAllGames(): IO[Map[MatchId, (GameType, Game[_, _, _, _, _])]]
 }

--- a/game-service-persistence/src/main/scala/com/andy327/persistence/db/InMemoryPlayerHistoryRepository.scala
+++ b/game-service-persistence/src/main/scala/com/andy327/persistence/db/InMemoryPlayerHistoryRepository.scala
@@ -5,7 +5,7 @@ import java.time.Instant
 import cats.effect.IO
 import cats.effect.kernel.Ref
 
-import com.andy327.model.core.{GameId, GameType, PlayerId}
+import com.andy327.model.core.{GameType, MatchId, PlayerId}
 import com.andy327.persistence.db.PlayerHistoryRepository.GameResult
 
 /** A [[PlayerHistoryRepository]] that keeps history in memory, with the same semantics as the Postgres implementation
@@ -17,21 +17,21 @@ import com.andy327.persistence.db.PlayerHistoryRepository.GameResult
   */
 class InMemoryPlayerHistoryRepository extends PlayerHistoryRepository {
 
-  /** Append-ordered rows; `(playerId, gameId)` uniqueness is enforced in [[record]]. */
+  /** Append-ordered rows; `(playerId, matchId)` uniqueness is enforced in [[record]]. */
   private val rows: Ref[IO, Vector[(PlayerId, PlayerGameRecord)]] = Ref.unsafe(Vector.empty)
 
   override def initialize(): IO[Unit] = IO.unit
 
   override def record(
       playerId: PlayerId,
-      gameId: GameId,
+      matchId: MatchId,
       gameType: GameType,
       result: GameResult,
       forfeit: Boolean
   ): IO[Unit] =
     rows.update { current =>
-      if (current.exists { case (pid, rec) => pid == playerId && rec.gameId == gameId }) current
-      else current :+ (playerId -> PlayerGameRecord(gameId, gameType, result, forfeit, Instant.now()))
+      if (current.exists { case (pid, rec) => pid == playerId && rec.matchId == matchId }) current
+      else current :+ (playerId -> PlayerGameRecord(matchId, gameType, result, forfeit, Instant.now()))
     }
 
   override def findByPlayer(playerId: PlayerId): IO[List[PlayerGameRecord]] =

--- a/game-service-persistence/src/main/scala/com/andy327/persistence/db/MoveHistoryRepository.scala
+++ b/game-service-persistence/src/main/scala/com/andy327/persistence/db/MoveHistoryRepository.scala
@@ -6,7 +6,7 @@ import cats.effect.IO
 
 import io.circe.Json
 
-import com.andy327.model.core.{GameId, PlayerId}
+import com.andy327.model.core.{MatchId, PlayerId}
 
 /** A single recorded move in a game's history.
   *
@@ -32,9 +32,9 @@ trait MoveHistoryRepository {
   /** Runs any needed initialization, such as creating the move-history table. */
   def initialize(): IO[Unit]
 
-  /** Append a single move to `gameId`'s log at ordinal `seq`. Fire-and-forget from the caller's perspective. */
-  def appendMove(gameId: GameId, seq: Int, playerId: PlayerId, move: Json): IO[Unit]
+  /** Append a single move to `matchId`'s log at ordinal `seq`. Fire-and-forget from the caller's perspective. */
+  def appendMove(matchId: MatchId, seq: Int, playerId: PlayerId, move: Json): IO[Unit]
 
-  /** Load all recorded moves for `gameId`, ordered by ascending `seq`. Empty if the game has no recorded moves. */
-  def loadMoves(gameId: GameId): IO[List[MoveRecord]]
+  /** Load all recorded moves for `matchId`, ordered by ascending `seq`. Empty if the game has no recorded moves. */
+  def loadMoves(matchId: MatchId): IO[List[MoveRecord]]
 }

--- a/game-service-persistence/src/main/scala/com/andy327/persistence/db/NoOpMoveHistoryRepository.scala
+++ b/game-service-persistence/src/main/scala/com/andy327/persistence/db/NoOpMoveHistoryRepository.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 
 import io.circe.Json
 
-import com.andy327.model.core.{GameId, PlayerId}
+import com.andy327.model.core.{MatchId, PlayerId}
 
 /** A [[MoveHistoryRepository]] that records nothing and returns no history.
   *
@@ -13,6 +13,6 @@ import com.andy327.model.core.{GameId, PlayerId}
   */
 object NoOpMoveHistoryRepository extends MoveHistoryRepository {
   override def initialize(): IO[Unit] = IO.unit
-  override def appendMove(gameId: GameId, seq: Int, playerId: PlayerId, move: Json): IO[Unit] = IO.unit
-  override def loadMoves(gameId: GameId): IO[List[MoveRecord]] = IO.pure(Nil)
+  override def appendMove(matchId: MatchId, seq: Int, playerId: PlayerId, move: Json): IO[Unit] = IO.unit
+  override def loadMoves(matchId: MatchId): IO[List[MoveRecord]] = IO.pure(Nil)
 }

--- a/game-service-persistence/src/main/scala/com/andy327/persistence/db/PlayerHistoryRepository.scala
+++ b/game-service-persistence/src/main/scala/com/andy327/persistence/db/PlayerHistoryRepository.scala
@@ -4,7 +4,7 @@ import java.time.Instant
 
 import cats.effect.IO
 
-import com.andy327.model.core.{GameId, GameType, PlayerId}
+import com.andy327.model.core.{GameType, MatchId, PlayerId}
 
 object PlayerHistoryRepository {
 
@@ -34,14 +34,14 @@ object PlayerHistoryRepository {
 /** One completed game from a single player's perspective, as returned by [[PlayerHistoryRepository.findByPlayer]]. The
   * player is the query key and so is not repeated here.
   *
-  * @param gameId the completed game
+  * @param matchId the completed game
   * @param gameType the kind of game played
   * @param result how the game turned out for this player
   * @param forfeit true when the result was reached by a player leaving an in-progress game rather than normal play
   * @param finishedAt server timestamp when the game completed
   */
 final case class PlayerGameRecord(
-    gameId: GameId,
+    matchId: MatchId,
     gameType: GameType,
     result: PlayerHistoryRepository.GameResult,
     forfeit: Boolean,
@@ -61,12 +61,12 @@ trait PlayerHistoryRepository {
   /** Runs any needed initialization, such as creating the player-history table. */
   def initialize(): IO[Unit]
 
-  /** Record `playerId`'s outcome for a completed `gameId`. One call per participant; fire-and-forget from the caller's
-    * perspective. Idempotent on `(playerId, gameId)`, so a re-delivered completion does not duplicate the row.
+  /** Record `playerId`'s outcome for a completed `matchId`. One call per participant; fire-and-forget from the caller's
+    * perspective. Idempotent on `(playerId, matchId)`, so a re-delivered completion does not duplicate the row.
     */
   def record(
       playerId: PlayerId,
-      gameId: GameId,
+      matchId: MatchId,
       gameType: GameType,
       result: PlayerHistoryRepository.GameResult,
       forfeit: Boolean

--- a/game-service-persistence/src/main/scala/com/andy327/persistence/db/postgres/PostgresGameRepository.scala
+++ b/game-service-persistence/src/main/scala/com/andy327/persistence/db/postgres/PostgresGameRepository.scala
@@ -10,7 +10,7 @@ import cats.implicits._
 import doobie._
 import doobie.implicits._
 
-import com.andy327.model.core.{Game, GameId, GameType}
+import com.andy327.model.core.{Game, GameType, MatchId}
 import com.andy327.persistence.db.GameRepository
 import com.andy327.persistence.db.schema.GameTypeCodecs
 
@@ -31,27 +31,27 @@ class PostgresGameRepository(xa: Transactor[IO]) extends GameRepository {
       )
     """.update.run.transact(xa).void
 
-  /** Saves the current state of a game of the given gameType into the database. If the gameId already exists, the
+  /** Saves the current state of a game of the given gameType into the database. If the matchId already exists, the
     * existing row is updated.
     */
-  override def saveGame(gameId: GameId, gameType: GameType, game: Game[_, _, _, _, _]): IO[Unit] = {
+  override def saveGame(matchId: MatchId, gameType: GameType, game: Game[_, _, _, _, _]): IO[Unit] = {
     val jsonStr = GameTypeCodecs.serializeGame(gameType, game)
     val gameTypeStr = gameType.toString
 
     sql"""
       INSERT INTO games (game_id, game_type, game_state)
-      VALUES (${gameId.toString}, $gameTypeStr, $jsonStr)
+      VALUES (${matchId.toString}, $gameTypeStr, $jsonStr)
       ON CONFLICT (game_id) DO UPDATE
       SET game_type = EXCLUDED.game_type,
           game_state = EXCLUDED.game_state
     """.update.run.transact(xa).void
   }
 
-  /** Loads the game state for a given gameId and gameType. If the game exists, it is deserialized from JSON into the
+  /** Loads the game state for a given matchId and gameType. If the game exists, it is deserialized from JSON into the
     * game model for its GameType.
     */
-  override def loadGame(gameId: GameId, gameType: GameType): IO[Option[Game[_, _, _, _, _]]] =
-    sql"SELECT game_state FROM games WHERE game_id = ${gameId.toString}"
+  override def loadGame(matchId: MatchId, gameType: GameType): IO[Option[Game[_, _, _, _, _]]] =
+    sql"SELECT game_state FROM games WHERE game_id = ${matchId.toString}"
       .query[String]
       .option
       .transact(xa)
@@ -60,16 +60,16 @@ class PostgresGameRepository(xa: Transactor[IO]) extends GameRepository {
           IO.fromEither(GameTypeCodecs.deserializeGame(gameType, jsonStr))
             .map(Some(_))
             .handleErrorWith { err =>
-              logger.warn(s"Failed to decode $gameType game ${gameId.toString}: ${err.getMessage}")
+              logger.warn(s"Failed to decode $gameType game ${matchId.toString}: ${err.getMessage}")
               IO.pure(None)
             }
         case None => IO.pure(None)
       }
 
-  /** Loads all games stored in the database and returns them as a Map from gameId to game state. If any games fail to
+  /** Loads all games stored in the database and returns them as a Map from matchId to game state. If any games fail to
     * decode from JSON, their errors are logged and we proceed with loading.
     */
-  override def loadAllGames(): IO[Map[GameId, (GameType, Game[_, _, _, _, _])]] =
+  override def loadAllGames(): IO[Map[MatchId, (GameType, Game[_, _, _, _, _])]] =
     sql"SELECT game_id, game_type, game_state FROM games"
       .query[(String, String, String)]
       .to[List]
@@ -80,9 +80,9 @@ class PostgresGameRepository(xa: Transactor[IO]) extends GameRepository {
           val maybeGameType = GameType.fromString(gameTypeStr).toRight(new Exception(s"Unknown GameType: $gameTypeStr"))
 
           (maybeId, maybeGameType) match {
-            case (Right(gameId), Right(gameType)) =>
+            case (Right(matchId), Right(gameType)) =>
               GameTypeCodecs.deserializeGame(gameType, jsonStr) match {
-                case Right(game) => IO.pure(List(gameId -> (gameType, game)))
+                case Right(game) => IO.pure(List(matchId -> (gameType, game)))
                 case Left(err)   =>
                   IO {
                     logger.warn(s"Skipping corrupted $gameType game $idStr: ${err.getMessage}")

--- a/game-service-persistence/src/main/scala/com/andy327/persistence/db/postgres/PostgresMoveHistoryRepository.scala
+++ b/game-service-persistence/src/main/scala/com/andy327/persistence/db/postgres/PostgresMoveHistoryRepository.scala
@@ -14,7 +14,7 @@ import doobie.postgres.implicits._
 import io.circe.Json
 import io.circe.parser.parse
 
-import com.andy327.model.core.{GameId, PlayerId}
+import com.andy327.model.core.{MatchId, PlayerId}
 import com.andy327.persistence.db.{MoveHistoryRepository, MoveRecord}
 
 /** [[MoveHistoryRepository]] backed by PostgreSQL via Doobie.
@@ -40,19 +40,19 @@ class PostgresMoveHistoryRepository(xa: Transactor[IO]) extends MoveHistoryRepos
     """.update.run.transact(xa).void
 
   /** Appends a move row. The `(game_id, seq)` primary key makes a duplicate ordinal a no-op rather than a duplicate. */
-  override def appendMove(gameId: GameId, seq: Int, playerId: PlayerId, move: Json): IO[Unit] =
+  override def appendMove(matchId: MatchId, seq: Int, playerId: PlayerId, move: Json): IO[Unit] =
     sql"""
       INSERT INTO game_moves (game_id, seq, player_id, move_json)
-      VALUES (${gameId.toString}, $seq, ${playerId.toString}, ${move.noSpaces})
+      VALUES (${matchId.toString}, $seq, ${playerId.toString}, ${move.noSpaces})
       ON CONFLICT (game_id, seq) DO NOTHING
     """.update.run.transact(xa).void
 
   /** Loads all moves for a game ordered by ascending seq. Rows that fail to parse are logged and skipped. */
-  override def loadMoves(gameId: GameId): IO[List[MoveRecord]] =
+  override def loadMoves(matchId: MatchId): IO[List[MoveRecord]] =
     sql"""
       SELECT seq, player_id, move_json, created_at
       FROM game_moves
-      WHERE game_id = ${gameId.toString}
+      WHERE game_id = ${matchId.toString}
       ORDER BY seq ASC
     """
       .query[(Int, String, String, Instant)]
@@ -68,7 +68,7 @@ class PostgresMoveHistoryRepository(xa: Transactor[IO]) extends MoveHistoryRepos
           record match {
             case Right(rec) => List(rec)
             case Left(err)  =>
-              logger.warn(s"Skipping unparseable move $seq for game ${gameId.toString}: ${err.getMessage}")
+              logger.warn(s"Skipping unparseable move $seq for game ${matchId.toString}: ${err.getMessage}")
               Nil
           }
         }

--- a/game-service-persistence/src/main/scala/com/andy327/persistence/db/postgres/PostgresPlayerHistoryRepository.scala
+++ b/game-service-persistence/src/main/scala/com/andy327/persistence/db/postgres/PostgresPlayerHistoryRepository.scala
@@ -12,7 +12,7 @@ import doobie._
 import doobie.implicits._
 import doobie.postgres.implicits._
 
-import com.andy327.model.core.{GameId, GameType, PlayerId}
+import com.andy327.model.core.{GameType, MatchId, PlayerId}
 import com.andy327.persistence.db.PlayerHistoryRepository.GameResult
 import com.andy327.persistence.db.{PlayerGameRecord, PlayerHistoryRepository}
 
@@ -47,14 +47,14 @@ class PostgresPlayerHistoryRepository(xa: Transactor[IO]) extends PlayerHistoryR
     */
   override def record(
       playerId: PlayerId,
-      gameId: GameId,
+      matchId: MatchId,
       gameType: GameType,
       result: GameResult,
       forfeit: Boolean
   ): IO[Unit] =
     sql"""
       INSERT INTO player_games (player_id, game_id, game_type, result, forfeit)
-      VALUES (${playerId.toString}, ${gameId.toString}, ${gameType.toString}, ${result.label}, $forfeit)
+      VALUES (${playerId.toString}, ${matchId.toString}, ${gameType.toString}, ${result.label}, $forfeit)
       ON CONFLICT (player_id, game_id) DO NOTHING
     """.update.run.transact(xa).void
 
@@ -72,12 +72,12 @@ class PostgresPlayerHistoryRepository(xa: Transactor[IO]) extends PlayerHistoryR
       .to[List]
       .transact(xa)
       .map { rows =>
-        rows.flatMap { case (gameIdStr, gameTypeStr, resultStr, forfeit, finishedAt) =>
+        rows.flatMap { case (matchIdStr, gameTypeStr, resultStr, forfeit, finishedAt) =>
           val record = for {
-            gameId <- Either.catchOnly[IllegalArgumentException](UUID.fromString(gameIdStr))
+            matchId <- Either.catchOnly[IllegalArgumentException](UUID.fromString(matchIdStr))
             gameType <- GameType.fromString(gameTypeStr).toRight(new Exception(s"Unknown GameType: $gameTypeStr"))
             result <- GameResult.fromLabel(resultStr).toRight(new Exception(s"Unknown GameResult: $resultStr"))
-          } yield PlayerGameRecord(gameId, gameType, result, forfeit, finishedAt)
+          } yield PlayerGameRecord(matchId, gameType, result, forfeit, finishedAt)
 
           record match {
             case Right(rec) => List(rec)

--- a/game-service-persistence/src/main/scala/com/andy327/persistence/db/redis/RedisGameRepository.scala
+++ b/game-service-persistence/src/main/scala/com/andy327/persistence/db/redis/RedisGameRepository.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 
 import dev.profunktor.redis4cats.RedisCommands
 
-import com.andy327.model.core.{Game, GameId, GameType}
+import com.andy327.model.core.{Game, GameType, MatchId}
 import com.andy327.persistence.db.GameRepository
 import com.andy327.persistence.db.schema.GameTypeCodecs
 
@@ -19,7 +19,7 @@ import com.andy327.persistence.db.schema.GameTypeCodecs
   * [[loadGame]], the Redis cache is checked first; on a miss the game is fetched from Postgres and the cache is warmed.
   * On startup, [[loadAllGames]] reads the authoritative state from Postgres and populates Redis in bulk.
   *
-  * Cache keys use the scheme `game:{gameId}`. Values are the JSON strings Postgres also stores in `game_state`.
+  * Cache keys use the scheme `game:{matchId}`. Values are the JSON strings Postgres also stores in `game_state`.
   *
   * @param gameRepo underlying [[GameRepository]] used as the source of truth for all reads and writes; in production
   *                 this is the Postgres repository, but any [[GameRepository]] implementation may be supplied
@@ -32,38 +32,38 @@ class RedisGameRepository(
 
   private val logger = LoggerFactory.getLogger(getClass)
 
-  private def cacheKey(gameId: GameId): String = s"game:$gameId"
+  private def cacheKey(matchId: MatchId): String = s"game:$matchId"
 
   override def initialize(): IO[Unit] = gameRepo.initialize()
 
-  override def saveGame(gameId: GameId, gameType: GameType, game: Game[_, _, _, _, _]): IO[Unit] = {
+  override def saveGame(matchId: MatchId, gameType: GameType, game: Game[_, _, _, _, _]): IO[Unit] = {
     val json = GameTypeCodecs.serializeGame(gameType, game)
-    gameRepo.saveGame(gameId, gameType, game) *> redis.set(cacheKey(gameId), json)
+    gameRepo.saveGame(matchId, gameType, game) *> redis.set(cacheKey(matchId), json)
   }
 
-  override def loadGame(gameId: GameId, gameType: GameType): IO[Option[Game[_, _, _, _, _]]] =
-    redis.get(cacheKey(gameId)).flatMap {
+  override def loadGame(matchId: MatchId, gameType: GameType): IO[Option[Game[_, _, _, _, _]]] =
+    redis.get(cacheKey(matchId)).flatMap {
       case Some(json) =>
         IO.fromEither(GameTypeCodecs.deserializeGame(gameType, json))
           .map(Some(_))
           .handleErrorWith { err =>
-            IO(logger.warn(s"Corrupt cache entry for $gameId, falling back to Postgres: ${err.getMessage}")) *>
-              loadFromPostgresAndWarm(gameId, gameType)
+            IO(logger.warn(s"Corrupt cache entry for $matchId, falling back to Postgres: ${err.getMessage}")) *>
+              loadFromPostgresAndWarm(matchId, gameType)
           }
       case None =>
-        loadFromPostgresAndWarm(gameId, gameType)
+        loadFromPostgresAndWarm(matchId, gameType)
     }
 
-  override def loadAllGames(): IO[Map[GameId, (GameType, Game[_, _, _, _, _])]] =
+  override def loadAllGames(): IO[Map[MatchId, (GameType, Game[_, _, _, _, _])]] =
     gameRepo.loadAllGames().flatTap { games =>
-      games.toList.traverse_ { case (gameId, (gameType, game)) =>
-        redis.set(cacheKey(gameId), GameTypeCodecs.serializeGame(gameType, game))
+      games.toList.traverse_ { case (matchId, (gameType, game)) =>
+        redis.set(cacheKey(matchId), GameTypeCodecs.serializeGame(gameType, game))
       }
     }
 
-  private def loadFromPostgresAndWarm(gameId: GameId, gameType: GameType): IO[Option[Game[_, _, _, _, _]]] =
-    gameRepo.loadGame(gameId, gameType).flatTap {
-      case Some(game) => redis.set(cacheKey(gameId), GameTypeCodecs.serializeGame(gameType, game))
+  private def loadFromPostgresAndWarm(matchId: MatchId, gameType: GameType): IO[Option[Game[_, _, _, _, _]]] =
+    gameRepo.loadGame(matchId, gameType).flatTap {
+      case Some(game) => redis.set(cacheKey(matchId), GameTypeCodecs.serializeGame(gameType, game))
       case None       => IO.unit
     }
 }

--- a/game-service-persistence/src/test/scala/com/andy327/persistence/db/InMemoryPlayerHistoryRepositorySpec.scala
+++ b/game-service-persistence/src/test/scala/com/andy327/persistence/db/InMemoryPlayerHistoryRepositorySpec.scala
@@ -20,7 +20,7 @@ class InMemoryPlayerHistoryRepositorySpec extends AnyWordSpec with Matchers {
       val player = UUID.randomUUID()
       val game = UUID.randomUUID()
       repo.record(player, game, GameType.TicTacToe, GameResult.Win, forfeit = false).unsafeRunSync()
-      repo.findByPlayer(player).unsafeRunSync().map(_.gameId) shouldBe List(game)
+      repo.findByPlayer(player).unsafeRunSync().map(_.matchId) shouldBe List(game)
     }
 
     "record a completed game and return it with its fields intact" in {
@@ -33,7 +33,7 @@ class InMemoryPlayerHistoryRepositorySpec extends AnyWordSpec with Matchers {
       val records = repo.findByPlayer(player).unsafeRunSync()
       records should have size 1
       val record = records.head
-      record.gameId shouldBe game
+      record.matchId shouldBe game
       record.gameType shouldBe GameType.ConnectFour
       record.result shouldBe GameResult.Loss
       record.forfeit shouldBe true
@@ -62,7 +62,7 @@ class InMemoryPlayerHistoryRepositorySpec extends AnyWordSpec with Matchers {
       repo.record(player, older, GameType.TicTacToe, GameResult.Win, forfeit = false).unsafeRunSync()
       repo.record(player, newer, GameType.TicTacToe, GameResult.Draw, forfeit = false).unsafeRunSync()
 
-      repo.findByPlayer(player).unsafeRunSync().map(_.gameId) shouldBe List(newer, older)
+      repo.findByPlayer(player).unsafeRunSync().map(_.matchId) shouldBe List(newer, older)
     }
 
     "ignore a re-recorded (player, game) outcome rather than duplicating it" in {

--- a/game-service-persistence/src/test/scala/com/andy327/persistence/db/NoOpMoveHistoryRepositorySpec.scala
+++ b/game-service-persistence/src/test/scala/com/andy327/persistence/db/NoOpMoveHistoryRepositorySpec.scala
@@ -13,11 +13,11 @@ class NoOpMoveHistoryRepositorySpec extends AnyWordSpec with Matchers {
   "NoOpMoveHistoryRepository" should {
     "do nothing on initialize and appendMove, and return no history" in {
       val repo = NoOpMoveHistoryRepository
-      val gameId = UUID.randomUUID()
+      val matchId = UUID.randomUUID()
 
       repo.initialize().unsafeRunSync() shouldBe (())
-      repo.appendMove(gameId, 0, UUID.randomUUID(), Json.obj()).unsafeRunSync() shouldBe (())
-      repo.loadMoves(gameId).unsafeRunSync() shouldBe empty
+      repo.appendMove(matchId, 0, UUID.randomUUID(), Json.obj()).unsafeRunSync() shouldBe (())
+      repo.loadMoves(matchId).unsafeRunSync() shouldBe empty
     }
   }
 }

--- a/game-service-persistence/src/test/scala/com/andy327/persistence/db/postgres/PostgresGameRepositorySpec.scala
+++ b/game-service-persistence/src/test/scala/com/andy327/persistence/db/postgres/PostgresGameRepositorySpec.scala
@@ -12,7 +12,7 @@ import doobie.implicits._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import com.andy327.model.core.{GameId, GameType, PlayerId}
+import com.andy327.model.core.{GameType, MatchId, PlayerId}
 import com.andy327.model.tictactoe.TicTacToe
 import com.andy327.persistence.db.schema.GameTypeCodecs
 
@@ -41,13 +41,13 @@ class PostgresGameRepositorySpec extends AnyWordSpec with Matchers with ForAllTe
 
   "PostgresGameRepository" should {
     "save then load a TicTacToe game" in {
-      val gameId: GameId = UUID.randomUUID()
+      val matchId: MatchId = UUID.randomUUID()
       val alice: PlayerId = UUID.randomUUID()
       val bob: PlayerId = UUID.randomUUID()
       val game = TicTacToe.empty(alice, bob)
 
-      gameRepo.saveGame(gameId, GameType.TicTacToe, game).unsafeRunSync()
-      gameRepo.loadGame(gameId, GameType.TicTacToe).unsafeRunSync() shouldBe Some(game)
+      gameRepo.saveGame(matchId, GameType.TicTacToe, game).unsafeRunSync()
+      gameRepo.loadGame(matchId, GameType.TicTacToe).unsafeRunSync() shouldBe Some(game)
     }
 
     "return None for a missing game" in {
@@ -56,34 +56,34 @@ class PostgresGameRepositorySpec extends AnyWordSpec with Matchers with ForAllTe
 
     "return None for a game with invalid JSON" in {
       val invalidJson = "invalid-json"
-      val gameId: GameId = UUID.randomUUID()
+      val matchId: MatchId = UUID.randomUUID()
       val insert = sql"""
         INSERT INTO games (game_id, game_type, game_state)
-        VALUES (${gameId.toString}, 'TicTacToe', $invalidJson)
+        VALUES (${matchId.toString}, 'TicTacToe', $invalidJson)
       """.update.run.transact(xa)
 
       insert.unsafeRunSync()
 
-      gameRepo.loadGame(gameId, GameType.TicTacToe).unsafeRunSync() shouldBe None
+      gameRepo.loadGame(matchId, GameType.TicTacToe).unsafeRunSync() shouldBe None
     }
 
     "list all saved games" in {
       val alice: PlayerId = UUID.randomUUID()
       val bob: PlayerId = UUID.randomUUID()
-      val gameId1 = UUID.randomUUID()
-      val gameId2 = UUID.randomUUID()
-      gameRepo.saveGame(gameId1, GameType.TicTacToe, TicTacToe.empty(alice, bob)).unsafeRunSync()
-      gameRepo.saveGame(gameId2, GameType.TicTacToe, TicTacToe.empty(alice, bob)).unsafeRunSync()
+      val matchId1 = UUID.randomUUID()
+      val matchId2 = UUID.randomUUID()
+      gameRepo.saveGame(matchId1, GameType.TicTacToe, TicTacToe.empty(alice, bob)).unsafeRunSync()
+      gameRepo.saveGame(matchId2, GameType.TicTacToe, TicTacToe.empty(alice, bob)).unsafeRunSync()
 
       val all = gameRepo.loadAllGames().unsafeRunSync()
-      (all.keySet should contain).allOf(gameId1, gameId2)
+      (all.keySet should contain).allOf(matchId1, matchId2)
     }
 
     "skip corrupted or unknown game types when loading all games" in {
-      val badTypeGameId: GameId = UUID.randomUUID()
-      val invalidGameId: String = "abc"
-      val corruptedGameId: GameId = UUID.randomUUID()
-      val validGameId: GameId = UUID.randomUUID()
+      val badTypeMatchId: MatchId = UUID.randomUUID()
+      val invalidMatchId: String = "abc"
+      val corruptedMatchId: MatchId = UUID.randomUUID()
+      val validMatchId: MatchId = UUID.randomUUID()
       val x: PlayerId = UUID.randomUUID()
       val y: PlayerId = UUID.randomUUID()
       val validGame = TicTacToe.empty(x, y)
@@ -91,22 +91,22 @@ class PostgresGameRepositorySpec extends AnyWordSpec with Matchers with ForAllTe
       // Insert valid, corrupted, and unknown-type rows
       val insertAll = List(
         sql"""INSERT INTO games (game_id, game_type, game_state)
-              VALUES (${badTypeGameId.toString}, 'UnknownGame', '{}')""",
+              VALUES (${badTypeMatchId.toString}, 'UnknownGame', '{}')""",
         sql"""INSERT INTO games (game_id, game_type, game_state)
-              VALUES (${invalidGameId}, 'TicTacToe', ${validGame.asJson.noSpaces})""",
+              VALUES (${invalidMatchId}, 'TicTacToe', ${validGame.asJson.noSpaces})""",
         sql"""INSERT INTO games (game_id, game_type, game_state)
-              VALUES (${corruptedGameId.toString}, 'TicTacToe', 'corrupted-json')""",
+              VALUES (${corruptedMatchId.toString}, 'TicTacToe', 'corrupted-json')""",
         sql"""INSERT INTO games (game_id, game_type, game_state)
-              VALUES (${validGameId.toString}, 'TicTacToe', ${validGame.asJson.noSpaces})"""
+              VALUES (${validMatchId.toString}, 'TicTacToe', ${validGame.asJson.noSpaces})"""
       ).traverse_(_.update.run).transact(xa)
 
       insertAll.unsafeRunSync()
 
       val result = gameRepo.loadAllGames().unsafeRunSync()
-      result.keySet should contain(validGameId)
-      result.keySet should not contain badTypeGameId
-      result.keySet should not contain invalidGameId
-      result.keySet should not contain corruptedGameId
+      result.keySet should contain(validMatchId)
+      result.keySet should not contain badTypeMatchId
+      result.keySet should not contain invalidMatchId
+      result.keySet should not contain corruptedMatchId
     }
   }
 }

--- a/game-service-persistence/src/test/scala/com/andy327/persistence/db/postgres/PostgresMoveHistoryRepositorySpec.scala
+++ b/game-service-persistence/src/test/scala/com/andy327/persistence/db/postgres/PostgresMoveHistoryRepositorySpec.scala
@@ -13,7 +13,7 @@ import io.circe.syntax._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import com.andy327.model.core.{GameId, PlayerId}
+import com.andy327.model.core.{MatchId, PlayerId}
 
 class PostgresMoveHistoryRepositorySpec extends AnyWordSpec with Matchers with ForAllTestContainer {
 
@@ -37,15 +37,15 @@ class PostgresMoveHistoryRepositorySpec extends AnyWordSpec with Matchers with F
 
   "PostgresMoveHistoryRepository" should {
     "append moves and load them ordered by seq" in {
-      val gameId: GameId = UUID.randomUUID()
+      val matchId: MatchId = UUID.randomUUID()
       val alice: PlayerId = UUID.randomUUID()
       val bob: PlayerId = UUID.randomUUID()
 
-      repo.appendMove(gameId, 0, alice, move(3)).unsafeRunSync()
-      repo.appendMove(gameId, 1, bob, move(4)).unsafeRunSync()
-      repo.appendMove(gameId, 2, alice, move(3)).unsafeRunSync()
+      repo.appendMove(matchId, 0, alice, move(3)).unsafeRunSync()
+      repo.appendMove(matchId, 1, bob, move(4)).unsafeRunSync()
+      repo.appendMove(matchId, 2, alice, move(3)).unsafeRunSync()
 
-      val moves = repo.loadMoves(gameId).unsafeRunSync()
+      val moves = repo.loadMoves(matchId).unsafeRunSync()
       moves.map(_.seq) shouldBe List(0, 1, 2)
       moves.map(_.playerId) shouldBe List(alice, bob, alice)
       moves.map(_.move) shouldBe List(move(3), move(4), move(3))
@@ -53,49 +53,49 @@ class PostgresMoveHistoryRepositorySpec extends AnyWordSpec with Matchers with F
     }
 
     "order by seq even when moves are appended out of order" in {
-      val gameId: GameId = UUID.randomUUID()
+      val matchId: MatchId = UUID.randomUUID()
       val player: PlayerId = UUID.randomUUID()
 
-      repo.appendMove(gameId, 2, player, move(2)).unsafeRunSync()
-      repo.appendMove(gameId, 0, player, move(0)).unsafeRunSync()
-      repo.appendMove(gameId, 1, player, move(1)).unsafeRunSync()
+      repo.appendMove(matchId, 2, player, move(2)).unsafeRunSync()
+      repo.appendMove(matchId, 0, player, move(0)).unsafeRunSync()
+      repo.appendMove(matchId, 1, player, move(1)).unsafeRunSync()
 
-      repo.loadMoves(gameId).unsafeRunSync().map(_.seq) shouldBe List(0, 1, 2)
+      repo.loadMoves(matchId).unsafeRunSync().map(_.seq) shouldBe List(0, 1, 2)
     }
 
     "return an empty list for a game with no recorded moves" in {
       repo.loadMoves(UUID.randomUUID()).unsafeRunSync() shouldBe empty
     }
 
-    "ignore a duplicate (gameId, seq) rather than failing" in {
-      val gameId: GameId = UUID.randomUUID()
+    "ignore a duplicate (matchId, seq) rather than failing" in {
+      val matchId: MatchId = UUID.randomUUID()
       val player: PlayerId = UUID.randomUUID()
 
-      repo.appendMove(gameId, 0, player, move(1)).unsafeRunSync()
-      repo.appendMove(gameId, 0, player, move(9)).unsafeRunSync() // same seq — must not overwrite or throw
+      repo.appendMove(matchId, 0, player, move(1)).unsafeRunSync()
+      repo.appendMove(matchId, 0, player, move(9)).unsafeRunSync() // same seq — must not overwrite or throw
 
-      val moves = repo.loadMoves(gameId).unsafeRunSync()
+      val moves = repo.loadMoves(matchId).unsafeRunSync()
       moves.map(_.move) shouldBe List(move(1))
     }
 
     "skip rows whose stored move JSON cannot be parsed" in {
-      val gameId: GameId = UUID.randomUUID()
+      val matchId: MatchId = UUID.randomUUID()
       val player: PlayerId = UUID.randomUUID()
 
-      repo.appendMove(gameId, 0, player, move(1)).unsafeRunSync()
+      repo.appendMove(matchId, 0, player, move(1)).unsafeRunSync()
       // a corrupt row inserted directly, bypassing appendMove (which always writes valid JSON)
       sql"""
         INSERT INTO game_moves (game_id, seq, player_id, move_json)
-        VALUES (${gameId.toString}, 1, ${player.toString}, 'not-json')
+        VALUES (${matchId.toString}, 1, ${player.toString}, 'not-json')
       """.update.run.transact(xa).unsafeRunSync()
 
-      val moves = repo.loadMoves(gameId).unsafeRunSync()
+      val moves = repo.loadMoves(matchId).unsafeRunSync()
       moves.map(_.seq) shouldBe List(0) // the corrupt seq-1 row is skipped
     }
 
-    "isolate move logs by gameId" in {
-      val game1: GameId = UUID.randomUUID()
-      val game2: GameId = UUID.randomUUID()
+    "isolate move logs by matchId" in {
+      val game1: MatchId = UUID.randomUUID()
+      val game2: MatchId = UUID.randomUUID()
       val player: PlayerId = UUID.randomUUID()
 
       repo.appendMove(game1, 0, player, move(1)).unsafeRunSync()

--- a/game-service-persistence/src/test/scala/com/andy327/persistence/db/postgres/PostgresPlayerHistoryRepositorySpec.scala
+++ b/game-service-persistence/src/test/scala/com/andy327/persistence/db/postgres/PostgresPlayerHistoryRepositorySpec.scala
@@ -13,7 +13,7 @@ import doobie.postgres.implicits._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import com.andy327.model.core.{GameId, GameType, PlayerId}
+import com.andy327.model.core.{GameType, MatchId, PlayerId}
 import com.andy327.persistence.db.PlayerHistoryRepository.GameResult
 
 class PostgresPlayerHistoryRepositorySpec extends AnyWordSpec with Matchers with ForAllTestContainer {
@@ -37,14 +37,14 @@ class PostgresPlayerHistoryRepositorySpec extends AnyWordSpec with Matchers with
   "PostgresPlayerHistoryRepository" should {
     "record a completed game and return it with its fields intact" in {
       val player: PlayerId = UUID.randomUUID()
-      val gameId: GameId = UUID.randomUUID()
+      val matchId: MatchId = UUID.randomUUID()
 
-      repo.record(player, gameId, GameType.ConnectFour, GameResult.Loss, forfeit = true).unsafeRunSync()
+      repo.record(player, matchId, GameType.ConnectFour, GameResult.Loss, forfeit = true).unsafeRunSync()
 
       val records = repo.findByPlayer(player).unsafeRunSync()
       records should have size 1
       val record = records.head
-      record.gameId shouldBe gameId
+      record.matchId shouldBe matchId
       record.gameType shouldBe GameType.ConnectFour
       record.result shouldBe GameResult.Loss
       record.forfeit shouldBe true
@@ -54,10 +54,10 @@ class PostgresPlayerHistoryRepositorySpec extends AnyWordSpec with Matchers with
     "record both participants of the same game under their own ids" in {
       val winner: PlayerId = UUID.randomUUID()
       val loser: PlayerId = UUID.randomUUID()
-      val gameId: GameId = UUID.randomUUID()
+      val matchId: MatchId = UUID.randomUUID()
 
-      repo.record(winner, gameId, GameType.TicTacToe, GameResult.Win, forfeit = false).unsafeRunSync()
-      repo.record(loser, gameId, GameType.TicTacToe, GameResult.Loss, forfeit = false).unsafeRunSync()
+      repo.record(winner, matchId, GameType.TicTacToe, GameResult.Win, forfeit = false).unsafeRunSync()
+      repo.record(loser, matchId, GameType.TicTacToe, GameResult.Loss, forfeit = false).unsafeRunSync()
 
       repo.findByPlayer(winner).unsafeRunSync().map(_.result) shouldBe List(GameResult.Win)
       repo.findByPlayer(loser).unsafeRunSync().map(_.result) shouldBe List(GameResult.Loss)
@@ -65,31 +65,31 @@ class PostgresPlayerHistoryRepositorySpec extends AnyWordSpec with Matchers with
 
     "order a player's games by most recently finished first" in {
       val player: PlayerId = UUID.randomUUID()
-      val older: GameId = UUID.randomUUID()
-      val newer: GameId = UUID.randomUUID()
+      val older: MatchId = UUID.randomUUID()
+      val newer: MatchId = UUID.randomUUID()
 
       // insert directly with controlled finished_at so the ordering assertion is deterministic
       insertAt(player, older, Instant.parse("2026-01-01T00:00:00Z"))
       insertAt(player, newer, Instant.parse("2026-06-01T00:00:00Z"))
 
-      repo.findByPlayer(player).unsafeRunSync().map(_.gameId) shouldBe List(newer, older)
+      repo.findByPlayer(player).unsafeRunSync().map(_.matchId) shouldBe List(newer, older)
     }
 
-    "ignore a re-recorded (playerId, gameId) outcome rather than failing or overwriting" in {
+    "ignore a re-recorded (playerId, matchId) outcome rather than failing or overwriting" in {
       val player: PlayerId = UUID.randomUUID()
-      val gameId: GameId = UUID.randomUUID()
+      val matchId: MatchId = UUID.randomUUID()
 
-      repo.record(player, gameId, GameType.TicTacToe, GameResult.Win, forfeit = false).unsafeRunSync()
-      repo.record(player, gameId, GameType.TicTacToe, GameResult.Loss, forfeit = false).unsafeRunSync()
+      repo.record(player, matchId, GameType.TicTacToe, GameResult.Win, forfeit = false).unsafeRunSync()
+      repo.record(player, matchId, GameType.TicTacToe, GameResult.Loss, forfeit = false).unsafeRunSync()
 
       repo.findByPlayer(player).unsafeRunSync().map(_.result) shouldBe List(GameResult.Win) // first write wins
     }
 
     "skip rows whose stored game type or result cannot be parsed" in {
       val player: PlayerId = UUID.randomUUID()
-      val good: GameId = UUID.randomUUID()
-      val badType: GameId = UUID.randomUUID()
-      val badResult: GameId = UUID.randomUUID()
+      val good: MatchId = UUID.randomUUID()
+      val badType: MatchId = UUID.randomUUID()
+      val badResult: MatchId = UUID.randomUUID()
 
       repo.record(player, good, GameType.TicTacToe, GameResult.Win, forfeit = false).unsafeRunSync()
       // corrupt rows inserted directly, bypassing record (which always writes valid labels)
@@ -102,7 +102,7 @@ class PostgresPlayerHistoryRepositorySpec extends AnyWordSpec with Matchers with
         VALUES (${player.toString}, ${badResult.toString}, 'TicTacToe', 'maybe', false)
       """.update.run.transact(xa).unsafeRunSync()
 
-      repo.findByPlayer(player).unsafeRunSync().map(_.gameId) shouldBe List(good) // only the parseable row survives
+      repo.findByPlayer(player).unsafeRunSync().map(_.matchId) shouldBe List(good) // only the parseable row survives
     }
 
     "isolate history by playerId" in {
@@ -122,9 +122,9 @@ class PostgresPlayerHistoryRepositorySpec extends AnyWordSpec with Matchers with
   }
 
   /** Inserts a row with an explicit `finished_at`, bypassing `record`'s `now()` default, for deterministic ordering. */
-  private def insertAt(playerId: PlayerId, gameId: GameId, finishedAt: Instant): Unit =
+  private def insertAt(playerId: PlayerId, matchId: MatchId, finishedAt: Instant): Unit =
     sql"""
       INSERT INTO player_games (player_id, game_id, game_type, result, forfeit, finished_at)
-      VALUES (${playerId.toString}, ${gameId.toString}, 'TicTacToe', 'win', false, $finishedAt)
+      VALUES (${playerId.toString}, ${matchId.toString}, 'TicTacToe', 'win', false, $finishedAt)
     """.update.run.transact(xa).unsafeRunSync()
 }

--- a/game-service-persistence/src/test/scala/com/andy327/persistence/db/redis/RedisGameRepositorySpec.scala
+++ b/game-service-persistence/src/test/scala/com/andy327/persistence/db/redis/RedisGameRepositorySpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.testcontainers.containers.wait.strategy.Wait
 
-import com.andy327.model.core.{Game, GameId, GameType}
+import com.andy327.model.core.{Game, GameType, MatchId}
 import com.andy327.model.tictactoe.TicTacToe
 import com.andy327.persistence.db.GameRepository
 import com.andy327.persistence.db.schema.GameTypeCodecs
@@ -42,12 +42,12 @@ class RedisGameRepositorySpec extends AnyWordSpec with Matchers with ForAllTestC
       f(new RedisGameRepository(stub, redis), redis)
     }.unsafeRunSync()
 
-  private def newGame(): (GameId, TicTacToe) =
+  private def newGame(): (MatchId, TicTacToe) =
     UUID.randomUUID() -> TicTacToe.empty(UUID.randomUUID(), UUID.randomUUID())
 
   // Stub GameRepository backed by an in-memory map with call counters
   private class StubGameRepository(
-      private var games: Map[GameId, (GameType, Game[_, _, _, _, _])] = Map.empty
+      private var games: Map[MatchId, (GameType, Game[_, _, _, _, _])] = Map.empty
   ) extends GameRepository {
     var initializeCallCount: Int = 0
     var loadGameCallCount: Int = 0
@@ -55,13 +55,13 @@ class RedisGameRepositorySpec extends AnyWordSpec with Matchers with ForAllTestC
 
     override def initialize(): IO[Unit] = IO(initializeCallCount += 1)
 
-    override def saveGame(gameId: GameId, gameType: GameType, game: Game[_, _, _, _, _]): IO[Unit] =
-      IO { saveGameCallCount += 1; games = games + (gameId -> (gameType, game)) }
+    override def saveGame(matchId: MatchId, gameType: GameType, game: Game[_, _, _, _, _]): IO[Unit] =
+      IO { saveGameCallCount += 1; games = games + (matchId -> (gameType, game)) }
 
-    override def loadGame(gameId: GameId, gameType: GameType): IO[Option[Game[_, _, _, _, _]]] =
-      IO { loadGameCallCount += 1; games.get(gameId).map(_._2) }
+    override def loadGame(matchId: MatchId, gameType: GameType): IO[Option[Game[_, _, _, _, _]]] =
+      IO { loadGameCallCount += 1; games.get(matchId).map(_._2) }
 
-    override def loadAllGames(): IO[Map[GameId, (GameType, Game[_, _, _, _, _])]] =
+    override def loadAllGames(): IO[Map[MatchId, (GameType, Game[_, _, _, _, _])]] =
       IO.pure(games)
   }
 
@@ -76,13 +76,13 @@ class RedisGameRepositorySpec extends AnyWordSpec with Matchers with ForAllTestC
 
   "RedisGameRepository.saveGame" should {
     "write the serialized game state to Redis and delegate to Postgres" in {
-      val (gameId, game) = newGame()
+      val (matchId, game) = newGame()
       val stub = new StubGameRepository()
 
       withResources(stub) { (repo, redis) =>
         for {
-          _ <- repo.saveGame(gameId, GameType.TicTacToe, game)
-          cached <- redis.get(s"game:$gameId")
+          _ <- repo.saveGame(matchId, GameType.TicTacToe, game)
+          cached <- redis.get(s"game:$matchId")
         } yield {
           cached shouldBe Some(GameTypeCodecs.serializeGame(GameType.TicTacToe, game))
           stub.saveGameCallCount shouldBe 1
@@ -93,13 +93,13 @@ class RedisGameRepositorySpec extends AnyWordSpec with Matchers with ForAllTestC
 
   "RedisGameRepository.loadGame" should {
     "return the cached value without calling Postgres on a cache hit" in {
-      val (gameId, game) = newGame()
+      val (matchId, game) = newGame()
       val stub = new StubGameRepository() // loadGame would return None
 
       withResources(stub) { (repo, redis) =>
         for {
-          _ <- redis.set(s"game:$gameId", GameTypeCodecs.serializeGame(GameType.TicTacToe, game))
-          result <- repo.loadGame(gameId, GameType.TicTacToe)
+          _ <- redis.set(s"game:$matchId", GameTypeCodecs.serializeGame(GameType.TicTacToe, game))
+          result <- repo.loadGame(matchId, GameType.TicTacToe)
         } yield {
           result shouldBe Some(game)
           stub.loadGameCallCount shouldBe 0
@@ -108,13 +108,13 @@ class RedisGameRepositorySpec extends AnyWordSpec with Matchers with ForAllTestC
     }
 
     "fall back to Postgres and warm the cache on a cache miss" in {
-      val (gameId, game) = newGame()
-      val stub = new StubGameRepository(Map(gameId -> (GameType.TicTacToe, game)))
+      val (matchId, game) = newGame()
+      val stub = new StubGameRepository(Map(matchId -> (GameType.TicTacToe, game)))
 
       withResources(stub) { (repo, redis) =>
         for {
-          result <- repo.loadGame(gameId, GameType.TicTacToe)
-          cached <- redis.get(s"game:$gameId")
+          result <- repo.loadGame(matchId, GameType.TicTacToe)
+          cached <- redis.get(s"game:$matchId")
         } yield {
           result shouldBe Some(game)
           stub.loadGameCallCount shouldBe 1
@@ -124,13 +124,13 @@ class RedisGameRepositorySpec extends AnyWordSpec with Matchers with ForAllTestC
     }
 
     "return None and leave the cache empty when the game is not found in Postgres" in {
-      val gameId = UUID.randomUUID()
+      val matchId = UUID.randomUUID()
       val stub = new StubGameRepository() // no games — loadGame returns None
 
       withResources(stub) { (repo, redis) =>
         for {
-          result <- repo.loadGame(gameId, GameType.TicTacToe)
-          cached <- redis.get(s"game:$gameId")
+          result <- repo.loadGame(matchId, GameType.TicTacToe)
+          cached <- redis.get(s"game:$matchId")
         } yield {
           result shouldBe None
           cached shouldBe None
@@ -139,14 +139,14 @@ class RedisGameRepositorySpec extends AnyWordSpec with Matchers with ForAllTestC
     }
 
     "fall back to Postgres and re-warm the cache when the cached value is corrupt" in {
-      val (gameId, game) = newGame()
-      val stub = new StubGameRepository(Map(gameId -> (GameType.TicTacToe, game)))
+      val (matchId, game) = newGame()
+      val stub = new StubGameRepository(Map(matchId -> (GameType.TicTacToe, game)))
 
       withResources(stub) { (repo, redis) =>
         for {
-          _ <- redis.set(s"game:$gameId", "not-valid-json")
-          result <- repo.loadGame(gameId, GameType.TicTacToe)
-          cached <- redis.get(s"game:$gameId")
+          _ <- redis.set(s"game:$matchId", "not-valid-json")
+          result <- repo.loadGame(matchId, GameType.TicTacToe)
+          cached <- redis.get(s"game:$matchId")
         } yield {
           result shouldBe Some(game)
           stub.loadGameCallCount shouldBe 1
@@ -158,15 +158,15 @@ class RedisGameRepositorySpec extends AnyWordSpec with Matchers with ForAllTestC
 
   "RedisGameRepository.loadAllGames" should {
     "load all games from Postgres and warm the Redis cache" in {
-      val (gameId, game) = newGame()
-      val stub = new StubGameRepository(Map(gameId -> (GameType.TicTacToe, game)))
+      val (matchId, game) = newGame()
+      val stub = new StubGameRepository(Map(matchId -> (GameType.TicTacToe, game)))
 
       withResources(stub) { (repo, redis) =>
         for {
           result <- repo.loadAllGames()
-          cached <- redis.get(s"game:$gameId")
+          cached <- redis.get(s"game:$matchId")
         } yield {
-          result.get(gameId) shouldBe Some((GameType.TicTacToe, game))
+          result.get(matchId) shouldBe Some((GameType.TicTacToe, game))
           cached shouldBe Some(GameTypeCodecs.serializeGame(GameType.TicTacToe, game))
         }
       }

--- a/game-service-server/src/main/resources/web/app.js
+++ b/game-service-server/src/main/resources/web/app.js
@@ -15,7 +15,7 @@ const session = {
   token: null,
   me: null, // { id, name }
   ws: null,
-  game: null // { gameId, gameType, isHost }
+  game: null // { roomId, gameType, isHost }
 };
 
 // Per-game-type knowledge the rest of the client stays agnostic to: display label, how a click becomes a move, and
@@ -112,10 +112,10 @@ async function restoreSession() {
 
 // Land on the invite-link target if one is pending, otherwise the lobby.
 function routeAfterSignIn() {
-  if (pendingJoinGameId) {
-    const id = pendingJoinGameId;
-    pendingJoinGameId = null;
-    joinByGameId(id);
+  if (pendingJoinRoomId) {
+    const id = pendingJoinRoomId;
+    pendingJoinRoomId = null;
+    joinByRoomId(id);
   } else {
     enterLobby();
   }
@@ -213,14 +213,14 @@ async function createGame(gameType) {
   setError("lobby-error", "");
   const res = await api(`/lobby/create/${gameType}`, { method: "POST", body: {} });
   if (!res.ok) return flashError("lobby-error", res.data?.error || res.data || "Could not create game");
-  await enterGame({ gameId: res.data.gameId, gameType, isHost: true });
+  await enterGame({ roomId: res.data.roomId, gameType, isHost: true });
 }
 
-async function joinGame(gameId, gameType) {
+async function joinGame(roomId, gameType) {
   setError("lobby-error", "");
-  const res = await api(`/lobby/${gameId}/join`, { method: "POST", body: {} });
+  const res = await api(`/lobby/${roomId}/join`, { method: "POST", body: {} });
   if (!res.ok) return flashError("lobby-error", res.data?.error || res.data || "Could not join game");
-  await enterGame({ gameId, gameType, isHost: false });
+  await enterGame({ roomId, gameType, isHost: false });
 }
 
 async function refreshLobbies() {
@@ -259,7 +259,7 @@ async function refreshLobbies() {
     const join = document.createElement("button");
     join.textContent = full ? "Full" : "Join";
     join.disabled = full;
-    if (!full) join.onclick = () => joinGame(lobby.gameId, type);
+    if (!full) join.onclick = () => joinGame(lobby.roomId, type);
 
     li.append(meta, join);
     list.appendChild(li);
@@ -267,8 +267,8 @@ async function refreshLobbies() {
 }
 
 // Reset the game view to a clean slate for a given game/lobby and show it. The caller sets the status and subscribes.
-function prepareGameView({ gameId, gameType, isHost }) {
-  session.game = { gameId, gameType, isHost };
+function prepareGameView({ roomId, gameType, isHost }) {
+  session.game = { roomId, gameType, isHost };
   $("game-title").textContent = GAMES[gameType].label;
   $("board").innerHTML = "";
   $("column-controls").innerHTML = "";
@@ -312,7 +312,7 @@ function renderMySessions(data) {
   for (const g of games) {
     const type = g.gameType.toLowerCase();
     ul.appendChild(
-      sessionRow(`${GAMES[type].label} — in progress`, "Return", () => resumeGame({ gameId: g.gameId, gameType: type }))
+      sessionRow(`${GAMES[type].label} — in progress`, "Return", () => resumeGame({ roomId: g.roomId, gameType: type }))
     );
   }
   for (const l of lobbies) {
@@ -321,7 +321,7 @@ function renderMySessions(data) {
     const count = Object.keys(l.players).length;
     const phase = l.status === "Finished" ? "finished — chat/rematch" : `lobby (${count}/${GAMES[type].maxPlayers})`;
     const label = `${GAMES[type].label} — ${phase}${youHost ? " · you host" : ""}`;
-    ul.appendChild(sessionRow(label, "Return", () => enterGame({ gameId: l.gameId, gameType: type, isHost: youHost })));
+    ul.appendChild(sessionRow(label, "Return", () => enterGame({ roomId: l.roomId, gameType: type, isHost: youHost })));
   }
 }
 
@@ -342,27 +342,27 @@ function sessionRow(text, btnText, onClick) {
 }
 
 // Enter the game view for a lobby we just created or joined, then subscribe to the lobby so we receive its push events.
-async function enterGame({ gameId, gameType, isHost }) {
-  prepareGameView({ gameId, gameType, isHost });
+async function enterGame({ roomId, gameType, isHost }) {
+  prepareGameView({ roomId, gameType, isHost });
   setStatus(isHost ? "Waiting for an opponent to join…" : "Joined. Waiting for the host to start…");
-  const res = await api(`/lobby/${gameId}/subscribe`, { method: "POST", body: {} });
+  const res = await api(`/lobby/${roomId}/subscribe`, { method: "POST", body: {} });
   if (!res.ok) flashError("game-error", res.data?.error || res.data || "Could not subscribe to the lobby");
-  loadChatHistory(gameId, gameType);
+  loadChatHistory(roomId, gameType);
 }
 
 // Return to a game already in progress (from the sessions list): subscribe to the game actor, which immediately pushes
 // the current board. Pre-game lobbies are returned to via enterGame instead (they subscribe to the lobby).
-async function resumeGame({ gameId, gameType }) {
-  prepareGameView({ gameId, gameType, isHost: false });
+async function resumeGame({ roomId, gameType }) {
+  prepareGameView({ roomId, gameType, isHost: false });
   setStatus("Returning to the game…");
-  const res = await api(`/${gameType}/${gameId}/subscribe`, { method: "POST", body: {} });
+  const res = await api(`/${gameType}/${roomId}/subscribe`, { method: "POST", body: {} });
   if (!res.ok) flashError("game-error", res.data?.error || res.data || "Could not return to the game");
-  loadChatHistory(gameId, gameType);
+  loadChatHistory(roomId, gameType);
 }
 
 // A pre-game lobby changed: refresh the player count, surface the host, and (for the host) enable Start when ready.
 function onLobbyUpdated(metadata) {
-  if (!session.game || metadata.gameId !== session.game.gameId) return;
+  if (!session.game || metadata.roomId !== session.game.roomId) return;
   if (metadata.status === "InProgress") {
     $("start-game").classList.add("hidden"); // the game is live; Start no longer applies
     $("post-game-bar").classList.add("hidden"); // a rematch just began; the next GameStateUpdated takes over
@@ -409,14 +409,14 @@ function onMatchFinished(metadata) {
 
 async function rematch() {
   setError("game-error", "");
-  const res = await api(`/lobby/${session.game.gameId}/start`, { method: "POST", body: {} });
+  const res = await api(`/lobby/${session.game.roomId}/start`, { method: "POST", body: {} });
   if (!res.ok) flashError("game-error", res.data?.error || res.data || "Could not start the rematch");
   // On success a fresh GameStateUpdated arrives over the WebSocket and clears the post-game bar.
 }
 
 async function startGame() {
   setError("game-error", "");
-  const res = await api(`/lobby/${session.game.gameId}/start`, { method: "POST", body: {} });
+  const res = await api(`/lobby/${session.game.roomId}/start`, { method: "POST", body: {} });
   if (!res.ok) flashError("game-error", res.data?.error || res.data || "Could not start the game");
   // On success the game-state push arrives over the WebSocket and renders the board.
 }
@@ -428,7 +428,7 @@ function onGameEnded(result) {
 
 async function leaveGame() {
   const game = session.game;
-  if (game) await api(`/lobby/${game.gameId}/leave`, { method: "POST", body: {} });
+  if (game) await api(`/lobby/${game.roomId}/leave`, { method: "POST", body: {} });
   session.game = null;
   enterLobby();
 }
@@ -456,15 +456,15 @@ function appendChat(m) {
 }
 
 // Load the recent backscroll (oldest first) for a game/lobby; best-effort, so an empty or failed load is harmless.
-async function loadChatHistory(gameId, gameType) {
-  const res = await api(`/${gameType}/${gameId}/chat`);
+async function loadChatHistory(roomId, gameType) {
+  const res = await api(`/${gameType}/${roomId}/chat`);
   if (res.ok && res.data && Array.isArray(res.data.messages)) res.data.messages.forEach(appendChat);
 }
 
 // Send a chat frame over the WebSocket. Requires an open socket and an active game/lobby context.
 function sendChat(text) {
   if (!session.ws || session.ws.readyState !== WebSocket.OPEN || !session.game) return;
-  session.ws.send(JSON.stringify({ type: "ChatSend", gameId: session.game.gameId, text }));
+  session.ws.send(JSON.stringify({ type: "ChatSend", roomId: session.game.roomId, text }));
 }
 
 // --- Board rendering -------------------------------------------------------------------------------------------------
@@ -526,23 +526,23 @@ async function submitMove(row, col) {
   if (!game) return;
   setError("game-error", "");
   const payload = GAMES[game.gameType].move(row, col);
-  const res = await api(`/${game.gameType}/${game.gameId}/move`, { method: "POST", body: payload });
+  const res = await api(`/${game.gameType}/${game.roomId}/move`, { method: "POST", body: payload });
   // Successful moves redraw via the WebSocket push; only failures need surfacing here.
   if (!res.ok) flashError("game-error", res.data?.error || res.data || "Move rejected");
 }
 
 // --- Deep links ------------------------------------------------------------------------------------------------------
-// A shareable URL hash (#join/<gameId>) drops a visitor straight into a specific lobby. The hash keeps the request on
+// A shareable URL hash (#join/<roomId>) drops a visitor straight into a specific lobby. The hash keeps the request on
 // the static-served `/` route (a path like /lobby/<id> is a JSON API route). It is captured once at load and consumed
 // after the visitor signs in, since joining needs a token and an open WebSocket.
-// Parse a #join/<gameId> invite hash, or null. Captured at load and also watched live via hashchange below.
+// Parse a #join/<roomId> invite hash, or null. Captured at load and also watched live via hashchange below.
 function parseJoinHash() {
   return (location.hash.match(/^#join\/([0-9a-fA-F-]+)$/) || [])[1] || null;
 }
 
 // A pending invite to consume once the visitor is signed in. Set from the initial hash and from later hash changes.
-let pendingJoinGameId = parseJoinHash();
-if (pendingJoinGameId) history.replaceState(null, "", location.pathname + location.search);
+let pendingJoinRoomId = parseJoinHash();
+if (pendingJoinRoomId) history.replaceState(null, "", location.pathname + location.search);
 
 // Following an invite link while the page is already open changes only the hash (no reload). If we're already signed
 // in, join right away; otherwise hold it until sign-in. A link opened in a fresh tab is a full load, which — with the
@@ -551,18 +551,18 @@ window.addEventListener("hashchange", () => {
   const id = parseJoinHash();
   if (!id) return;
   history.replaceState(null, "", location.pathname + location.search);
-  if (session.me) joinByGameId(id);
-  else pendingJoinGameId = id;
+  if (session.me) joinByRoomId(id);
+  else pendingJoinRoomId = id;
 });
 
 // Join the lobby named by a deep link: look up its game type, then join — falling back to the lobby list on any issue.
-async function joinByGameId(gameId) {
+async function joinByRoomId(roomId) {
   enterLobby();
-  const res = await api(`/lobby/${gameId}`);
+  const res = await api(`/lobby/${roomId}`);
   if (!res.ok) return flashError("lobby-error", "That lobby is no longer available.");
   const type = res.data.gameType.toLowerCase();
   if (!GAMES[type]) return flashError("lobby-error", "That game isn't supported in the web UI yet.");
-  joinGame(gameId, type);
+  joinGame(roomId, type);
 }
 
 // Copy a shareable invite link for the current lobby/game to the clipboard, with a prompt() fallback. Briefly flips the
@@ -572,7 +572,7 @@ const COPY_LINK_LABEL = "Copy invite link";
 let copyLinkTimer;
 async function copyInviteLink() {
   if (!session.game) return;
-  const link = `${location.origin}/#join/${session.game.gameId}`;
+  const link = `${location.origin}/#join/${session.game.roomId}`;
   const btn = $("copy-link");
   try {
     await navigator.clipboard.writeText(link);

--- a/game-service-server/src/main/resources/web/app.js
+++ b/game-service-server/src/main/resources/web/app.js
@@ -275,6 +275,8 @@ function prepareGameView({ gameId, gameType, isHost }) {
   setError("game-error", "");
   $("start-game").classList.add("hidden");
   $("start-game").disabled = true;
+  $("post-game-bar").classList.add("hidden");
+  $("rematch-btn").classList.add("hidden");
   clearTimeout(copyLinkTimer);
   $("copy-link").textContent = COPY_LINK_LABEL;
   $("chat-log").innerHTML = "";
@@ -317,7 +319,8 @@ function renderMySessions(data) {
     const type = l.gameType.toLowerCase();
     const youHost = Boolean(session.me) && l.hostId === session.me.id;
     const count = Object.keys(l.players).length;
-    const label = `${GAMES[type].label} — lobby (${count}/${GAMES[type].maxPlayers})${youHost ? " · you host" : ""}`;
+    const phase = l.status === "Finished" ? "finished — chat/rematch" : `lobby (${count}/${GAMES[type].maxPlayers})`;
+    const label = `${GAMES[type].label} — ${phase}${youHost ? " · you host" : ""}`;
     ul.appendChild(sessionRow(label, "Return", () => enterGame({ gameId: l.gameId, gameType: type, isHost: youHost })));
   }
 }
@@ -362,7 +365,13 @@ function onLobbyUpdated(metadata) {
   if (!session.game || metadata.gameId !== session.game.gameId) return;
   if (metadata.status === "InProgress") {
     $("start-game").classList.add("hidden"); // the game is live; Start no longer applies
+    $("post-game-bar").classList.add("hidden"); // a rematch just began; the next GameStateUpdated takes over
+    $("rematch-btn").classList.add("hidden");
     return; // game state pushes take over from here
+  }
+  if (metadata.status === "Finished") {
+    onMatchFinished(metadata);
+    return;
   }
 
   const count = Object.keys(metadata.players).length;
@@ -382,6 +391,27 @@ function onLobbyUpdated(metadata) {
     $("start-game").classList.add("hidden");
     setStatus(`Hosted by ${hostName} — waiting for them to start… (${count}/${max})`);
   }
+}
+
+// The room's match has ended but the room survives: keep the final board on screen, surface a rematch bar, and let
+// the host start again. The guest sees a wait message; both keep chatting via the still-live ChatMessage stream.
+function onMatchFinished(metadata) {
+  const youHost = Boolean(session.me) && metadata.hostId === session.me.id;
+  session.game.isHost = youHost;
+
+  const series = metadata.matchCount > 1 ? ` (match ${metadata.matchCount})` : "";
+  $("post-game-status").textContent = youHost
+    ? `Game over${series}. Start a rematch when you're ready.`
+    : `Game over${series}. Waiting for the host to start a rematch…`;
+  $("rematch-btn").classList.toggle("hidden", !youHost);
+  $("post-game-bar").classList.remove("hidden");
+}
+
+async function rematch() {
+  setError("game-error", "");
+  const res = await api(`/lobby/${session.game.gameId}/start`, { method: "POST", body: {} });
+  if (!res.ok) flashError("game-error", res.data?.error || res.data || "Could not start the rematch");
+  // On success a fresh GameStateUpdated arrives over the WebSocket and clears the post-game bar.
 }
 
 async function startGame() {
@@ -444,6 +474,8 @@ function sendChat(text) {
 function renderBoard(state) {
   const board = $("board");
   $("start-game").classList.add("hidden"); // a live board means the game has started; Start no longer applies
+  $("post-game-bar").classList.add("hidden"); // a fresh board (e.g. a rematch) supersedes the prior match's post-game bar
+  $("rematch-btn").classList.add("hidden");
   setError("game-error", ""); // the state changed, so any prior move error (e.g. "not your turn") is now stale
   const rows = state.board;
   const cols = rows[0] ? rows[0].length : 0;
@@ -629,6 +661,7 @@ $("refresh-lobbies").addEventListener("click", () => {
 });
 $("lobby-filter").addEventListener("change", refreshLobbies);
 $("start-game").addEventListener("click", startGame);
+$("rematch-btn").addEventListener("click", rematch);
 $("back-to-lobby").addEventListener("click", enterLobby); // browse the lobby without leaving the current game
 $("leave-game").addEventListener("click", leaveGame);
 $("copy-link").addEventListener("click", copyInviteLink);

--- a/game-service-server/src/main/resources/web/index.html
+++ b/game-service-server/src/main/resources/web/index.html
@@ -78,6 +78,11 @@
     <!-- Drop buttons for column-based games (Connect Four); empty (and hidden) for cell-click games. -->
     <div id="column-controls"></div>
     <div id="board"></div>
+    <!-- Shown once a match in this room has finished; offers a rematch (host) or a wait message (guest). -->
+    <div id="post-game-bar" class="row hidden">
+      <span id="post-game-status" class="status"></span>
+      <button id="rematch-btn" class="hidden">Rematch</button>
+    </div>
     <div class="row">
       <button id="back-to-lobby">← Lobby</button>
       <button id="start-game" class="hidden">Start game</button>

--- a/game-service-server/src/main/scala/com/andy327/server/analytics/GameEventCodecs.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/analytics/GameEventCodecs.scala
@@ -5,7 +5,7 @@ import io.circe.{Decoder, Encoder, Json}
 
 import com.andy327.actor.events.GameEvent
 import com.andy327.actor.events.GameEvent._
-import com.andy327.model.core.{GameId, GameType, PlayerId}
+import com.andy327.model.core.{GameType, MatchId, PlayerId, RoomId}
 import com.andy327.persistence.db.schema.GameTypeCodecs.gameTypeCodec
 
 /** Circe codecs for `GameEvent` and its `GameEvent.Outcome`, used only at the edge: to put events
@@ -24,33 +24,33 @@ object GameEventCodecs {
     * [[com.andy327.server.http.json.JsonProtocol.playerEventEncoder]].
     */
   implicit val encoder: Encoder[GameEvent] = Encoder.instance {
-    case GameStarted(gameId, gameType, playerCount) =>
+    case GameStarted(matchId, gameType, playerCount) =>
       Json.obj(
         "type" -> "GameStarted".asJson,
-        "gameId" -> gameId.asJson,
+        "matchId" -> matchId.asJson,
         "gameType" -> gameType.asJson,
         "playerCount" -> playerCount.asJson
       )
-    case MoveMade(gameId, gameType, playerId, seq) =>
+    case MoveMade(matchId, gameType, playerId, seq) =>
       Json.obj(
         "type" -> "MoveMade".asJson,
-        "gameId" -> gameId.asJson,
+        "matchId" -> matchId.asJson,
         "gameType" -> gameType.asJson,
         "playerId" -> playerId.asJson,
         "seq" -> seq.asJson
       )
-    case GameCompleted(gameId, gameType, outcome, moveCount) =>
+    case GameCompleted(matchId, gameType, outcome, moveCount) =>
       Json.obj(
         "type" -> "GameCompleted".asJson,
-        "gameId" -> gameId.asJson,
+        "matchId" -> matchId.asJson,
         "gameType" -> gameType.asJson,
         "outcome" -> outcome.asJson,
         "moveCount" -> moveCount.asJson
       )
-    case ChatSent(gameId, gameType) =>
+    case ChatSent(roomId, gameType) =>
       Json.obj(
         "type" -> "ChatSent".asJson,
-        "gameId" -> gameId.asJson,
+        "roomId" -> roomId.asJson,
         "gameType" -> gameType.asJson
       )
   }
@@ -59,29 +59,29 @@ object GameEventCodecs {
     c.get[String]("type").flatMap {
       case "GameStarted" =>
         for {
-          gameId <- c.get[GameId]("gameId")
+          matchId <- c.get[MatchId]("matchId")
           gameType <- c.get[GameType]("gameType")
           playerCount <- c.get[Int]("playerCount")
-        } yield GameStarted(gameId, gameType, playerCount)
+        } yield GameStarted(matchId, gameType, playerCount)
       case "MoveMade" =>
         for {
-          gameId <- c.get[GameId]("gameId")
+          matchId <- c.get[MatchId]("matchId")
           gameType <- c.get[GameType]("gameType")
           playerId <- c.get[PlayerId]("playerId")
           seq <- c.get[Int]("seq")
-        } yield MoveMade(gameId, gameType, playerId, seq)
+        } yield MoveMade(matchId, gameType, playerId, seq)
       case "GameCompleted" =>
         for {
-          gameId <- c.get[GameId]("gameId")
+          matchId <- c.get[MatchId]("matchId")
           gameType <- c.get[GameType]("gameType")
           outcome <- c.get[Outcome]("outcome")
           moveCount <- c.get[Int]("moveCount")
-        } yield GameCompleted(gameId, gameType, outcome, moveCount)
+        } yield GameCompleted(matchId, gameType, outcome, moveCount)
       case "ChatSent" =>
         for {
-          gameId <- c.get[GameId]("gameId")
+          roomId <- c.get[RoomId]("roomId")
           gameType <- c.get[Option[GameType]]("gameType")
-        } yield ChatSent(gameId, gameType)
+        } yield ChatSent(roomId, gameType)
       case other =>
         Left(io.circe.DecodingFailure(s"Unknown GameEvent type: $other", c.history))
     }

--- a/game-service-server/src/main/scala/com/andy327/server/http/auth/PlayerHistoryResponse.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/auth/PlayerHistoryResponse.scala
@@ -2,19 +2,19 @@ package com.andy327.server.http.auth
 
 import java.time.Instant
 
-import com.andy327.model.core.{GameId, GameType}
+import com.andy327.model.core.{GameType, MatchId}
 import com.andy327.persistence.db.PlayerHistoryRepository.GameResult
 
 /** One completed game in a player's history, as returned by `GET /players/me/history`.
   *
-  * @param gameId the completed game
+  * @param matchId the completed match
   * @param gameType the kind of game played
   * @param result how the game turned out for the requesting player
   * @param forfeit true when the result was reached by a player leaving rather than normal play
   * @param finishedAt when the game completed
   */
 case class PlayerGameSummary(
-    gameId: GameId,
+    matchId: MatchId,
     gameType: GameType,
     result: GameResult,
     forfeit: Boolean,

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/ClientMessage.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/ClientMessage.scala
@@ -2,7 +2,7 @@ package com.andy327.server.http.json
 
 import io.circe.{Decoder, DecodingFailure}
 
-import com.andy327.model.core.GameId
+import com.andy327.model.core.RoomId
 
 /** A message a connected client sends to the server over the WebSocket.
   *
@@ -13,17 +13,17 @@ sealed trait ClientMessage
 
 object ClientMessage {
 
-  /** Post `text` to the chat thread of the match identified by `gameId`. */
-  final case class ChatSend(gameId: GameId, text: String) extends ClientMessage
+  /** Post `text` to the chat thread of the room identified by `roomId`. */
+  final case class ChatSend(roomId: RoomId, text: String) extends ClientMessage
 
   /** Decodes a client frame by its `type` field; fails for unknown or malformed frames. */
   implicit val decoder: Decoder[ClientMessage] = Decoder.instance { cursor =>
     cursor.get[String]("type").flatMap {
       case "ChatSend" =>
         for {
-          gameId <- cursor.get[GameId]("gameId")
+          roomId <- cursor.get[RoomId]("roomId")
           text <- cursor.get[String]("text")
-        } yield ChatSend(gameId, text)
+        } yield ChatSend(roomId, text)
       case other =>
         Left(DecodingFailure(s"Unknown client message type: $other", cursor.history))
     }

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -141,15 +141,15 @@ object JsonProtocol extends CirceSupport {
     * Each variant is encoded as a JSON object with a `type` discriminator field so the client can dispatch on the event
     * kind without additional out-of-band information:
     *   - `{"type":"LobbyUpdated",     "metadata":{...}}`
-    *   - `{"type":"GameStateUpdated", "state":{...}}`
+    *   - `{"type":"GameStateUpdated", "roomId":..., "state":{...}}`
     *   - `{"type":"GameEnded",        "result":"Completed"}`
     *   - `{"type":"ChatMessage",      "gameId":..., "senderId":..., "senderName":..., "text":..., "sentAt":...}`
     */
   implicit val playerEventEncoder: Encoder[PlayerEvent] = Encoder.instance {
     case PlayerEvent.LobbyUpdated(metadata) =>
       Json.obj("type" -> "LobbyUpdated".asJson, "metadata" -> metadata.asJson)
-    case PlayerEvent.GameStateUpdated(state) =>
-      Json.obj("type" -> "GameStateUpdated".asJson, "state" -> state.asJson)
+    case PlayerEvent.GameStateUpdated(roomId, state) =>
+      Json.obj("type" -> "GameStateUpdated".asJson, "roomId" -> roomId.asJson, "state" -> state.asJson)
     case PlayerEvent.GameEnded(result) =>
       Json.obj("type" -> "GameEnded".asJson, "result" -> (result: GameLifecycleStatus).asJson)
     case PlayerEvent.ChatMessage(gameId, senderId, senderName, text, sentAt) =>

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -143,7 +143,7 @@ object JsonProtocol extends CirceSupport {
     *   - `{"type":"LobbyUpdated",     "metadata":{...}}`
     *   - `{"type":"GameStateUpdated", "roomId":..., "state":{...}}`
     *   - `{"type":"GameEnded",        "result":"Completed"}`
-    *   - `{"type":"ChatMessage",      "gameId":..., "senderId":..., "senderName":..., "text":..., "sentAt":...}`
+    *   - `{"type":"ChatMessage",      "roomId":..., "senderId":..., "senderName":..., "text":..., "sentAt":...}`
     */
   implicit val playerEventEncoder: Encoder[PlayerEvent] = Encoder.instance {
     case PlayerEvent.LobbyUpdated(metadata) =>
@@ -152,10 +152,10 @@ object JsonProtocol extends CirceSupport {
       Json.obj("type" -> "GameStateUpdated".asJson, "roomId" -> roomId.asJson, "state" -> state.asJson)
     case PlayerEvent.GameEnded(result) =>
       Json.obj("type" -> "GameEnded".asJson, "result" -> (result: GameLifecycleStatus).asJson)
-    case PlayerEvent.ChatMessage(gameId, senderId, senderName, text, sentAt) =>
+    case PlayerEvent.ChatMessage(roomId, senderId, senderName, text, sentAt) =>
       Json.obj(
         "type" -> "ChatMessage".asJson,
-        "gameId" -> gameId.asJson,
+        "roomId" -> roomId.asJson,
         "senderId" -> senderId.asJson,
         "senderName" -> senderName.asJson,
         "text" -> text.asJson,

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/GameRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/GameRoutes.scala
@@ -42,12 +42,12 @@ import com.andy327.server.http.routes.RouteDirectives._
   * are dynamically decoded using the game-specific `MovePayload` decoder from the `GameRegistry`.
   *
   * Route Summary:
-  *   - POST /{gameType}/{gameId}/move - Submit a move to the specified game
-  *   - GET /{gameType}/{gameId}/status - Fetch the current state of a game
-  *   - GET /{gameType}/{gameId}/history - Fetch the ordered move history for a game
-  *   - GET /{gameType}/{gameId}/chat - Fetch the recent chat history (backscroll) for a game
-  *   - POST /{gameType}/{gameId}/subscribe - Start spectating a game (push events over the player's WebSocket)
-  *   - DELETE /{gameType}/{gameId}/subscribe - Stop spectating a game
+  *   - POST /{gameType}/{roomId}/move - Submit a move to the specified game
+  *   - GET /{gameType}/{roomId}/status - Fetch the current state of a game
+  *   - GET /{gameType}/{roomId}/history - Fetch the ordered move history for a game
+  *   - GET /{gameType}/{roomId}/chat - Fetch the recent chat history (backscroll) for a game
+  *   - POST /{gameType}/{roomId}/subscribe - Start spectating a game (push events over the player's WebSocket)
+  *   - DELETE /{gameType}/{roomId}/subscribe - Stop spectating a game
   */
 class GameRoutes(gameType: GameType, system: ActorSystem[Command]) {
   implicit val scheduler: Scheduler = system.scheduler
@@ -82,14 +82,14 @@ class GameRoutes(gameType: GameType, system: ActorSystem[Command]) {
 
   val routes: Route = pathPrefix(gameTypePrefix) {
 
-    pathPrefix(Segment) { gameIdStr =>
-      parseGameId(gameIdStr) { gameId =>
+    pathPrefix(Segment) { roomIdStr =>
+      parseRoomId(roomIdStr) { roomId =>
         /** Submits a move to the specified game using the authenticated player's ID.
           *
           * The move payload format is game-specific and decoded dynamically via the `GameRegistry`.
           *
           * - Auth: Bearer token required
-          * - Path: `gameId` — the UUID of the active game
+          * - Path: `roomId` — the UUID of the active game
           * - Body: game-specific `MovePayload` JSON (structure depends on game type)
           * - 200: updated game state after the move is applied
           * - 400: invalid UUID format, or malformed/invalid JSON payload
@@ -105,9 +105,9 @@ class GameRoutes(gameType: GameType, system: ActorSystem[Command]) {
                 onSuccess(decodeJsonEntity(module.moveDecoder)(req)) {
                   case Right(move) =>
                     val op = GameOperation.MakeMove(player.id, move)
-                    onSuccess(system.ask[GameResponse](GameManager.RunGameOperation(gameId, op, _))) {
+                    onSuccess(system.ask[GameResponse](GameManager.RunGameOperation(roomId, op, _))) {
                       case GameStatus(state)  => complete(state)
-                      case GameNotFound(id)   => complete(StatusCodes.NotFound -> s"No game found with gameId $id")
+                      case GameNotFound(id)   => complete(StatusCodes.NotFound -> s"No game found for room $id")
                       case MoveRejected(msg)  => complete(StatusCodes.Conflict -> msg)
                       case ErrorResponse(msg) => complete(StatusCodes.InternalServerError -> msg)
                       case unknown => complete(StatusCodes.InternalServerError -> s"Unexpected response: $unknown")
@@ -122,7 +122,7 @@ class GameRoutes(gameType: GameType, system: ActorSystem[Command]) {
         } ~
         /** Fetches the current state of the specified game.
           *
-          * - Path: `gameId` — the UUID of the game to check
+          * - Path: `roomId` — the UUID of the game to check
           * - 200: current game state
           * - 400: invalid UUID format
           * - 404: game not found
@@ -130,9 +130,9 @@ class GameRoutes(gameType: GameType, system: ActorSystem[Command]) {
           */
         path("status") {
           get {
-            onSuccess(system.ask[GameResponse](GameManager.RunGameOperation(gameId, GameOperation.GetState, _))) {
+            onSuccess(system.ask[GameResponse](GameManager.RunGameOperation(roomId, GameOperation.GetState, _))) {
               case GameStatus(state)  => complete(state)
-              case GameNotFound(id)   => complete(StatusCodes.NotFound -> s"No game found with gameId $id")
+              case GameNotFound(id)   => complete(StatusCodes.NotFound -> s"No game found for room $id")
               case MoveRejected(msg)  => complete(StatusCodes.Conflict -> msg)
               case ErrorResponse(msg) => complete(StatusCodes.InternalServerError -> msg)
               case unknown            => complete(StatusCodes.InternalServerError -> s"Unexpected response: $unknown")
@@ -144,14 +144,14 @@ class GameRoutes(gameType: GameType, system: ActorSystem[Command]) {
           * Served from the move log, so it works for both active and finished games (and returns an empty list for a
           * game with no recorded moves).
           *
-          * - Path: `gameId` — the UUID of the game
+          * - Path: `roomId` — the UUID of the game
           * - 200: `MoveHistory` — the ordered list of moves played
           * - 400: invalid UUID format
           * - 500: unexpected error
           */
         path("history") {
           get {
-            onSuccess(system.ask[GameResponse](GameManager.GetMoveHistory(gameId, _))) {
+            onSuccess(system.ask[GameResponse](GameManager.GetMoveHistory(roomId, _))) {
               case history: MoveHistory => complete(history)
               case ErrorResponse(msg)   => complete(StatusCodes.InternalServerError -> msg)
               case unknown              => complete(StatusCodes.InternalServerError -> s"Unexpected response: $unknown")
@@ -163,14 +163,14 @@ class GameRoutes(gameType: GameType, system: ActorSystem[Command]) {
           * Served from the chat store, so it works for both active and finished games (and returns an empty list for a
           * game with no recorded messages). Live chat continues to arrive over the WebSocket.
           *
-          * - Path: `gameId` — the UUID of the game
+          * - Path: `roomId` — the UUID of the game
           * - 200: `ChatHistory` — the recent messages, oldest first
           * - 400: invalid UUID format
           * - 500: unexpected error
           */
         path("chat") {
           get {
-            onSuccess(system.ask[GameResponse](GameManager.GetChatHistory(gameId, _))) {
+            onSuccess(system.ask[GameResponse](GameManager.GetChatHistory(roomId, _))) {
               case history: ChatHistory => complete(history)
               case ErrorResponse(msg)   => complete(StatusCodes.InternalServerError -> msg)
               case unknown              => complete(StatusCodes.InternalServerError -> s"Unexpected response: $unknown")
@@ -182,7 +182,7 @@ class GameRoutes(gameType: GameType, system: ActorSystem[Command]) {
           * The player must have an active WebSocket connection established before calling this endpoint.
           *
           * - Auth: Bearer token required
-          * - Path: `gameId` — the UUID of the active game to observe
+          * - Path: `roomId` — the UUID of the active game to observe
           * - 200: `SubscribeAcknowledged` confirming the subscription was registered
           * - 400: invalid UUID format, player has no active WebSocket connection, or game is not active
           * - 401: missing or invalid token
@@ -191,7 +191,7 @@ class GameRoutes(gameType: GameType, system: ActorSystem[Command]) {
         path("subscribe") {
           post {
             authenticatePlayer { player =>
-              onSuccess(system.ask[GameResponse](GameManager.SubscribePlayerToGame(gameId, player.id, _))) {
+              onSuccess(system.ask[GameResponse](GameManager.SubscribePlayerToGame(roomId, player.id, _))) {
                 case ack: SubscribeAcknowledged => complete(ack)
                 case ErrorResponse(msg)         => complete(StatusCodes.BadRequest -> msg)
                 case unknown => complete(StatusCodes.InternalServerError -> s"Unexpected response: $unknown")
@@ -204,7 +204,7 @@ class GameRoutes(gameType: GameType, system: ActorSystem[Command]) {
             * can call it without tracking its own subscription state.
             *
             * - Auth: Bearer token required
-            * - Path: `gameId` — the UUID of the game to stop observing
+            * - Path: `roomId` — the UUID of the game to stop observing
             * - 200: `UnsubscribeAcknowledged` confirming the subscription was removed
             * - 400: invalid UUID format
             * - 401: missing or invalid token
@@ -212,7 +212,7 @@ class GameRoutes(gameType: GameType, system: ActorSystem[Command]) {
             */
           delete {
             authenticatePlayer { player =>
-              onSuccess(system.ask[GameResponse](GameManager.UnsubscribePlayerFromGame(gameId, player.id, _))) {
+              onSuccess(system.ask[GameResponse](GameManager.UnsubscribePlayerFromGame(roomId, player.id, _))) {
                 case ack: UnsubscribeAcknowledged => complete(ack)
                 case unknown => complete(StatusCodes.InternalServerError -> s"Unexpected response: $unknown")
               }

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/LobbyRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/LobbyRoutes.scala
@@ -39,13 +39,13 @@ import com.andy327.server.http.routes.RouteDirectives._
   * Route Summary:
   *   - POST /lobby/create/{gameType} - Create a new lobby for a specific game type
   *   - GET /lobby/list - List all available open lobbies
-  *   - GET /lobby/{gameId} - Fetch metadata for a specific lobby
-  *   - POST /lobby/{gameId}/join - Join an existing lobby
-  *   - POST /lobby/{gameId}/leave - Leave a lobby (or forfeit an in-progress game)
-  *   - POST /lobby/{gameId}/start - Start a game from a lobby (host only)
-  *   - DELETE /lobby/{gameId} - Cancel a pre-game lobby (host only)
-  *   - POST /lobby/{gameId}/subscribe - Start spectating a lobby (push events over the player's WebSocket)
-  *   - DELETE /lobby/{gameId}/subscribe - Stop spectating a lobby
+  *   - GET /lobby/{roomId} - Fetch metadata for a specific lobby
+  *   - POST /lobby/{roomId}/join - Join an existing lobby
+  *   - POST /lobby/{roomId}/leave - Leave a lobby (or forfeit an in-progress game)
+  *   - POST /lobby/{roomId}/start - Start a game from a lobby (host only)
+  *   - DELETE /lobby/{roomId} - Cancel a pre-game lobby (host only)
+  *   - POST /lobby/{roomId}/subscribe - Start spectating a lobby (push events over the player's WebSocket)
+  *   - DELETE /lobby/{roomId}/subscribe - Stop spectating a lobby
   */
 class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
   implicit val timeout: Timeout = 3.seconds
@@ -111,11 +111,11 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
         }
       }
     } ~
-    pathPrefix(Segment) { gameIdStr =>
-      parseGameId(gameIdStr) { gameId =>
+    pathPrefix(Segment) { roomIdStr =>
+      parseRoomId(roomIdStr) { roomId =>
         /** Fetches metadata for a specific lobby.
           *
-          * - Path: `gameId` — the UUID of the lobby to retrieve
+          * - Path: `roomId` — the UUID of the lobby to retrieve
           * - 200: `LobbyMetadata` for the specified lobby
           * - 400: invalid UUID format
           * - 404: lobby not found
@@ -123,7 +123,7 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
           */
         pathEndOrSingleSlash {
           get {
-            onSuccess(system.ask[GameResponse](replyTo => GameManager.GetLobbyInfo(gameId, replyTo))) {
+            onSuccess(system.ask[GameResponse](replyTo => GameManager.GetLobbyInfo(roomId, replyTo))) {
               case LobbyInfo(metadata)       => complete(metadata)
               case LobbyErrorResponse(error) => complete(statusFor(error) -> error.message)
               case other => complete(StatusCodes.InternalServerError -> s"Unexpected response: $other")
@@ -133,7 +133,7 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
             * receive a `GameEnded(Cancelled)` push). This is the explicit counterpart to a host leaving via `/leave`.
             *
             * - Auth: Bearer token required
-            * - Path: `gameId` — the UUID of the lobby to cancel
+            * - Path: `roomId` — the UUID of the lobby to cancel
             * - 200: `LobbyLeft` with the game ID and a status message
             * - 400: invalid UUID format
             * - 401: missing or invalid token
@@ -144,7 +144,7 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
             */
           delete {
             authenticatePlayer { player =>
-              onSuccess(system.ask[GameResponse](replyTo => GameManager.CancelLobby(gameId, player.id, replyTo))) {
+              onSuccess(system.ask[GameResponse](replyTo => GameManager.CancelLobby(roomId, player.id, replyTo))) {
                 case left @ LobbyLeft(_, _)    => complete(left)
                 case LobbyErrorResponse(error) => complete(statusFor(error) -> error.message)
                 case other => complete(StatusCodes.InternalServerError -> s"Unexpected response: $other")
@@ -155,7 +155,7 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
         /** Joins an existing lobby using the authenticated player.
           *
           * - Auth: Bearer token required
-          * - Path: `gameId` — the UUID of the lobby to join
+          * - Path: `roomId` — the UUID of the lobby to join
           * - 200: `LobbyJoined` with metadata for the joined lobby
           * - 400: invalid UUID format
           * - 401: missing or invalid token
@@ -166,7 +166,7 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
         path("join") {
           post {
             authenticatePlayer { player =>
-              onSuccess(system.ask[GameResponse](replyTo => GameManager.JoinLobby(gameId, player, replyTo))) {
+              onSuccess(system.ask[GameResponse](replyTo => GameManager.JoinLobby(roomId, player, replyTo))) {
                 case joined: LobbyJoined       => complete(joined)
                 case LobbyErrorResponse(error) => complete(statusFor(error) -> error.message)
                 case other => complete(StatusCodes.InternalServerError -> s"Unexpected response: $other")
@@ -178,10 +178,10 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
           *
           * If the host leaves a pre-game lobby with other members present, the host role migrates to a remaining member
           * and the lobby stays open; it is cancelled only if the host was the last player. To deliberately end a lobby,
-          * the host uses `DELETE /lobby/{gameId}` instead.
+          * the host uses `DELETE /lobby/{roomId}` instead.
           *
           * - Auth: Bearer token required
-          * - Path: `gameId` — the UUID of the lobby to leave
+          * - Path: `roomId` — the UUID of the lobby to leave
           * - 200: `LobbyLeft` (pre-game leave) with the game ID and a status message, or the leaver's final game
           *   state if the game was in progress (leaving forfeits it — the opponent wins)
           * - 400: invalid UUID format
@@ -193,7 +193,7 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
         path("leave") {
           post {
             authenticatePlayer { player =>
-              onSuccess(system.ask[GameResponse](replyTo => GameManager.LeaveLobby(gameId, player, replyTo))) {
+              onSuccess(system.ask[GameResponse](replyTo => GameManager.LeaveLobby(roomId, player, replyTo))) {
                 case left @ LobbyLeft(_, _)    => complete(left)
                 case GameForfeited(_, state)   => complete(state)
                 case MoveRejected(msg)         => complete(StatusCodes.Conflict -> msg)
@@ -206,7 +206,7 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
         /** Starts the game from the given lobby. Only the host may call this endpoint.
           *
           * - Auth: Bearer token required
-          * - Path: `gameId` — the UUID of the lobby to start
+          * - Path: `roomId` — the UUID of the lobby to start
           * - 200: `GameStarted` with the game ID
           * - 400: invalid UUID format
           * - 401: missing or invalid token
@@ -218,7 +218,7 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
         path("start") {
           post {
             authenticatePlayer { player =>
-              onSuccess(system.ask[GameResponse](replyTo => GameManager.StartGame(gameId, player.id, replyTo))) {
+              onSuccess(system.ask[GameResponse](replyTo => GameManager.StartGame(roomId, player.id, replyTo))) {
                 case gs @ GameStarted(_)       => complete(gs)
                 case LobbyErrorResponse(error) => complete(statusFor(error) -> error.message)
                 case other => complete(StatusCodes.InternalServerError -> s"Unexpected response: $other")
@@ -231,7 +231,7 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
           * The player must have an active WebSocket connection established before calling this endpoint.
           *
           * - Auth: Bearer token required
-          * - Path: `gameId` — the UUID of the lobby to observe
+          * - Path: `roomId` — the UUID of the lobby to observe
           * - 200: `SubscribeAcknowledged` confirming the subscription was registered
           * - 400: invalid UUID format, or player has no active WebSocket connection
           * - 401: missing or invalid token
@@ -243,7 +243,7 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
           post {
             authenticatePlayer { player =>
               onSuccess(
-                system.ask[GameResponse](replyTo => GameManager.SubscribePlayerToLobby(gameId, player.id, replyTo))
+                system.ask[GameResponse](replyTo => GameManager.SubscribePlayerToLobby(roomId, player.id, replyTo))
               ) {
                 case ack: SubscribeAcknowledged => complete(ack)
                 case ErrorResponse(msg)         => complete(StatusCodes.BadRequest -> msg)
@@ -257,7 +257,7 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
             * Idempotent — succeeds whether or not the player was subscribed.
             *
             * - Auth: Bearer token required
-            * - Path: `gameId` — the UUID of the lobby to stop observing
+            * - Path: `roomId` — the UUID of the lobby to stop observing
             * - 200: `UnsubscribeAcknowledged` confirming the subscription was removed
             * - 400: invalid UUID format
             * - 401: missing or invalid token
@@ -266,7 +266,7 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
           delete {
             authenticatePlayer { player =>
               onSuccess(
-                system.ask[GameResponse](replyTo => GameManager.UnsubscribePlayerFromLobby(gameId, player.id, replyTo))
+                system.ask[GameResponse](replyTo => GameManager.UnsubscribePlayerFromLobby(roomId, player.id, replyTo))
               ) {
                 case ack: UnsubscribeAcknowledged => complete(ack)
                 case other => complete(StatusCodes.InternalServerError -> s"Unexpected response: $other")

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/PlayerRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/PlayerRoutes.scala
@@ -72,7 +72,7 @@ class PlayerRoutes(
       get {
         authenticatePlayer { player =>
           onSuccess(playerHistoryRepo.findByPlayer(player.id).unsafeToFuture()) { records =>
-            val games = records.map(r => PlayerGameSummary(r.gameId, r.gameType, r.result, r.forfeit, r.finishedAt))
+            val games = records.map(r => PlayerGameSummary(r.matchId, r.gameType, r.result, r.forfeit, r.finishedAt))
             complete(PlayerHistory(games))
           }
         }

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/RouteDirectives.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/RouteDirectives.scala
@@ -8,7 +8,7 @@ import org.apache.pekko.http.scaladsl.model.StatusCodes
 import org.apache.pekko.http.scaladsl.server.Directives._
 import org.apache.pekko.http.scaladsl.server._
 
-import com.andy327.model.core.{GameId, GameType}
+import com.andy327.model.core.{GameType, RoomId}
 
 /** Common HTTP route directives for parsing and validating parameters such as UUIDs and GameTypes.
   *
@@ -18,21 +18,22 @@ import com.andy327.model.core.{GameId, GameType}
   *
   * Example use:
   * {{{
-  *   pathPrefix(Segment) { gameIdStr =>
-  *     parseGameId(gameIdStr) { gameId =>
-  *       // gameId is safely typed as UUID
+  *   pathPrefix(Segment) { roomIdStr =>
+  *     parseRoomId(roomIdStr) { roomId =>
+  *       // roomId is safely typed as UUID
   *     }
   *   }
   * }}}
   */
 object RouteDirectives {
 
-  /** Parses a game ID/UUID from a provided string, returning a Directive1 if valid. If invalid, responds with HTTP 400.
+  /** Parses a room ID/UUID from a provided string, returning a Directive1 if valid. If invalid, responds with HTTP
+    * 400.
     */
-  def parseGameId(idStr: String): Directive1[GameId] =
+  def parseRoomId(idStr: String): Directive1[RoomId] =
     Try(UUID.fromString(idStr)).toOption match {
       case Some(uuid) => provide(uuid)
-      case None       => complete(StatusCodes.BadRequest -> s"Invalid UUID for game ID: $idStr")
+      case None       => complete(StatusCodes.BadRequest -> s"Invalid UUID for room ID: $idStr")
     }
 
   /** Parses a GameType from a provided string, returning a Directive1 if valid. If invalid, responds with HTTP 400. */

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/WebSocketRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/WebSocketRoutes.scala
@@ -59,8 +59,8 @@ class WebSocketRoutes(gameManager: ActorSystem[GameManager.Command]) {
   /** Decode one inbound client frame and act on it; malformed frames are logged and ignored. */
   private def handleInbound(player: Player)(text: String): Unit =
     decode[ClientMessage](text) match {
-      case Right(ClientMessage.ChatSend(gameId, body)) =>
-        gameManager ! GameManager.SendChat(gameId, player, body)
+      case Right(ClientMessage.ChatSend(roomId, body)) =>
+        gameManager ! GameManager.SendChat(roomId, player, body)
       case Left(err) =>
         logger.warn(s"Ignoring unparseable client message from ${player.id}: ${err.getMessage}")
     }

--- a/game-service-server/src/test/scala/com/andy327/server/GameServerSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/GameServerSpec.scala
@@ -18,7 +18,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 import com.andy327.actor.core.GameManager
 import com.andy327.actor.lobby.{LobbyMetadata, LobbyRepository, Player}
-import com.andy327.model.core.{Game, GameId, GameType, PlayerId}
+import com.andy327.model.core.{Game, GameType, MatchId, PlayerId, RoomId}
 import com.andy327.persistence.db.{GameRepository, MoveHistoryRepository, MoveRecord}
 import com.andy327.server.http.json.JsonProtocol._
 import com.andy327.server.testutil.AuthTestHelper.createTestToken
@@ -29,23 +29,23 @@ class GameServerSpec extends AnyWordSpec with Matchers {
 
   private val noOpLobbyRepo: LobbyRepository = new LobbyRepository {
     override def saveLobby(metadata: LobbyMetadata): IO[Unit] = IO.unit
-    override def deleteLobby(gameId: GameId): IO[Unit] = IO.unit
+    override def deleteLobby(roomId: RoomId): IO[Unit] = IO.unit
     override def loadAllLobbies(): IO[List[LobbyMetadata]] = IO.pure(Nil)
   }
 
   private val noOpMoveRepo: MoveHistoryRepository = new MoveHistoryRepository {
     override def initialize(): IO[Unit] = IO.unit
-    override def appendMove(gameId: GameId, seq: Int, playerId: PlayerId, move: Json): IO[Unit] = IO.unit
-    override def loadMoves(gameId: GameId): IO[List[MoveRecord]] = IO.pure(Nil)
+    override def appendMove(matchId: MatchId, seq: Int, playerId: PlayerId, move: Json): IO[Unit] = IO.unit
+    override def loadMoves(matchId: MatchId): IO[List[MoveRecord]] = IO.pure(Nil)
   }
 
   "GameServer" should {
     "start and respond to /tictactoe" in {
       val dummyRepo = new GameRepository {
         def initialize(): IO[Unit] = IO.unit
-        def loadGame(gameId: GameId, tpe: GameType): IO[Option[Game[_, _, _, _, _]]] = IO.pure(None)
-        def saveGame(gameId: GameId, gameType: GameType, game: Game[_, _, _, _, _]): IO[Unit] = IO.unit
-        def loadAllGames(): IO[Map[GameId, (GameType, Game[_, _, _, _, _])]] = IO.pure(Map.empty)
+        def loadGame(matchId: MatchId, tpe: GameType): IO[Option[Game[_, _, _, _, _]]] = IO.pure(None)
+        def saveGame(matchId: MatchId, gameType: GameType, game: Game[_, _, _, _, _]): IO[Unit] = IO.unit
+        def loadAllGames(): IO[Map[MatchId, (GameType, Game[_, _, _, _, _])]] = IO.pure(Map.empty)
       }
 
       val (system, binding) =
@@ -66,13 +66,13 @@ class GameServerSpec extends AnyWordSpec with Matchers {
           uri = s"http://localhost:$actualPort/lobby/create/tictactoe"
         ).withHeaders(player1Header)
         val createLobbyResp = Await.result(Http()(classicSystem).singleRequest(createLobbyReq), 2.seconds)
-        val gameId = Await.result(Unmarshal(createLobbyResp.entity).to[GameManager.LobbyCreated], 2.seconds).gameId
+        val roomId = Await.result(Unmarshal(createLobbyResp.entity).to[GameManager.LobbyCreated], 2.seconds).roomId
         createLobbyResp.status shouldBe StatusCodes.OK
 
         // Join lobby with player 2
         val joinLobbyReq = HttpRequest(
           method = HttpMethods.POST,
-          uri = s"http://localhost:$actualPort/lobby/$gameId/join"
+          uri = s"http://localhost:$actualPort/lobby/$roomId/join"
         ).withHeaders(player2Header)
         val joinLobbyResp = Await.result(Http()(classicSystem).singleRequest(joinLobbyReq), 2.seconds)
         joinLobbyResp.status shouldBe StatusCodes.OK
@@ -80,13 +80,13 @@ class GameServerSpec extends AnyWordSpec with Matchers {
         // Start the game from the lobby (initiated by the host)
         val startGameReq = HttpRequest(
           method = HttpMethods.POST,
-          uri = s"http://localhost:$actualPort/lobby/$gameId/start"
+          uri = s"http://localhost:$actualPort/lobby/$roomId/start"
         ).withHeaders(player1Header)
         val startResp = Await.result(Http()(classicSystem).singleRequest(startGameReq), 2.seconds)
         startResp.status shouldBe StatusCodes.OK
 
         val startGameResp = Await.result(Unmarshal(startResp.entity).to[GameManager.GameStarted], 2.seconds)
-        startGameResp.gameId shouldBe gameId
+        startGameResp.roomId shouldBe roomId
       } finally {
         Await.result(binding.unbind(), 5.seconds)
         system.terminate()

--- a/game-service-server/src/test/scala/com/andy327/server/analytics/GameMetricsSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/analytics/GameMetricsSpec.scala
@@ -32,10 +32,10 @@ class GameMetricsSpec extends AnyWordSpec with Matchers {
 
     "count moves and record the per-game move distribution on completion" in {
       val (registry, metrics) = fixture
-      val gameId = UUID.randomUUID()
-      metrics.record(MoveMade(gameId, GameType.TicTacToe, UUID.randomUUID(), 0))
-      metrics.record(MoveMade(gameId, GameType.TicTacToe, UUID.randomUUID(), 1))
-      metrics.record(GameCompleted(gameId, GameType.TicTacToe, Outcome.Won, 9))
+      val matchId = UUID.randomUUID()
+      metrics.record(MoveMade(matchId, GameType.TicTacToe, UUID.randomUUID(), 0))
+      metrics.record(MoveMade(matchId, GameType.TicTacToe, UUID.randomUUID(), 1))
+      metrics.record(GameCompleted(matchId, GameType.TicTacToe, Outcome.Won, 9))
 
       sample(registry, "moves_total", Array("game_type"), Array("tictactoe")) shouldBe Some(2.0)
       sample(registry, "game_moves_count", Array("game_type"), Array("tictactoe")) shouldBe Some(1.0)

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -144,10 +144,12 @@ class SerializationSpec extends AnyWordSpec with Matchers {
       json.asObject.flatMap(_("metadata")) should be(defined)
     }
 
-    "encode GameStateUpdated with a type discriminator and state" in {
+    "encode GameStateUpdated with a type discriminator, roomId, and state" in {
+      val roomId = UUID.randomUUID()
       val state = GameStateConverters.serializeGame(TicTacToe.empty(UUID.randomUUID(), UUID.randomUUID()), None)
-      val json = (PlayerEvent.GameStateUpdated(state): PlayerEvent).asJson
+      val json = (PlayerEvent.GameStateUpdated(roomId, state): PlayerEvent).asJson
       json.hcursor.get[String]("type") shouldBe Right("GameStateUpdated")
+      json.hcursor.get[UUID]("roomId") shouldBe Right(roomId)
       json.asObject.flatMap(_("state")) should be(defined)
     }
 

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -45,11 +45,11 @@ class SerializationSpec extends AnyWordSpec with Matchers {
     "round-trip serialize and deserialize" in {
       val host = Player("host")
       val joiner = Player("guest")
-      val gameId = UUID.randomUUID()
+      val roomId = UUID.randomUUID()
       val lobby = LobbyJoined(
-        gameId = gameId,
+        roomId = roomId,
         metadata = LobbyMetadata(
-          gameId = gameId,
+          roomId = roomId,
           gameType = GameType.TicTacToe,
           players = Map(host.id -> host, joiner.id -> joiner),
           hostId = host.id,
@@ -132,7 +132,7 @@ class SerializationSpec extends AnyWordSpec with Matchers {
     "encode LobbyUpdated with a type discriminator and metadata" in {
       val host = Player("host")
       val metadata = LobbyMetadata(
-        gameId = UUID.randomUUID(),
+        roomId = UUID.randomUUID(),
         gameType = GameType.TicTacToe,
         players = Map(host.id -> host),
         hostId = host.id,
@@ -178,9 +178,9 @@ class SerializationSpec extends AnyWordSpec with Matchers {
 
   "ClientMessage decoder" should {
     "decode a ChatSend frame" in {
-      val gameId = UUID.randomUUID()
-      val json = s"""{"type":"ChatSend","gameId":"$gameId","text":"hello"}"""
-      io.circe.parser.decode[ClientMessage](json) shouldBe Right(ClientMessage.ChatSend(gameId, "hello"))
+      val roomId = UUID.randomUUID()
+      val json = s"""{"type":"ChatSend","roomId":"$roomId","text":"hello"}"""
+      io.circe.parser.decode[ClientMessage](json) shouldBe Right(ClientMessage.ChatSend(roomId, "hello"))
     }
 
     "reject an unknown message type with an explanatory error" in {

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -53,7 +53,8 @@ class SerializationSpec extends AnyWordSpec with Matchers {
           gameType = GameType.TicTacToe,
           players = Map(host.id -> host, joiner.id -> joiner),
           hostId = host.id,
-          status = GameLifecycleStatus.InProgress
+          status = GameLifecycleStatus.InProgress,
+          createdAt = Instant.EPOCH
         ),
         joinedPlayer = joiner
       )
@@ -135,7 +136,8 @@ class SerializationSpec extends AnyWordSpec with Matchers {
         gameType = GameType.TicTacToe,
         players = Map(host.id -> host),
         hostId = host.id,
-        status = GameLifecycleStatus.WaitingForPlayers
+        status = GameLifecycleStatus.WaitingForPlayers,
+        createdAt = Instant.EPOCH
       )
       val json = (PlayerEvent.LobbyUpdated(metadata): PlayerEvent).asJson
       json.hcursor.get[String]("type") shouldBe Right("LobbyUpdated")

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/GameRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/GameRoutesSpec.scala
@@ -28,7 +28,7 @@ import com.andy327.actor.core.{GameManager, InMemChatRepo, InMemMoveRepo, InMemR
 import com.andy327.actor.game.GridGameState
 import com.andy327.actor.lobby.{LobbyMetadata, LobbyRepository, Player}
 import com.andy327.actor.persistence.PersistenceProtocol
-import com.andy327.model.core.{GameId, GameType}
+import com.andy327.model.core.{GameType, RoomId}
 import com.andy327.persistence.db.MoveRecord
 import com.andy327.server.http.json.JsonProtocol._
 import com.andy327.server.testutil.AuthTestHelper.createTestToken
@@ -41,7 +41,7 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
 
   private val noOpLobbyRepo: LobbyRepository = new LobbyRepository {
     override def saveLobby(metadata: LobbyMetadata): IO[Unit] = IO.unit
-    override def deleteLobby(gameId: GameId): IO[Unit] = IO.unit
+    override def deleteLobby(roomId: RoomId): IO[Unit] = IO.unit
     override def loadAllLobbies(): IO[List[LobbyMetadata]] = IO.pure(Nil)
   }
 
@@ -69,21 +69,21 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
   "GameRoutes" when {
     "handling TicTacToe" should {
       "submit a move to a valid game" in {
-        val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-          responseAs[GameManager.LobbyCreated].gameId
+        val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+          responseAs[GameManager.LobbyCreated].roomId
         }
 
-        Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+        Post(s"/lobby/$roomId/join").withHeaders(bobHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
         }
 
-        Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check {
+        Post(s"/lobby/$roomId/start").withHeaders(aliceHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
         }
 
         val moveEntity = HttpEntity(ContentTypes.`application/json`, """{"row":0,"col":0}""")
 
-        Post(s"/tictactoe/$gameId/move", moveEntity).withHeaders(aliceHeader) ~> routes ~> check {
+        Post(s"/tictactoe/$roomId/move", moveEntity).withHeaders(aliceHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
           val gameState = io.circe.parser.decode[GridGameState](responseAs[String]).toOption.get
           gameState.board(0)(0) shouldBe "X"
@@ -99,43 +99,43 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
       }
 
       "return 409 when a move is rejected by the game" in {
-        val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-          responseAs[GameManager.LobbyCreated].gameId
+        val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+          responseAs[GameManager.LobbyCreated].roomId
         }
-        Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+        Post(s"/lobby/$roomId/join").withHeaders(bobHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
         }
-        Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check {
+        Post(s"/lobby/$roomId/start").withHeaders(aliceHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
         }
 
         val moveEntity = HttpEntity(ContentTypes.`application/json`, """{"row":0,"col":0}""")
 
-        Post(s"/tictactoe/$gameId/move", moveEntity).withHeaders(aliceHeader) ~> routes ~> check {
+        Post(s"/tictactoe/$roomId/move", moveEntity).withHeaders(aliceHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
         }
 
         // alice moves again out of turn — rejected with 409, not 404
-        Post(s"/tictactoe/$gameId/move", moveEntity).withHeaders(aliceHeader) ~> routes ~> check {
+        Post(s"/tictactoe/$roomId/move", moveEntity).withHeaders(aliceHeader) ~> routes ~> check {
           status shouldBe StatusCodes.Conflict
           responseAs[String] should include("not your turn")
         }
       }
 
       "fetch game status" in {
-        val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-          responseAs[GameManager.LobbyCreated].gameId
+        val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+          responseAs[GameManager.LobbyCreated].roomId
         }
 
-        Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+        Post(s"/lobby/$roomId/join").withHeaders(bobHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
         }
 
-        Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check {
+        Post(s"/lobby/$roomId/start").withHeaders(aliceHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
         }
 
-        Get(s"/tictactoe/$gameId/status") ~> routes ~> check {
+        Get(s"/tictactoe/$roomId/status") ~> routes ~> check {
           status shouldBe StatusCodes.OK
           val gameState = io.circe.parser.decode[GridGameState](responseAs[String]).toOption.get
           gameState.currentPlayer shouldBe "X"
@@ -150,7 +150,7 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
       }
 
       "return the recorded move history" in {
-        val gameId = UUID.randomUUID()
+        val roomId = UUID.randomUUID()
         val moves = List(
           MoveRecord(0, aliceId, Json.obj("row" -> 0.asJson, "col" -> 0.asJson), Instant.EPOCH),
           MoveRecord(1, bobId, Json.obj("row" -> 1.asJson, "col" -> 1.asJson), Instant.EPOCH)
@@ -160,58 +160,58 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
             persistProbe.ref,
             new InMemRepo,
             noOpLobbyRepo,
-            moveRepo = new InMemMoveRepo(Map(gameId -> moves))
+            moveRepo = new InMemMoveRepo(Map(roomId -> moves))
           ),
           "GameRoutesHistorySystem"
         )
         val histRoutes = new GameRoutes(GameType.TicTacToe, histSystem).routes
 
-        Get(s"/tictactoe/$gameId/history") ~> histRoutes ~> check {
+        Get(s"/tictactoe/$roomId/history") ~> histRoutes ~> check {
           status shouldBe StatusCodes.OK
           val history = responseAs[GameManager.MoveHistory]
-          history.gameId shouldBe gameId
+          history.roomId shouldBe roomId
           history.moves.map(_.seq) shouldBe List(0, 1)
           history.moves.map(_.move) shouldBe moves.map(_.move)
         }
       }
 
       "return an empty move history for a game with no moves" in {
-        val gameId = UUID.randomUUID()
-        Get(s"/tictactoe/$gameId/history") ~> routes ~> check {
+        val roomId = UUID.randomUUID()
+        Get(s"/tictactoe/$roomId/history") ~> routes ~> check {
           status shouldBe StatusCodes.OK
           responseAs[GameManager.MoveHistory].moves shouldBe empty
         }
       }
 
       "return the recorded chat history" in {
-        val gameId = UUID.randomUUID()
+        val roomId = UUID.randomUUID()
         val messages = List(
-          PlayerEvent.ChatMessage(gameId, aliceId, "alice", "hi", Instant.EPOCH),
-          PlayerEvent.ChatMessage(gameId, bobId, "bob", "hey", Instant.EPOCH)
+          PlayerEvent.ChatMessage(roomId, aliceId, "alice", "hi", Instant.EPOCH),
+          PlayerEvent.ChatMessage(roomId, bobId, "bob", "hey", Instant.EPOCH)
         )
         val chatSystem = ActorSystem(
           GameManager(
             persistProbe.ref,
             new InMemRepo,
             noOpLobbyRepo,
-            chatRepo = new InMemChatRepo(Map(gameId -> messages))
+            chatRepo = new InMemChatRepo(Map(roomId -> messages))
           ),
           "GameRoutesChatSystem"
         )
         val chatRoutes = new GameRoutes(GameType.TicTacToe, chatSystem).routes
 
-        Get(s"/tictactoe/$gameId/chat") ~> chatRoutes ~> check {
+        Get(s"/tictactoe/$roomId/chat") ~> chatRoutes ~> check {
           status shouldBe StatusCodes.OK
           val history = responseAs[GameManager.ChatHistory]
-          history.gameId shouldBe gameId
+          history.roomId shouldBe roomId
           history.messages.map(_.text) shouldBe List("hi", "hey")
           history.messages.map(_.senderName) shouldBe List("alice", "bob")
         }
       }
 
       "return an empty chat history for a game with no messages" in {
-        val gameId = UUID.randomUUID()
-        Get(s"/tictactoe/$gameId/chat") ~> routes ~> check {
+        val roomId = UUID.randomUUID()
+        Get(s"/tictactoe/$roomId/chat") ~> routes ~> check {
           status shouldBe StatusCodes.OK
           responseAs[GameManager.ChatHistory].messages shouldBe empty
         }
@@ -226,22 +226,22 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
       }
 
       "return 400 for invalid JSON structure on move" in {
-        val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-          responseAs[GameManager.LobbyCreated].gameId
+        val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+          responseAs[GameManager.LobbyCreated].roomId
         }
 
-        Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+        Post(s"/lobby/$roomId/join").withHeaders(bobHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
         }
 
-        Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check {
+        Post(s"/lobby/$roomId/start").withHeaders(aliceHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
         }
 
         val invalidJson = """{ "x": 0, "y": 1 }"""
         val entity = HttpEntity(ContentTypes.`application/json`, invalidJson)
 
-        Post(s"/tictactoe/$gameId/move", entity).withHeaders(aliceHeader) ~> routes ~> check {
+        Post(s"/tictactoe/$roomId/move", entity).withHeaders(aliceHeader) ~> routes ~> check {
           status shouldBe StatusCodes.BadRequest
           responseAs[String] should include("Invalid JSON")
         }
@@ -363,13 +363,13 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
       }
 
       "return 200 when subscribing to an active game with a WebSocket connection" in {
-        val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-          responseAs[GameManager.LobbyCreated].gameId
+        val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+          responseAs[GameManager.LobbyCreated].roomId
         }
-        Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+        Post(s"/lobby/$roomId/join").withHeaders(bobHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
         }
-        Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check {
+        Post(s"/lobby/$roomId/start").withHeaders(aliceHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
         }
 
@@ -379,22 +379,22 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
           3.seconds
         )
 
-        Post(s"/tictactoe/$gameId/subscribe").withHeaders(aliceHeader) ~> routes ~> check {
+        Post(s"/tictactoe/$roomId/subscribe").withHeaders(aliceHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
-          responseAs[GameManager.SubscribeAcknowledged].gameId shouldBe gameId
+          responseAs[GameManager.SubscribeAcknowledged].roomId shouldBe roomId
         }
 
         typedSystem ! GameManager.PlayerDisconnected(alicePlayer.id, aliceRef)
       }
 
       "return 200 (idempotent) when unsubscribing from a game" in {
-        val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-          responseAs[GameManager.LobbyCreated].gameId
+        val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+          responseAs[GameManager.LobbyCreated].roomId
         }
         // DELETE is idempotent — it succeeds even with no prior subscription and no active game actor
-        Delete(s"/tictactoe/$gameId/subscribe").withHeaders(aliceHeader) ~> routes ~> check {
+        Delete(s"/tictactoe/$roomId/subscribe").withHeaders(aliceHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
-          responseAs[GameManager.UnsubscribeAcknowledged].gameId shouldBe gameId
+          responseAs[GameManager.UnsubscribeAcknowledged].roomId shouldBe roomId
         }
       }
 
@@ -404,25 +404,25 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
         }
 
       "return 400 when subscribing to a game without an active WebSocket connection" in {
-        val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-          responseAs[GameManager.LobbyCreated].gameId
+        val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+          responseAs[GameManager.LobbyCreated].roomId
         }
-        Post("/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check(())
-        Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check(())
+        Post("/lobby/$roomId/join").withHeaders(bobHeader) ~> routes ~> check(())
+        Post(s"/lobby/$roomId/start").withHeaders(aliceHeader) ~> routes ~> check(())
 
         // Alice has no WebSocket connection registered, so the subscribe will fail
-        Post(s"/tictactoe/$gameId/subscribe").withHeaders(aliceHeader) ~> routes ~> check {
+        Post(s"/tictactoe/$roomId/subscribe").withHeaders(aliceHeader) ~> routes ~> check {
           status shouldBe StatusCodes.BadRequest
           responseAs[String] should include("not connected")
         }
       }
 
       "return 401 when subscribing to a game without authentication" in {
-        val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-          responseAs[GameManager.LobbyCreated].gameId
+        val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+          responseAs[GameManager.LobbyCreated].roomId
         }
 
-        Post(s"/tictactoe/$gameId/subscribe") ~> routes ~> check {
+        Post(s"/tictactoe/$roomId/subscribe") ~> routes ~> check {
           status shouldBe StatusCodes.Unauthorized
         }
       }
@@ -430,21 +430,21 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
 
     "handling ConnectFour" should {
       "submit a move to a valid game" in {
-        val gameId = Post("/lobby/create/connectfour").withHeaders(aliceHeader) ~> routes ~> check {
-          responseAs[GameManager.LobbyCreated].gameId
+        val roomId = Post("/lobby/create/connectfour").withHeaders(aliceHeader) ~> routes ~> check {
+          responseAs[GameManager.LobbyCreated].roomId
         }
 
-        Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+        Post(s"/lobby/$roomId/join").withHeaders(bobHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
         }
 
-        Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check {
+        Post(s"/lobby/$roomId/start").withHeaders(aliceHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
         }
 
         val moveEntity = HttpEntity(ContentTypes.`application/json`, """{"col":3}""")
 
-        Post(s"/connectfour/$gameId/move", moveEntity).withHeaders(aliceHeader) ~> routes ~> check {
+        Post(s"/connectfour/$roomId/move", moveEntity).withHeaders(aliceHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
           val gameState = io.circe.parser.decode[GridGameState](responseAs[String]).toOption.get
           gameState.board(5)(3) shouldBe "R"
@@ -460,19 +460,19 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
       }
 
       "fetch game status" in {
-        val gameId = Post("/lobby/create/connectfour").withHeaders(aliceHeader) ~> routes ~> check {
-          responseAs[GameManager.LobbyCreated].gameId
+        val roomId = Post("/lobby/create/connectfour").withHeaders(aliceHeader) ~> routes ~> check {
+          responseAs[GameManager.LobbyCreated].roomId
         }
 
-        Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+        Post(s"/lobby/$roomId/join").withHeaders(bobHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
         }
 
-        Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check {
+        Post(s"/lobby/$roomId/start").withHeaders(aliceHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
         }
 
-        Get(s"/connectfour/$gameId/status") ~> routes ~> check {
+        Get(s"/connectfour/$roomId/status") ~> routes ~> check {
           status shouldBe StatusCodes.OK
           val gameState = io.circe.parser.decode[GridGameState](responseAs[String]).toOption.get
           gameState.currentPlayer shouldBe "R"
@@ -495,22 +495,22 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
       }
 
       "return 400 for invalid JSON structure on move" in {
-        val gameId = Post("/lobby/create/connectfour").withHeaders(aliceHeader) ~> routes ~> check {
-          responseAs[GameManager.LobbyCreated].gameId
+        val roomId = Post("/lobby/create/connectfour").withHeaders(aliceHeader) ~> routes ~> check {
+          responseAs[GameManager.LobbyCreated].roomId
         }
 
-        Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+        Post(s"/lobby/$roomId/join").withHeaders(bobHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
         }
 
-        Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check {
+        Post(s"/lobby/$roomId/start").withHeaders(aliceHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
         }
 
         val invalidJson = """{ "row": 0, "column": 3 }"""
         val entity = HttpEntity(ContentTypes.`application/json`, invalidJson)
 
-        Post(s"/connectfour/$gameId/move", entity).withHeaders(aliceHeader) ~> routes ~> check {
+        Post(s"/connectfour/$roomId/move", entity).withHeaders(aliceHeader) ~> routes ~> check {
           status shouldBe StatusCodes.BadRequest
           responseAs[String] should include("Invalid JSON")
         }
@@ -558,13 +558,13 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
       }
 
       "return 200 when subscribing to an active game with a WebSocket connection" in {
-        val gameId = Post("/lobby/create/connectfour").withHeaders(aliceHeader) ~> routes ~> check {
-          responseAs[GameManager.LobbyCreated].gameId
+        val roomId = Post("/lobby/create/connectfour").withHeaders(aliceHeader) ~> routes ~> check {
+          responseAs[GameManager.LobbyCreated].roomId
         }
-        Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+        Post(s"/lobby/$roomId/join").withHeaders(bobHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
         }
-        Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check {
+        Post(s"/lobby/$roomId/start").withHeaders(aliceHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
         }
 
@@ -574,33 +574,33 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
           3.seconds
         )
 
-        Post(s"/connectfour/$gameId/subscribe").withHeaders(aliceHeader) ~> routes ~> check {
+        Post(s"/connectfour/$roomId/subscribe").withHeaders(aliceHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
-          responseAs[GameManager.SubscribeAcknowledged].gameId shouldBe gameId
+          responseAs[GameManager.SubscribeAcknowledged].roomId shouldBe roomId
         }
 
         typedSystem ! GameManager.PlayerDisconnected(alicePlayer.id, aliceRef)
       }
 
       "return 400 when subscribing to a game without an active WebSocket connection" in {
-        val gameId = Post("/lobby/create/connectfour").withHeaders(aliceHeader) ~> routes ~> check {
-          responseAs[GameManager.LobbyCreated].gameId
+        val roomId = Post("/lobby/create/connectfour").withHeaders(aliceHeader) ~> routes ~> check {
+          responseAs[GameManager.LobbyCreated].roomId
         }
-        Post("/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check(())
-        Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check(())
+        Post("/lobby/$roomId/join").withHeaders(bobHeader) ~> routes ~> check(())
+        Post(s"/lobby/$roomId/start").withHeaders(aliceHeader) ~> routes ~> check(())
 
-        Post(s"/connectfour/$gameId/subscribe").withHeaders(aliceHeader) ~> routes ~> check {
+        Post(s"/connectfour/$roomId/subscribe").withHeaders(aliceHeader) ~> routes ~> check {
           status shouldBe StatusCodes.BadRequest
           responseAs[String] should include("not connected")
         }
       }
 
       "return 401 when subscribing to a game without authentication" in {
-        val gameId = Post("/lobby/create/connectfour").withHeaders(aliceHeader) ~> routes ~> check {
-          responseAs[GameManager.LobbyCreated].gameId
+        val roomId = Post("/lobby/create/connectfour").withHeaders(aliceHeader) ~> routes ~> check {
+          responseAs[GameManager.LobbyCreated].roomId
         }
 
-        Post(s"/connectfour/$gameId/subscribe") ~> routes ~> check {
+        Post(s"/connectfour/$roomId/subscribe") ~> routes ~> check {
           status shouldBe StatusCodes.Unauthorized
         }
       }

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/LobbyRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/LobbyRoutesSpec.scala
@@ -1,5 +1,6 @@
 package com.andy327.server.http.routes
 
+import java.time.Instant
 import java.util.UUID
 
 import scala.concurrent.Await
@@ -245,13 +246,15 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
         gameType = GameType.TicTacToe,
         players = Map(aliceId -> alicePlayer),
         hostId = aliceId,
-        status = GameLifecycleStatus.WaitingForPlayers
+        status = GameLifecycleStatus.WaitingForPlayers,
+        createdAt = Instant.EPOCH
       )
 
       Get(s"/lobby/$gameId") ~> routes ~> check {
         status shouldBe StatusCodes.OK
         val response = responseAs[LobbyMetadata]
-        response shouldBe expectedLobbyMetadata
+        // createdAt is stamped server-side at creation time, so compare the rest of the metadata against it
+        response shouldBe expectedLobbyMetadata.copy(createdAt = response.createdAt)
       }
     }
 

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/LobbyRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/LobbyRoutesSpec.scala
@@ -253,8 +253,11 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
       Get(s"/lobby/$gameId") ~> routes ~> check {
         status shouldBe StatusCodes.OK
         val response = responseAs[LobbyMetadata]
-        // createdAt is stamped server-side at creation time, so compare the rest of the metadata against it
-        response shouldBe expectedLobbyMetadata.copy(createdAt = response.createdAt)
+        // createdAt/lastActivityAt are stamped server-side, so compare the rest of the metadata against them
+        response shouldBe expectedLobbyMetadata.copy(
+          createdAt = response.createdAt,
+          lastActivityAt = response.lastActivityAt
+        )
       }
     }
 

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/LobbyRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/LobbyRoutesSpec.scala
@@ -24,7 +24,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import com.andy327.actor.core.{GameManager, InMemRepo, PlayerActor}
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyMetadata, LobbyRepository, Player}
 import com.andy327.actor.persistence.PersistenceProtocol
-import com.andy327.model.core.{GameId, GameType}
+import com.andy327.model.core.{GameType, RoomId}
 import com.andy327.server.http.json.JsonProtocol._
 import com.andy327.server.testutil.AuthTestHelper.createTestToken
 
@@ -36,7 +36,7 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
 
   private val noOpLobbyRepo: LobbyRepository = new LobbyRepository {
     override def saveLobby(metadata: LobbyMetadata): IO[Unit] = IO.unit
-    override def deleteLobby(gameId: GameId): IO[Unit] = IO.unit
+    override def deleteLobby(roomId: RoomId): IO[Unit] = IO.unit
     override def loadAllLobbies(): IO[List[LobbyMetadata]] = IO.pure(Nil)
   }
 
@@ -61,8 +61,8 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
     "create a new lobby" in
       Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
-        val GameManager.LobbyCreated(gameId, host) = responseAs[GameManager.LobbyCreated]
-        gameId.toString.length should be > 0
+        val GameManager.LobbyCreated(roomId, host) = responseAs[GameManager.LobbyCreated]
+        roomId.toString.length should be > 0
         host.name shouldBe "alice"
         host.id shouldBe aliceId
       }
@@ -80,11 +80,11 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
       }
 
     "join a lobby with a second player" in {
-      val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-        responseAs[GameManager.LobbyCreated].gameId
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
       }
 
-      Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/join").withHeaders(bobHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
         val GameManager.LobbyJoined(_, metadata, joinedPlayer) = responseAs[GameManager.LobbyJoined]
         metadata.players.values.toSet should contain only (alicePlayer, joinedPlayer)
@@ -92,53 +92,53 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
     }
 
     "not allow too many players to join a lobby" in {
-      val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-        responseAs[GameManager.LobbyCreated].gameId
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
       }
 
-      Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/join").withHeaders(bobHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
       }
 
-      Post(s"/lobby/$gameId/join").withHeaders(carlHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/join").withHeaders(carlHeader) ~> routes ~> check {
         status shouldBe StatusCodes.Conflict
       }
     }
 
     "leave a lobby" in {
-      val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-        responseAs[GameManager.LobbyCreated].gameId
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
       }
 
-      Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/join").withHeaders(bobHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
       }
 
       // Bob leaves — lobby drops from ReadyToStart back to WaitingForPlayers
-      Post(s"/lobby/$gameId/leave").withHeaders(bobHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/leave").withHeaders(bobHeader) ~> routes ~> check {
         val leftLobby = responseAs[GameManager.LobbyLeft]
-        leftLobby.gameId shouldBe gameId
+        leftLobby.roomId shouldBe roomId
       }
 
-      Get(s"/lobby/$gameId") ~> routes ~> check {
+      Get(s"/lobby/$roomId") ~> routes ~> check {
         status shouldBe StatusCodes.OK
         responseAs[LobbyMetadata].status shouldBe GameLifecycleStatus.WaitingForPlayers
       }
 
       // Bob tries to leave again (OK)
-      Post(s"/lobby/$gameId/leave").withHeaders(bobHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/leave").withHeaders(bobHeader) ~> routes ~> check {
         val leftLobby = responseAs[GameManager.LobbyLeft]
-        leftLobby.gameId shouldBe gameId
+        leftLobby.roomId shouldBe roomId
       }
 
       // Alice (host) leaves
-      Post(s"/lobby/$gameId/leave").withHeaders(aliceHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/leave").withHeaders(aliceHeader) ~> routes ~> check {
         val leftLobby = responseAs[GameManager.LobbyLeft]
-        leftLobby.gameId shouldBe gameId
+        leftLobby.roomId shouldBe roomId
       }
 
       // Game should be cancelled
-      Get(s"/lobby/$gameId") ~> routes ~> check {
+      Get(s"/lobby/$roomId") ~> routes ~> check {
         status shouldBe StatusCodes.OK
         val response = responseAs[LobbyMetadata]
         response.status shouldBe GameLifecycleStatus.Cancelled
@@ -146,36 +146,36 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
     }
 
     "forfeit an in-progress game when a player leaves it" in {
-      val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-        responseAs[GameManager.LobbyCreated].gameId
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
       }
-      Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/join").withHeaders(bobHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
       }
-      Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/start").withHeaders(aliceHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
       }
 
       // Bob (O) leaves the live game: 200 with the finished game state, Alice (X) the winner
-      Post(s"/lobby/$gameId/leave").withHeaders(bobHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/leave").withHeaders(bobHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
         responseAs[String] should include(""""winner":"X"""")
       }
     }
 
     "reject a forfeit from a non-participant of an in-progress game" in {
-      val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-        responseAs[GameManager.LobbyCreated].gameId
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
       }
-      Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/join").withHeaders(bobHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
       }
-      Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/start").withHeaders(aliceHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
       }
 
       // Carl is not seated in the game; leaving is rejected with 409 and the game stays live
-      Post(s"/lobby/$gameId/leave").withHeaders(carlHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/leave").withHeaders(carlHeader) ~> routes ~> check {
         status shouldBe StatusCodes.Conflict
       }
     }
@@ -189,60 +189,60 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
       }
     }
 
-    "reject leaving a lobby if the gameId is not a valid UUID" in
+    "reject leaving a lobby if the roomId is not a valid UUID" in
       Post("/lobby/not-a-uuid/leave").withHeaders(aliceHeader) ~> routes ~> check {
         status shouldBe StatusCodes.BadRequest
-        responseAs[String] should include("Invalid UUID for game")
+        responseAs[String] should include("Invalid UUID for room")
       }
 
     "start a game after a lobby has enough players" in {
-      val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-        responseAs[GameManager.LobbyCreated].gameId
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
       }
 
-      Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/join").withHeaders(bobHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
       }
 
-      Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/start").withHeaders(aliceHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
-        responseAs[GameManager.GameStarted].gameId shouldBe gameId
+        responseAs[GameManager.GameStarted].roomId shouldBe roomId
       }
     }
 
     "reject starting a game if the requester is not the host" in {
-      val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-        responseAs[GameManager.LobbyCreated].gameId
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
       }
 
-      Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/join").withHeaders(bobHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
       }
 
-      Post(s"/lobby/$gameId/start").withHeaders(bobHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/start").withHeaders(bobHeader) ~> routes ~> check {
         status shouldBe StatusCodes.Forbidden
         responseAs[String] should include("Only the host can start")
       }
     }
 
     "reject starting a game with not enough players" in {
-      val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-        responseAs[GameManager.LobbyCreated].gameId
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
       }
 
-      Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/start").withHeaders(aliceHeader) ~> routes ~> check {
         status shouldBe StatusCodes.Conflict
         responseAs[String] should include("does not have enough players")
       }
     }
 
     "return metadata for a valid TicTacToe lobby" in {
-      val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-        responseAs[GameManager.LobbyCreated].gameId
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
       }
 
       val expectedLobbyMetadata = LobbyMetadata(
-        gameId = gameId,
+        roomId = roomId,
         gameType = GameType.TicTacToe,
         players = Map(aliceId -> alicePlayer),
         hostId = aliceId,
@@ -250,7 +250,7 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
         createdAt = Instant.EPOCH
       )
 
-      Get(s"/lobby/$gameId") ~> routes ~> check {
+      Get(s"/lobby/$roomId") ~> routes ~> check {
         status shouldBe StatusCodes.OK
         val response = responseAs[LobbyMetadata]
         // createdAt/lastActivityAt are stamped server-side, so compare the rest of the metadata against them
@@ -261,10 +261,10 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
       }
     }
 
-    "reject a lobby info request if the gameId is not a valid UUID" in
+    "reject a lobby info request if the roomId is not a valid UUID" in
       Get("/lobby/not-a-uuid") ~> routes ~> check {
         status shouldBe StatusCodes.BadRequest
-        responseAs[String] should include("Invalid UUID for game")
+        responseAs[String] should include("Invalid UUID for room")
       }
 
     "reject a lobby info request if the lobby does not exist" in {
@@ -277,14 +277,14 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
     }
 
     "list all lobbies with pagination metadata" in {
-      val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-        responseAs[GameManager.LobbyCreated].gameId
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
       }
 
       Get("/lobby/list") ~> routes ~> check {
         status shouldBe StatusCodes.OK
         val result = responseAs[GameManager.LobbiesListed]
-        result.lobbies.map(_.gameId) should contain(gameId)
+        result.lobbies.map(_.roomId) should contain(roomId)
         result.page shouldBe 1
         result.limit shouldBe 20
         result.total should be >= 1
@@ -304,15 +304,15 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
     }
 
     "return metadata for a valid ConnectFour lobby" in {
-      val gameId = Post("/lobby/create/connectfour").withHeaders(aliceHeader) ~> routes ~> check {
-        responseAs[GameManager.LobbyCreated].gameId
+      val roomId = Post("/lobby/create/connectfour").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
       }
 
-      Get(s"/lobby/$gameId") ~> routes ~> check {
+      Get(s"/lobby/$roomId") ~> routes ~> check {
         status shouldBe StatusCodes.OK
         val response = responseAs[LobbyMetadata]
         response.gameType shouldBe GameType.ConnectFour
-        response.gameId shouldBe gameId
+        response.roomId shouldBe roomId
       }
     }
 
@@ -415,8 +415,8 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
     }
 
     "return 200 when subscribing to a lobby with an active WebSocket connection" in {
-      val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-        responseAs[GameManager.LobbyCreated].gameId
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
       }
 
       val wsProbe = testKit.createTestProbe[PlayerActor.SessionOutput]()
@@ -425,22 +425,22 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
         3.seconds
       )
 
-      Post(s"/lobby/$gameId/subscribe").withHeaders(aliceHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/subscribe").withHeaders(aliceHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
-        responseAs[GameManager.SubscribeAcknowledged].gameId shouldBe gameId
+        responseAs[GameManager.SubscribeAcknowledged].roomId shouldBe roomId
       }
 
       typedSystem ! GameManager.PlayerDisconnected(alicePlayer.id, aliceRef)
     }
 
     "return 409 when subscribing to a lobby whose game has already started" in {
-      val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-        responseAs[GameManager.LobbyCreated].gameId
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
       }
-      Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/join").withHeaders(bobHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
       }
-      Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/start").withHeaders(aliceHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
       }
 
@@ -450,7 +450,7 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
         3.seconds
       )
 
-      Post(s"/lobby/$gameId/subscribe").withHeaders(aliceHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/subscribe").withHeaders(aliceHeader) ~> routes ~> check {
         status shouldBe StatusCodes.Conflict
         responseAs[String] should include("already started")
       }
@@ -459,90 +459,90 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
     }
 
     "return 400 when subscribing to a lobby without an active WebSocket connection" in {
-      val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-        responseAs[GameManager.LobbyCreated].gameId
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
       }
 
       // Alice has no WebSocket connection registered, so the subscribe will fail
-      Post(s"/lobby/$gameId/subscribe").withHeaders(aliceHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/subscribe").withHeaders(aliceHeader) ~> routes ~> check {
         status shouldBe StatusCodes.BadRequest
         responseAs[String] should include("not connected")
       }
     }
 
     "return 401 when subscribing to a lobby without authentication" in {
-      val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-        responseAs[GameManager.LobbyCreated].gameId
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
       }
 
-      Post(s"/lobby/$gameId/subscribe") ~> routes ~> check {
+      Post(s"/lobby/$roomId/subscribe") ~> routes ~> check {
         status shouldBe StatusCodes.Unauthorized
       }
     }
 
     "return 200 (idempotent) when unsubscribing from a lobby" in {
-      val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-        responseAs[GameManager.LobbyCreated].gameId
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
       }
       // DELETE is idempotent — it succeeds even with no prior subscription
-      Delete(s"/lobby/$gameId/subscribe").withHeaders(aliceHeader) ~> routes ~> check {
+      Delete(s"/lobby/$roomId/subscribe").withHeaders(aliceHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
-        responseAs[GameManager.UnsubscribeAcknowledged].gameId shouldBe gameId
+        responseAs[GameManager.UnsubscribeAcknowledged].roomId shouldBe roomId
       }
     }
 
     "let the host cancel a pre-game lobby" in {
-      val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-        responseAs[GameManager.LobbyCreated].gameId
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
       }
 
-      Delete(s"/lobby/$gameId").withHeaders(aliceHeader) ~> routes ~> check {
+      Delete(s"/lobby/$roomId").withHeaders(aliceHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
-        responseAs[GameManager.LobbyLeft].gameId shouldBe gameId
+        responseAs[GameManager.LobbyLeft].roomId shouldBe roomId
       }
 
       // the cancelled lobby is no longer joinable
       Get("/lobby/list") ~> routes ~> check {
         status shouldBe StatusCodes.OK
-        responseAs[GameManager.LobbiesListed].lobbies.map(_.gameId) should not contain gameId
+        responseAs[GameManager.LobbiesListed].lobbies.map(_.roomId) should not contain roomId
       }
     }
 
     "return 403 when a non-host tries to cancel a lobby" in {
-      val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-        responseAs[GameManager.LobbyCreated].gameId
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
       }
-      Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/join").withHeaders(bobHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
       }
 
-      Delete(s"/lobby/$gameId").withHeaders(bobHeader) ~> routes ~> check {
+      Delete(s"/lobby/$roomId").withHeaders(bobHeader) ~> routes ~> check {
         status shouldBe StatusCodes.Forbidden
       }
     }
 
     "return 409 when cancelling a lobby whose game has already started" in {
-      val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-        responseAs[GameManager.LobbyCreated].gameId
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
       }
-      Post(s"/lobby/$gameId/join").withHeaders(bobHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/join").withHeaders(bobHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
       }
-      Post(s"/lobby/$gameId/start").withHeaders(aliceHeader) ~> routes ~> check {
+      Post(s"/lobby/$roomId/start").withHeaders(aliceHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
       }
 
-      Delete(s"/lobby/$gameId").withHeaders(aliceHeader) ~> routes ~> check {
+      Delete(s"/lobby/$roomId").withHeaders(aliceHeader) ~> routes ~> check {
         status shouldBe StatusCodes.Conflict
       }
     }
 
     "return 401 when cancelling a lobby without authentication" in {
-      val gameId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
-        responseAs[GameManager.LobbyCreated].gameId
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
       }
 
-      Delete(s"/lobby/$gameId") ~> routes ~> check {
+      Delete(s"/lobby/$roomId") ~> routes ~> check {
         status shouldBe StatusCodes.Unauthorized
       }
     }

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/PlayerRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/PlayerRoutesSpec.scala
@@ -22,7 +22,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import com.andy327.actor.core.{GameManager, InMemRepo}
 import com.andy327.actor.lobby.{LobbyMetadata, LobbyRepository, Player}
 import com.andy327.actor.persistence.PersistenceProtocol
-import com.andy327.model.core.{GameId, GameType}
+import com.andy327.model.core.{GameType, RoomId}
 import com.andy327.persistence.db.InMemoryPlayerHistoryRepository
 import com.andy327.persistence.db.PlayerHistoryRepository.GameResult
 import com.andy327.server.http.auth.PlayerHistory
@@ -37,7 +37,7 @@ class PlayerRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest
 
   private val noOpLobbyRepo: LobbyRepository = new LobbyRepository {
     override def saveLobby(metadata: LobbyMetadata): IO[Unit] = IO.unit
-    override def deleteLobby(gameId: GameId): IO[Unit] = IO.unit
+    override def deleteLobby(roomId: RoomId): IO[Unit] = IO.unit
     override def loadAllLobbies(): IO[List[LobbyMetadata]] = IO.pure(Nil)
   }
 
@@ -87,10 +87,10 @@ class PlayerRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest
       Get("/players/me/sessions").withHeaders(aliceHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
         val sessions = responseAs[GameManager.PlayerSessions]
-        sessions.lobbies.map(_.gameId) should contain(lobbyA)
-        sessions.lobbies.map(_.gameId) should not contain gameB
-        sessions.games.map(_.gameId) should contain(gameB)
-        sessions.games.find(_.gameId == gameB).map(_.gameType) shouldBe Some(GameType.TicTacToe)
+        sessions.lobbies.map(_.roomId) should contain(lobbyA)
+        sessions.lobbies.map(_.roomId) should not contain gameB
+        sessions.games.map(_.roomId) should contain(gameB)
+        sessions.games.find(_.roomId == gameB).map(_.gameType) shouldBe Some(GameType.TicTacToe)
       }
     }
 
@@ -124,14 +124,14 @@ class PlayerRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest
       Get("/players/me/history").withHeaders(aliceHeader) ~> historyRoutes ~> check {
         status shouldBe StatusCodes.OK
         val games = responseAs[PlayerHistory].games
-        games.map(_.gameId) should contain theSameElementsAs List(won, lost)
+        games.map(_.matchId) should contain theSameElementsAs List(won, lost)
 
-        val winEntry = games.find(_.gameId == won).getOrElse(fail("missing win entry"))
+        val winEntry = games.find(_.matchId == won).getOrElse(fail("missing win entry"))
         winEntry.gameType shouldBe GameType.TicTacToe
         winEntry.result shouldBe GameResult.Win
         winEntry.forfeit shouldBe false
 
-        val lossEntry = games.find(_.gameId == lost).getOrElse(fail("missing loss entry"))
+        val lossEntry = games.find(_.matchId == lost).getOrElse(fail("missing loss entry"))
         lossEntry.gameType shouldBe GameType.ConnectFour
         lossEntry.result shouldBe GameResult.Loss
         lossEntry.forfeit shouldBe true

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/WebSocketRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/WebSocketRoutesSpec.scala
@@ -14,7 +14,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import com.andy327.actor.core.{GameManager, InMemRepo}
 import com.andy327.actor.lobby.{LobbyMetadata, LobbyRepository, Player}
 import com.andy327.actor.persistence.PersistenceProtocol
-import com.andy327.model.core.{GameId, GameType}
+import com.andy327.model.core.{GameType, RoomId}
 import com.andy327.server.testutil.AuthTestHelper.createTestToken
 
 class WebSocketRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
@@ -22,7 +22,7 @@ class WebSocketRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteT
 
   private val noOpLobbyRepo: LobbyRepository = new LobbyRepository {
     override def saveLobby(metadata: LobbyMetadata): IO[Unit] = IO.unit
-    override def deleteLobby(gameId: GameId): IO[Unit] = IO.unit
+    override def deleteLobby(roomId: RoomId): IO[Unit] = IO.unit
     override def loadAllLobbies(): IO[List[LobbyMetadata]] = IO.pure(Nil)
   }
 
@@ -68,7 +68,7 @@ class WebSocketRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteT
 
       // a lobby alice can subscribe to once her WebSocket session is registered
       typedSystem ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val gameId = responseProbe.expectMessageType[GameManager.LobbyCreated].gameId
+      val roomId = responseProbe.expectMessageType[GameManager.LobbyCreated].roomId
 
       val wsClient = WSProbe()
       WS("/ws", wsClient.flow) ~> addHeader(RawHeader("Authorization", s"Bearer $token")) ~> routes ~> check {
@@ -76,7 +76,7 @@ class WebSocketRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteT
 
         // registration happens asynchronously after connect, so retry the subscribe until it lands
         responseProbe.awaitAssert {
-          typedSystem ! GameManager.SubscribePlayerToLobby(gameId, alice.id, responseProbe.ref)
+          typedSystem ! GameManager.SubscribePlayerToLobby(roomId, alice.id, responseProbe.ref)
           responseProbe.receiveMessage() shouldBe a[GameManager.SubscribeAcknowledged]
         }
 
@@ -98,7 +98,7 @@ class WebSocketRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteT
       val responseProbe = typedKit.createTestProbe[GameManager.GameResponse]()
 
       typedSystem ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
-      val gameId = responseProbe.expectMessageType[GameManager.LobbyCreated].gameId
+      val roomId = responseProbe.expectMessageType[GameManager.LobbyCreated].roomId
 
       val wsClient = WSProbe()
       WS("/ws", wsClient.flow) ~> addHeader(RawHeader("Authorization", s"Bearer $token")) ~> routes ~> check {
@@ -106,7 +106,7 @@ class WebSocketRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteT
 
         // subscribe alice to the lobby once her session is registered (registration is async)
         responseProbe.awaitAssert {
-          typedSystem ! GameManager.SubscribePlayerToLobby(gameId, alice.id, responseProbe.ref)
+          typedSystem ! GameManager.SubscribePlayerToLobby(roomId, alice.id, responseProbe.ref)
           responseProbe.receiveMessage() shouldBe a[GameManager.SubscribeAcknowledged]
         }
         wsClient.expectMessage().asTextMessage.getStrictText should include("LobbyUpdated") // initial state
@@ -115,7 +115,7 @@ class WebSocketRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteT
         wsClient.sendMessage("not even json")
 
         // the next valid chat frame is still routed: inbound decode -> SendChat -> lobby fan-out -> back to her socket
-        wsClient.sendMessage(s"""{"type":"ChatSend","gameId":"$gameId","text":"hello all"}""")
+        wsClient.sendMessage(s"""{"type":"ChatSend","roomId":"$roomId","text":"hello all"}""")
         val frame = wsClient.expectMessage().asTextMessage.getStrictText
         frame should include("ChatMessage")
         frame should include("hello all")


### PR DESCRIPTION
Adds post-game rooms: when a match ends, its lobby survives in a non-joinable `Finished` state instead of disappearing, so the same players can keep chatting and the host can start a same-roster rematch. Getting there required first separating the room (the durable lobby) from the match (one playthrough) at the type level — `RoomId` and `MatchId` replace the transitional `GameId` alias everywhere, which is why this branch's diff is so much wider: most of the 63 files touched are mechanical retyping/renaming, not new behavior.

### What's included
- **Post-game rooms** — a finished match moves its room to `Finished` instead of retiring it; the room keeps fanning out chat and stays discoverable via `GET /players/me/sessions`.
- **Rematch** — the host re-issues the same `POST /lobby/{roomId}/start`; it mints a fresh `matchId`, rotates seating so the other player leads, and pushes a fresh `GameStateUpdated` to both players.
- **Idle-room eviction** — `LobbyManager` runs a periodic sweep that retires a `Finished` room once it's empty *and* idle past a grace period (not on the very next tick after a momentary disconnect), or once it's been idle past a longer TTL regardless of occupancy.
- **`RoomId`/`MatchId` identifier sweep** — `GameId` is gone from the codebase. Every field, parameter, and JSON/WebSocket wire key that was ambiguously `gameId` is now precisely `roomId` or `matchId`, including `app.js` and the README. No backward compatibility was kept for the wire format — this is a breaking change to the API shape (`gameId` → `roomId`/`matchId` on most JSON responses and the chat WS frame), but the player-facing flow is unchanged.
- **`GameManager.completedMatch` pruning** — previously unbounded; now dropped via a new `RoomClosed` message whenever a room is retired (cancelled by the host or evicted).
- **Race-window fixes** — the idle-room eviction no longer fires for a room that's merely had a momentary zero-subscriber blip (e.g. a tab refresh); a move/leave/state-read landing in the brief window between game completion and the final snapshot save now gets a clean `GameOver` rejection instead of hanging.

### Design notes
- The web client speaks only `RoomId`; `MatchId` is server-internal except where a player's completed-game history needs to name a specific match.
- Rematch reuses the existing `start` endpoint rather than adding a new one — same auth, same validation path, same push sequence the client already handles.
- Seat rotation on rematch uses the room's `matchCount` so the first-move advantage alternates across replays of the same room.

### Testing
- `sbt test` — 447 passing across all four modules.
- `scalafixAll --check` / `scalafmtCheckAll` clean.
- Manually verified two-player play-to-completion, post-game chat, rematch, and idle-room eviction timing via direct HTTP/WS calls against a running server.
