### PR TITLE
Add spectator mode: watch lobbies and live games without playing

### DIFF
--- a/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
@@ -286,7 +286,8 @@ object GameManager {
   final case class LobbyInfo(metadata: LobbyMetadata) extends GameResponse
 
   /** Paginated list of joinable lobbies. */
-  final case class LobbiesListed(lobbies: List[LobbyMetadata], page: Int, limit: Int, total: Int) extends GameResponse
+  final case class LobbiesListed(lobbies: List[LobbyManager.LobbySummary], page: Int, limit: Int, total: Int)
+      extends GameResponse
 
   /** A single live game the requesting player is seated in, carried by [[PlayerSessions]]. Deliberately minimal — just
     * the id and kind, enough to re-discover and reconnect to the match; full state is fetched via the game endpoint.

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
@@ -462,7 +462,10 @@ object LobbyManager {
 
       case ListLobbies(gameTypeFilter, page, limit, replyTo) =>
         context.log.info("Listing available lobbies")
-        val all = lobbies.values.filter(_.status.isJoinable).toList
+        // every room this map tracks is listable (WaitingForPlayers/ReadyToStart/InProgress/Finished) — terminal
+        // Completed/Cancelled rooms are never in this map, having already moved to recentlyEnded. Listing Finished
+        // rooms too (not just InProgress) avoids a room flickering in and out of the list across each rematch cycle
+        val all = lobbies.values.toList
         val filtered = gameTypeFilter.fold(all)(gt => all.filter(_.gameType == gt))
         val summaries = filtered.map(m => LobbySummary(m, spectatorCount(subscribers, m.roomId, m)))
         // most-watched first, newest first as a tiebreaker; sortBy is stable, so sorting by createdAt first and then

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
@@ -138,7 +138,13 @@ object LobbyManager {
   // --- Response type owned by LobbyManager ---
 
   /** Paginated lobby-list result; adapted into [[GameManager.LobbiesListed]] by a GameManager message adapter. */
-  final case class LobbiesListed(lobbies: List[LobbyMetadata], page: Int, limit: Int, total: Int)
+  final case class LobbiesListed(lobbies: List[LobbySummary], page: Int, limit: Int, total: Int)
+
+  /** A lobby paired with its current spectator count, for the public lobby-list endpoint. Kept separate from
+    * [[lobby.LobbyMetadata]] (which is persisted to Redis) since the spectator count is a live connection detail, not
+    * durable lobby state.
+    */
+  final case class LobbySummary(metadata: LobbyMetadata, spectatorCount: Int)
 
   /** A player's joined pre-game lobbies, replied to a [[ListLobbiesForPlayer]] query; consumed by [[GameManager]] while
     * assembling its combined [[GameManager.PlayerSessions]] response.
@@ -195,6 +201,14 @@ object LobbyManager {
       event: PlayerEvent
   ): Unit =
     subscribers.getOrElse(roomId, Map.empty).values.foreach(_ ! PlayerActor.SendEvent(event))
+
+  /** Connected subscribers for `roomId` who are not seated in `metadata.players` — i.e. watching but not playing. */
+  private def spectatorCount(
+      subscribers: Map[RoomId, Map[PlayerId, ActorRef[PlayerActor.Command]]],
+      roomId: RoomId,
+      metadata: LobbyMetadata
+  ): Int =
+    (subscribers.getOrElse(roomId, Map.empty).keySet -- metadata.players.keySet).size
 
   /** Seat order for a match: the host first, then the remaining players ordered by id, rotated left by the room's
     * match count. Rotation makes the first-move seat (seat 0) alternate across rematches; the first match (count 0)
@@ -275,7 +289,11 @@ object LobbyManager {
                 else GameLifecycleStatus.WaitingForPlayers
               val updatedMetadata = metadata.copy(players = updatedPlayers, status = updatedStatus)
               replyTo ! GameManager.LobbyJoined(roomId, updatedMetadata, player)
-              fanOut(subscribers, roomId, PlayerEvent.LobbyUpdated(updatedMetadata))
+              fanOut(
+                subscribers,
+                roomId,
+                PlayerEvent.LobbyUpdated(updatedMetadata, spectatorCount(subscribers, roomId, updatedMetadata))
+              )
               persist(lobbyRepo.saveLobby(updatedMetadata))
               running(
                 lobbies + (roomId -> updatedMetadata),
@@ -336,7 +354,8 @@ object LobbyManager {
                   val migrated = newMetadata.copy(hostId = newHostId)
                   val msg = s"${player.name} left lobby $roomId; host transferred to ${newHost.name}"
                   replyTo ! GameManager.LobbyLeft(roomId, msg)
-                  fanOut(subscribers, roomId, PlayerEvent.LobbyUpdated(migrated))
+                  val spectators = spectatorCount(subscribers, roomId, migrated)
+                  fanOut(subscribers, roomId, PlayerEvent.LobbyUpdated(migrated, spectators))
                   val updatedSubscribers = subscribers.updatedWith(roomId)(_.map(_ - player.id))
                   persist(lobbyRepo.saveLobby(migrated))
                   running(
@@ -351,7 +370,11 @@ object LobbyManager {
             } else {
               context.log.info(s"Player ${player.name} left lobby $roomId")
               replyTo ! GameManager.LobbyLeft(roomId, s"${player.name} left lobby $roomId")
-              fanOut(subscribers, roomId, PlayerEvent.LobbyUpdated(newMetadata))
+              fanOut(
+                subscribers,
+                roomId,
+                PlayerEvent.LobbyUpdated(newMetadata, spectatorCount(subscribers, roomId, newMetadata))
+              )
               val updatedSubscribers = subscribers.updatedWith(roomId)(_.map(_ - player.id))
               persist(lobbyRepo.saveLobby(newMetadata))
               running(
@@ -441,8 +464,11 @@ object LobbyManager {
         context.log.info("Listing available lobbies")
         val all = lobbies.values.filter(_.status.isJoinable).toList
         val filtered = gameTypeFilter.fold(all)(gt => all.filter(_.gameType == gt))
-        // newest first, so freshly created lobbies surface at the top of the (paginated) list
-        val ordered = filtered.sortBy(_.createdAt)(Ordering[Instant].reverse)
+        val summaries = filtered.map(m => LobbySummary(m, spectatorCount(subscribers, m.roomId, m)))
+        // most-watched first, newest first as a tiebreaker; sortBy is stable, so sorting by createdAt first and then
+        // (stably) by spectatorCount preserves newest-first order within each spectatorCount group
+        val byCreatedAt = summaries.sortBy(_.metadata.createdAt)(Ordering[Instant].reverse)
+        val ordered = byCreatedAt.sortBy(-_.spectatorCount)
         val total = ordered.size
         val paged = ordered.drop((page - 1) * limit).take(limit)
         replyTo ! LobbyManager.LobbiesListed(paged, page, limit, total)
@@ -474,9 +500,15 @@ object LobbyManager {
             // mirroring TurnBasedGameActor; without this a dead ref would linger and receive dead-letter fan-out
             context.watch(playerRef)
             val updated = subscribers.getOrElse(roomId, Map.empty) + (playerId -> playerRef)
-            playerRef ! PlayerActor.SendEvent(PlayerEvent.LobbyUpdated(metadata))
+            val updatedSubscribers = subscribers + (roomId -> updated)
+            // fan out (not just to the new subscriber) so already-connected viewers see the spectator count tick up
+            fanOut(
+              updatedSubscribers,
+              roomId,
+              PlayerEvent.LobbyUpdated(metadata, spectatorCount(updatedSubscribers, roomId, metadata))
+            )
             replyTo ! GameManager.SubscribeAcknowledged(roomId)
-            running(lobbies, recentlyEnded, subscribers + (roomId -> updated), gameManager, lobbyRepo, emptyRoomGrace)
+            running(lobbies, recentlyEnded, updatedSubscribers, gameManager, lobbyRepo, emptyRoomGrace)
           case None =>
             replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotFound(roomId))
             Behaviors.same
@@ -486,6 +518,10 @@ object LobbyManager {
         // idempotent: unwatch and drop the player's ref if present, otherwise a harmless no-op; either way ack
         subscribers.getOrElse(roomId, Map.empty).get(playerId).foreach(context.unwatch)
         val updated = subscribers.updatedWith(roomId)(_.map(_ - playerId).filter(_.nonEmpty))
+        // tell the remaining viewers the spectator count just dropped
+        lobbies.get(roomId).foreach { metadata =>
+          fanOut(updated, roomId, PlayerEvent.LobbyUpdated(metadata, spectatorCount(updated, roomId, metadata)))
+        }
         replyTo ! GameManager.UnsubscribeAcknowledged(roomId)
         running(lobbies, recentlyEnded, updated, gameManager, lobbyRepo, emptyRoomGrace)
 
@@ -498,14 +534,16 @@ object LobbyManager {
             // watch each so a later disconnect drops it, mirroring SubscribeToLobby
             returnedSubscribers.values.foreach(context.watch)
             val merged = subscribers.getOrElse(roomId, Map.empty) ++ returnedSubscribers
+            val mergedSubscribers = subscribers + (roomId -> merged)
             // tell everyone in the room it is now in its post-game state (drives the rematch process)
-            merged.values.foreach(_ ! PlayerActor.SendEvent(PlayerEvent.LobbyUpdated(finished)))
+            val event = PlayerEvent.LobbyUpdated(finished, spectatorCount(mergedSubscribers, roomId, finished))
+            merged.values.foreach(_ ! PlayerActor.SendEvent(event))
             // the post-game room lives in memory only; drop the stale in-progress record so a restart won't revive it
             persist(lobbyRepo.deleteLobby(roomId))
             running(
               lobbies + (roomId -> finished),
               recentlyEnded,
-              subscribers + (roomId -> merged),
+              mergedSubscribers,
               gameManager,
               lobbyRepo,
               emptyRoomGrace

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/PlayerEvent.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/PlayerEvent.scala
@@ -14,16 +14,21 @@ sealed trait PlayerEvent
 
 object PlayerEvent {
 
-  /** The lobby the player is in has changed — a player joined, left, or the status updated. */
-  final case class LobbyUpdated(metadata: LobbyMetadata) extends PlayerEvent
+  /** The lobby the player is in has changed — a player joined, left, or the status updated.
+    *
+    * @param spectatorCount connected subscribers who are not seated in `metadata.players` — i.e. watching but not
+    *                       playing
+    */
+  final case class LobbyUpdated(metadata: LobbyMetadata, spectatorCount: Int) extends PlayerEvent
 
   /** The game state changed after a move — carries the full updated board state.
     *
     * @param roomId the room this update belongs to; lets a client routing several rooms dispatch the push to the right
     *               one (a room hosts at most one live match at a time)
     * @param state the full updated board state, rendered for the receiving subscriber
+    * @param spectatorCount connected subscribers who are not one of the match's seated players
     */
-  final case class GameStateUpdated(roomId: RoomId, state: GameState) extends PlayerEvent
+  final case class GameStateUpdated(roomId: RoomId, state: GameState, spectatorCount: Int) extends PlayerEvent
 
   /** The game has ended.
     *

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/TurnBasedGameActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/TurnBasedGameActor.scala
@@ -174,6 +174,10 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
       }
     }
 
+  /** Connected subscribers who are not one of `game.players` — i.e. watching but not seated in the match. */
+  private def spectatorCount(subscribers: Map[ActorRef[PlayerActor.Command], PlayerId], game: G): Int =
+    (subscribers.values.toSet -- game.players.toSet).size
+
   /** Persists, fans out, and completes a successful state transition — shared by `MakeMove` and `PlayerLeft`.
     *
     * Saves a snapshot, replies to the acting player with their own view, and fans a per-viewer view out to every
@@ -215,8 +219,10 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
 
     // reply to the acting player with their own view; fan out a per-viewer view to each subscriber
     replyTo ! Right(view.fromGame(nextState, Some(viewerId)))
+    val spectators = spectatorCount(subscribers, nextState)
     subscribers.foreach { case (ref, subscriberId) =>
-      ref ! PlayerActor.SendEvent(PlayerEvent.GameStateUpdated(roomId, view.fromGame(nextState, Some(subscriberId))))
+      val event = PlayerEvent.GameStateUpdated(roomId, view.fromGame(nextState, Some(subscriberId)), spectators)
+      ref ! PlayerActor.SendEvent(event)
     }
 
     nextState.gameStatus match {
@@ -338,12 +344,18 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
       case Subscribe(playerRef, playerId) =>
         // watch the subscriber so its termination (disconnect/reconnect) drops it from the map automatically
         context.watch(playerRef)
-        playerRef ! PlayerActor.SendEvent(PlayerEvent.GameStateUpdated(roomId, view.fromGame(game, Some(playerId))))
-        active(game, matchId, roomId, persist, gameManager, subscribers + (playerRef -> playerId), publisher)
+        val updatedSubscribers = subscribers + (playerRef -> playerId)
+        // only the (un)subscribing client is pushed here; already-connected viewers pick up the new spectator count
+        // on the next real state change (a move) rather than being re-pushed a full board on every subscribe
+        val viewState = view.fromGame(game, Some(playerId))
+        val event = PlayerEvent.GameStateUpdated(roomId, viewState, spectatorCount(updatedSubscribers, game))
+        playerRef ! PlayerActor.SendEvent(event)
+        active(game, matchId, roomId, persist, gameManager, updatedSubscribers, publisher)
 
       case Unsubscribe(playerRef) =>
         context.unwatch(playerRef)
-        active(game, matchId, roomId, persist, gameManager, subscribers - playerRef, publisher)
+        val updatedSubscribers = subscribers - playerRef
+        active(game, matchId, roomId, persist, gameManager, updatedSubscribers, publisher)
 
       case Broadcast(event) =>
         // chat and other broadcasts carry no hidden state, so every viewer gets the same event

--- a/game-service-actor/src/test/scala/com/andy327/actor/battleship/BattleshipActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/battleship/BattleshipActorSpec.scala
@@ -40,7 +40,7 @@ class BattleshipActorSpec extends AnyWordSpecLike with Matchers {
   /** Receives the next pushed event and asserts it is a GameStateUpdated carrying a BattleshipState. */
   private def stateFrom(probe: TestProbe[PlayerActor.Command]): BattleshipState =
     probe.expectMessageType[PlayerActor.SendEvent].event match {
-      case PlayerEvent.GameStateUpdated(_, s: BattleshipState) => s
+      case PlayerEvent.GameStateUpdated(_, s: BattleshipState, _) => s
       case other => fail(s"expected GameStateUpdated(BattleshipState), got $other")
     }
 

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
@@ -391,7 +391,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       gm ! GameManager.ListLobbies(None, 1, 20, responseProbe.ref)
       val response = responseProbe.expectMessageType[GameManager.LobbiesListed]
-      response.lobbies.map(_.roomId) should contain only (roomId2, roomId3)
+      response.lobbies.map(_.metadata.roomId) should contain only (roomId2, roomId3)
     }
 
     "report a player's joined lobbies and active games via GetPlayerSessions" in {

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
@@ -389,9 +389,11 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
       val GameManager.LobbyCreated(roomId3, _) = responseProbe.receiveMessage()
 
+      // joinable lobbies plus the live game are all listable (so a browser can spectate an in-progress match);
+      // only Finished/Completed/Cancelled rooms stay off this list
       gm ! GameManager.ListLobbies(None, 1, 20, responseProbe.ref)
       val response = responseProbe.expectMessageType[GameManager.LobbiesListed]
-      response.lobbies.map(_.metadata.roomId) should contain only (roomId2, roomId3)
+      response.lobbies.map(_.metadata.roomId) should contain only (roomId1, roomId2, roomId3)
     }
 
     "report a player's joined lobbies and active games via GetPlayerSessions" in {

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
@@ -180,18 +180,18 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       metadata.status shouldBe GameLifecycleStatus.Finished
     }
 
-    "keep a finished room out of the joinable list but still queryable" in {
+    "keep a finished room listed (for spectating) and still queryable" in {
       val f = newLobby()
       val listProbe = TestProbe[LobbyManager.LobbiesListed]()
       val (roomId, _) = startGame(f)
 
       f.lm ! LobbyManager.MatchEnded(roomId, Map.empty)
 
-      // a Finished room is not joinable, so it must not appear in ListLobbies
+      // a Finished room isn't joinable, but it's still listed so a room doesn't flicker off the list between matches
       f.lm ! LobbyManager.ListLobbies(None, 1, 20, listProbe.ref)
-      listProbe.expectMessageType[LobbyManager.LobbiesListed].lobbies.map(_.metadata.roomId) should not contain roomId
+      listProbe.expectMessageType[LobbyManager.LobbiesListed].lobbies.map(_.metadata.roomId) should contain(roomId)
 
-      // but the room survives in memory (for chat/rematch), so GetLobbyInfo still finds it
+      // and the room survives in memory (for chat/rematch), so GetLobbyInfo still finds it
       f.lm ! LobbyManager.GetLobbyInfo(roomId, f.responseProbe.ref)
       val GameManager.LobbyInfo(metadata) = f.responseProbe.expectMessageType[GameManager.LobbyInfo]
       metadata.status shouldBe GameLifecycleStatus.Finished

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
@@ -189,7 +189,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
 
       // a Finished room is not joinable, so it must not appear in ListLobbies
       f.lm ! LobbyManager.ListLobbies(None, 1, 20, listProbe.ref)
-      listProbe.expectMessageType[LobbyManager.LobbiesListed].lobbies.map(_.roomId) should not contain roomId
+      listProbe.expectMessageType[LobbyManager.LobbiesListed].lobbies.map(_.metadata.roomId) should not contain roomId
 
       // but the room survives in memory (for chat/rematch), so GetLobbyInfo still finds it
       f.lm ! LobbyManager.GetLobbyInfo(roomId, f.responseProbe.ref)
@@ -206,8 +206,8 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
 
       // the returned subscriber is told the room is now in its post-game (Finished) state
       sub.expectMessageType[PlayerActor.SendEvent].event match {
-        case PlayerEvent.LobbyUpdated(m) => m.status shouldBe GameLifecycleStatus.Finished
-        case other                       => fail(s"expected LobbyUpdated(Finished), got $other")
+        case PlayerEvent.LobbyUpdated(m, _) => m.status shouldBe GameLifecycleStatus.Finished
+        case other                          => fail(s"expected LobbyUpdated(Finished), got $other")
       }
 
       // and a chat broadcast to the room now reaches the returned subscriber (chat-after-end)
@@ -337,7 +337,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       f.responseProbe.expectMessageType[GameManager.LobbyLeft].message should include("host transferred")
 
       subscriberProbe.expectMessageType[PlayerActor.SendEvent].event match {
-        case PlayerEvent.LobbyUpdated(meta) =>
+        case PlayerEvent.LobbyUpdated(meta, _) =>
           meta.hostId shouldBe bob.id
           meta.players.keySet shouldBe Set(bob.id)
         case other => fail(s"expected LobbyUpdated, got $other")
@@ -543,7 +543,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
 
       lm ! LobbyManager.ListLobbies(None, 1, 20, listProbe.ref)
       val listed = listProbe.expectMessageType[LobbyManager.LobbiesListed]
-      listed.lobbies.map(l => l.players(l.hostId).name) shouldBe List("carol", "bob", "alice")
+      listed.lobbies.map(l => l.metadata.players(l.metadata.hostId).name) shouldBe List("carol", "bob", "alice")
     }
 
     "ignore MatchEnded for an unknown lobby" in {
@@ -595,7 +595,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val result = listProbe.expectMessageType[LobbyManager.LobbiesListed]
       result.lobbies should have size 2
       result.total shouldBe 2
-      result.lobbies.foreach(_.gameType shouldBe GameType.TicTacToe)
+      result.lobbies.foreach(_.metadata.gameType shouldBe GameType.TicTacToe)
     }
 
     "list only the joinable lobbies a player has joined via ListLobbiesForPlayer" in {

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/PlayerActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/PlayerActorSpec.scala
@@ -25,7 +25,7 @@ class PlayerActorSpec extends AnyWordSpecLike with Matchers {
         winner = None,
         draw = false
       )
-      val event = PlayerEvent.GameStateUpdated(UUID.randomUUID(), dummyState)
+      val event = PlayerEvent.GameStateUpdated(UUID.randomUUID(), dummyState, spectatorCount = 0)
 
       actor ! PlayerActor.SendEvent(event)
       sessionProbe.expectMessage(PlayerActor.SessionEvent(event))

--- a/game-service-server/src/main/resources/web/app.js
+++ b/game-service-server/src/main/resources/web/app.js
@@ -264,19 +264,27 @@ async function refreshLobbies() {
 
     li.appendChild(meta);
 
+    // grouped so Join (when present) and Spectate always sit together at a consistent spot, rather than each being
+    // spread out individually by the row's space-between; Spectate first, Join last so Join always lands at the
+    // rightmost edge
+    const actions = document.createElement("span");
+    actions.className = "actions";
+
+    const spectate = document.createElement("button");
+    spectate.textContent = "Spectate";
+    spectate.onclick = () => spectateGame(lobby.roomId, type, lobby.status);
+    actions.appendChild(spectate);
+
     if (joinable) {
       const full = count >= max;
       const join = document.createElement("button");
       join.textContent = full ? "Full" : "Join";
       join.disabled = full;
       if (!full) join.onclick = () => joinGame(lobby.roomId, type);
-      li.appendChild(join);
+      actions.appendChild(join);
     }
 
-    const spectate = document.createElement("button");
-    spectate.textContent = "Spectate";
-    spectate.onclick = () => spectateGame(lobby.roomId, type, lobby.status);
-    li.appendChild(spectate);
+    li.appendChild(actions);
 
     list.appendChild(li);
   }
@@ -299,9 +307,16 @@ function prepareGameView({ roomId, gameType, isHost, isSpectator = false, isLive
   clearTimeout(copyLinkTimer);
   $("copy-link").textContent = COPY_LINK_LABEL;
   $("chat-log").innerHTML = "";
-  $("chat-form").classList.toggle("hidden", isSpectator); // spectators get read-only chat
-  $("leave-game").textContent = isSpectator ? "Stop spectating" : "Leave";
+  $("join-as-player").classList.add("hidden"); // shown only once onLobbyUpdated confirms a joinable, open seat
+  applySpectatorUi(isSpectator);
   showPanel("game");
+}
+
+// Toggle the read-only affordances that depend on whether we're spectating: a spectator gets no chat-send box and a
+// "Stop spectating" label instead of "Leave" (both call the same leaveGame, which routes to the right unsubscribe).
+function applySpectatorUi(isSpectator) {
+  $("chat-form").classList.toggle("hidden", isSpectator);
+  $("leave-game").textContent = isSpectator ? "Stop spectating" : "Leave";
 }
 
 // Watch a lobby or live game without taking a seat. Subscribes via the lobby endpoint for a pre-game room (the same
@@ -398,13 +413,22 @@ async function resumeGame({ roomId, gameType }) {
 // A pre-game lobby changed: refresh the player count, surface the host, and (for the host) enable Start when ready.
 function onLobbyUpdated(metadata) {
   if (!session.game || metadata.roomId !== session.game.roomId) return;
+
+  // Membership in metadata.players is the source of truth for whether we're seated or just watching — re-derive it on
+  // every update so a spectator who clicks "Join this game" picks up their new seat as soon as this push arrives.
+  const isSpectator = !(session.me && metadata.players[session.me.id]);
+  session.game.isSpectator = isSpectator;
+  applySpectatorUi(isSpectator);
+
   if (metadata.status === "InProgress") {
     $("start-game").classList.add("hidden"); // the game is live; Start no longer applies
+    $("join-as-player").classList.add("hidden"); // too late to join — the match already started
     $("post-game-bar").classList.add("hidden"); // a rematch just began; the next GameStateUpdated takes over
     $("rematch-btn").classList.add("hidden");
     return; // game state pushes take over from here
   }
   if (metadata.status === "Finished") {
+    $("join-as-player").classList.add("hidden"); // a finished room's roster is fixed; no new seats to join
     onMatchFinished(metadata);
     return;
   }
@@ -417,15 +441,30 @@ function onLobbyUpdated(metadata) {
   session.game.isHost = youHost;
 
   const max = GAMES[session.game.gameType].maxPlayers;
+  $("join-as-player").classList.toggle("hidden", !isSpectator || count >= max);
   if (youHost) {
     const ready = metadata.status === "ReadyToStart";
     $("start-game").classList.remove("hidden");
     $("start-game").disabled = !ready;
     setStatus(ready ? "Opponent joined — press Start." : `You're hosting — waiting for an opponent… (${count}/${max})`);
+  } else if (isSpectator) {
+    setStatus(`Hosted by ${hostName} — spectating (${count}/${max})`);
   } else {
     $("start-game").classList.add("hidden");
     setStatus(`Hosted by ${hostName} — waiting for them to start… (${count}/${max})`);
   }
+}
+
+// A spectator takes a seat in the still-open lobby they're already watching. Reuses the normal join endpoint — a
+// spectator is just a subscriber with no seat, so joining is exactly what a fresh joiner does. No resubscribe needed:
+// we're already registered for push events, and the resulting LobbyUpdated (fanned out to every subscriber) is what
+// flips session.game.isSpectator and refreshes the UI above.
+async function joinAsPlayer() {
+  const game = session.game;
+  if (!game) return;
+  setError("game-error", "");
+  const res = await api(`/lobby/${game.roomId}/join`, { method: "POST", body: {} });
+  if (!res.ok) flashError("game-error", res.data?.error || res.data || "Could not join the game");
 }
 
 // The room's match has ended but the room survives: keep the final board on screen, surface a rematch bar, and let
@@ -709,6 +748,7 @@ $("refresh-lobbies").addEventListener("click", () => {
 });
 $("lobby-filter").addEventListener("change", refreshLobbies);
 $("start-game").addEventListener("click", startGame);
+$("join-as-player").addEventListener("click", joinAsPlayer);
 $("rematch-btn").addEventListener("click", rematch);
 $("back-to-lobby").addEventListener("click", enterLobby); // browse the lobby without leaving the current game
 $("leave-game").addEventListener("click", leaveGame);

--- a/game-service-server/src/main/resources/web/app.js
+++ b/game-service-server/src/main/resources/web/app.js
@@ -232,10 +232,11 @@ async function refreshLobbies() {
   list.innerHTML = "";
   if (!res.ok) return flashError("lobby-error", "Could not list lobbies");
 
-  const lobbies = (res.data.lobbies || [])
-    .filter((l) => GAMES[l.gameType.toLowerCase()])
-    .filter((l) => !(session.me && l.players[session.me.id])); // lobbies you're in appear under "Your games & lobbies"
-  if (lobbies.length === 0) {
+  // entries are { metadata, spectatorCount }; the server already orders them most-watched-first
+  const entries = (res.data.lobbies || [])
+    .filter((e) => GAMES[e.metadata.gameType.toLowerCase()])
+    .filter((e) => !(session.me && e.metadata.players[session.me.id])); // yours appear under "Your games & lobbies"
+  if (entries.length === 0) {
     const li = document.createElement("li");
     li.className = "meta";
     li.textContent = filter ? "No open lobbies for this game. Create one above." : "No open lobbies. Create one above.";
@@ -243,32 +244,50 @@ async function refreshLobbies() {
     return;
   }
 
-  for (const lobby of lobbies) {
+  for (const entry of entries) {
+    const lobby = entry.metadata;
     const type = lobby.gameType.toLowerCase();
     const max = GAMES[type].maxPlayers;
     const count = Object.keys(lobby.players).length;
     const host = lobby.players[lobby.hostId]; // the host is always present in the players map
     const hostName = host ? host.name : "unknown";
+    const joinable = lobby.status === "WaitingForPlayers" || lobby.status === "ReadyToStart";
+    const phase = lobby.status === "InProgress" ? "in progress" : lobby.status === "Finished" ? "post-game" : null;
     const li = document.createElement("li");
 
+    const watching = entry.spectatorCount > 0 ? ` — ${entry.spectatorCount} watching` : "";
     const meta = document.createElement("span");
     meta.className = "meta";
-    meta.textContent = `${GAMES[type].label} — hosted by ${hostName} — ${count}/${max} players`;
+    meta.textContent = phase
+      ? `${GAMES[type].label} — hosted by ${hostName} — ${phase}${watching}`
+      : `${GAMES[type].label} — hosted by ${hostName} — ${count}/${max} players${watching}`;
 
-    const full = count >= max;
-    const join = document.createElement("button");
-    join.textContent = full ? "Full" : "Join";
-    join.disabled = full;
-    if (!full) join.onclick = () => joinGame(lobby.roomId, type);
+    li.appendChild(meta);
 
-    li.append(meta, join);
+    if (joinable) {
+      const full = count >= max;
+      const join = document.createElement("button");
+      join.textContent = full ? "Full" : "Join";
+      join.disabled = full;
+      if (!full) join.onclick = () => joinGame(lobby.roomId, type);
+      li.appendChild(join);
+    }
+
+    const spectate = document.createElement("button");
+    spectate.textContent = "Spectate";
+    spectate.onclick = () => spectateGame(lobby.roomId, type, lobby.status);
+    li.appendChild(spectate);
+
     list.appendChild(li);
   }
 }
 
 // Reset the game view to a clean slate for a given game/lobby and show it. The caller sets the status and subscribes.
-function prepareGameView({ roomId, gameType, isHost }) {
-  session.game = { roomId, gameType, isHost };
+// isSpectator marks a read-only viewer (board clicks disabled, no chat send); isLive tracks whether we're watching an
+// already-started match (game-actor subscription) vs. a pre-game lobby (lobby subscription) — needed so leaveGame
+// calls the matching unsubscribe endpoint.
+function prepareGameView({ roomId, gameType, isHost, isSpectator = false, isLive = false }) {
+  session.game = { roomId, gameType, isHost, isSpectator, isLive };
   $("game-title").textContent = GAMES[gameType].label;
   $("board").innerHTML = "";
   $("column-controls").innerHTML = "";
@@ -280,7 +299,23 @@ function prepareGameView({ roomId, gameType, isHost }) {
   clearTimeout(copyLinkTimer);
   $("copy-link").textContent = COPY_LINK_LABEL;
   $("chat-log").innerHTML = "";
+  $("chat-form").classList.toggle("hidden", isSpectator); // spectators get read-only chat
+  $("leave-game").textContent = isSpectator ? "Stop spectating" : "Leave";
   showPanel("game");
+}
+
+// Watch a lobby or live game without taking a seat. Subscribes via the lobby endpoint for a pre-game room (the same
+// path a joining player uses) or the game endpoint for an already-started match; both endpoints accept any
+// authenticated player regardless of whether they're seated.
+async function spectateGame(roomId, gameType, status) {
+  setError("lobby-error", "");
+  const live = status === "InProgress";
+  prepareGameView({ roomId, gameType, isHost: false, isSpectator: true, isLive: live });
+  setStatus(live ? "Spectating the match…" : "Spectating the lobby…");
+  const path = live ? `/${gameType}/${roomId}/subscribe` : `/lobby/${roomId}/subscribe`;
+  const res = await api(path, { method: "POST", body: {} });
+  if (!res.ok) flashError("game-error", res.data?.error || res.data || "Could not spectate");
+  loadChatHistory(roomId, gameType);
 }
 
 // Show the lobby screen and refresh both lists: the player's own sessions and the open lobbies.
@@ -353,7 +388,7 @@ async function enterGame({ roomId, gameType, isHost }) {
 // Return to a game already in progress (from the sessions list): subscribe to the game actor, which immediately pushes
 // the current board. Pre-game lobbies are returned to via enterGame instead (they subscribe to the lobby).
 async function resumeGame({ roomId, gameType }) {
-  prepareGameView({ roomId, gameType, isHost: false });
+  prepareGameView({ roomId, gameType, isHost: false, isLive: true });
   setStatus("Returning to the game…");
   const res = await api(`/${gameType}/${roomId}/subscribe`, { method: "POST", body: {} });
   if (!res.ok) flashError("game-error", res.data?.error || res.data || "Could not return to the game");
@@ -428,7 +463,16 @@ function onGameEnded(result) {
 
 async function leaveGame() {
   const game = session.game;
-  if (game) await api(`/lobby/${game.roomId}/leave`, { method: "POST", body: {} });
+  if (game) {
+    if (game.isSpectator) {
+      // a spectator never took a seat, so /lobby/leave (which forfeits a seated player) doesn't apply — unsubscribe
+      // from whichever side (lobby or live game) we're currently watching instead
+      const path = game.isLive ? `/${game.gameType}/${game.roomId}/subscribe` : `/lobby/${game.roomId}/subscribe`;
+      await api(path, { method: "DELETE" });
+    } else {
+      await api(`/lobby/${game.roomId}/leave`, { method: "POST", body: {} });
+    }
+  }
   session.game = null;
   enterLobby();
 }
@@ -473,6 +517,9 @@ function sendChat(text) {
 // are played via drop buttons above the board rather than by clicking individual cells.
 function renderBoard(state) {
   const board = $("board");
+  // a board push means we're now (or still) watching a live game, however we got here — e.g. a spectator watching a
+  // lobby whose match just started, handed off to the game actor along with the seated players
+  if (session.game) session.game.isLive = true;
   $("start-game").classList.add("hidden"); // a live board means the game has started; Start no longer applies
   $("post-game-bar").classList.add("hidden"); // a fresh board (e.g. a rematch) supersedes the prior match's post-game bar
   $("rematch-btn").classList.add("hidden");
@@ -483,15 +530,16 @@ function renderBoard(state) {
   board.innerHTML = "";
 
   const over = Boolean(state.winner) || state.draw === true;
+  const spectating = Boolean(session.game && session.game.isSpectator);
   const columnMode = Boolean(session.game && GAMES[session.game.gameType] && GAMES[session.game.gameType].columns);
 
-  renderColumnControls(columnMode ? cols : 0, rows, over);
+  renderColumnControls(columnMode ? cols : 0, rows, over || spectating);
 
   rows.forEach((cells, r) => {
     cells.forEach((mark, c) => {
       const cell = document.createElement("div");
       // In column mode the cells are display-only; you drop via the buttons above the board.
-      const clickable = !over && !columnMode;
+      const clickable = !over && !spectating && !columnMode;
       cell.className = "cell" + (mark ? ` mark-${mark}` : "") + (clickable ? " clickable" : " disabled");
       cell.textContent = mark;
       if (clickable) cell.onclick = () => submitMove(r, c);

--- a/game-service-server/src/main/resources/web/index.html
+++ b/game-service-server/src/main/resources/web/index.html
@@ -86,6 +86,7 @@
     <div class="row">
       <button id="back-to-lobby">← Lobby</button>
       <button id="start-game" class="hidden">Start game</button>
+      <button id="join-as-player" class="hidden">Join this game</button>
       <button id="copy-link">Copy invite link</button>
       <button id="leave-game">Leave</button>
     </div>

--- a/game-service-server/src/main/resources/web/style.css
+++ b/game-service-server/src/main/resources/web/style.css
@@ -124,6 +124,10 @@ button:disabled { opacity: 0.5; cursor: default; }
 #lobby-list .meta,
 #my-sessions .meta { color: var(--muted); font-size: 0.9rem; }
 
+/* Groups a lobby row's action buttons (Join, Spectate) so they sit together at a consistent spot regardless of how
+   many are present, rather than each being spread out individually by the row's space-between. */
+#lobby-list .actions { display: flex; gap: 0.5rem; flex-shrink: 0; }
+
 /* Board: a grid of square cells sized from the --cols custom property. */
 #board {
   display: grid;

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -20,6 +20,7 @@ import com.andy327.actor.core.GameManager.{
   SubscribeAcknowledged,
   UnsubscribeAcknowledged
 }
+import com.andy327.actor.core.LobbyManager.LobbySummary
 import com.andy327.actor.core.PlayerEvent
 import com.andy327.actor.game.{BattleshipState, GameState, GridGameState}
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyCodecs, LobbyMetadata, Player}
@@ -63,6 +64,8 @@ object JsonProtocol extends CirceSupport {
   implicit val lobbyLeftCodec: Codec[LobbyLeft] = deriveCodec[LobbyLeft]
 
   implicit val gameStartedCodec: Codec[GameStarted] = deriveCodec[GameStarted]
+
+  implicit val lobbySummaryCodec: Codec[LobbySummary] = deriveCodec[LobbySummary]
 
   implicit val lobbiesListedCodec: Codec[LobbiesListed] = deriveCodec[LobbiesListed]
 
@@ -140,16 +143,25 @@ object JsonProtocol extends CirceSupport {
     *
     * Each variant is encoded as a JSON object with a `type` discriminator field so the client can dispatch on the event
     * kind without additional out-of-band information:
-    *   - `{"type":"LobbyUpdated",     "metadata":{...}}`
-    *   - `{"type":"GameStateUpdated", "roomId":..., "state":{...}}`
+    *   - `{"type":"LobbyUpdated",     "metadata":{...}, "spectatorCount":...}`
+    *   - `{"type":"GameStateUpdated", "roomId":..., "state":{...}, "spectatorCount":...}`
     *   - `{"type":"GameEnded",        "result":"Completed"}`
     *   - `{"type":"ChatMessage",      "roomId":..., "senderId":..., "senderName":..., "text":..., "sentAt":...}`
     */
   implicit val playerEventEncoder: Encoder[PlayerEvent] = Encoder.instance {
-    case PlayerEvent.LobbyUpdated(metadata) =>
-      Json.obj("type" -> "LobbyUpdated".asJson, "metadata" -> metadata.asJson)
-    case PlayerEvent.GameStateUpdated(roomId, state) =>
-      Json.obj("type" -> "GameStateUpdated".asJson, "roomId" -> roomId.asJson, "state" -> state.asJson)
+    case PlayerEvent.LobbyUpdated(metadata, spectatorCount) =>
+      Json.obj(
+        "type" -> "LobbyUpdated".asJson,
+        "metadata" -> metadata.asJson,
+        "spectatorCount" -> spectatorCount.asJson
+      )
+    case PlayerEvent.GameStateUpdated(roomId, state, spectatorCount) =>
+      Json.obj(
+        "type" -> "GameStateUpdated".asJson,
+        "roomId" -> roomId.asJson,
+        "state" -> state.asJson,
+        "spectatorCount" -> spectatorCount.asJson
+      )
     case PlayerEvent.GameEnded(result) =>
       Json.obj("type" -> "GameEnded".asJson, "result" -> (result: GameLifecycleStatus).asJson)
     case PlayerEvent.ChatMessage(roomId, senderId, senderName, text, sentAt) =>

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -139,18 +139,20 @@ class SerializationSpec extends AnyWordSpec with Matchers {
         status = GameLifecycleStatus.WaitingForPlayers,
         createdAt = Instant.EPOCH
       )
-      val json = (PlayerEvent.LobbyUpdated(metadata): PlayerEvent).asJson
+      val json = (PlayerEvent.LobbyUpdated(metadata, spectatorCount = 0): PlayerEvent).asJson
       json.hcursor.get[String]("type") shouldBe Right("LobbyUpdated")
       json.asObject.flatMap(_("metadata")) should be(defined)
+      json.hcursor.get[Int]("spectatorCount") shouldBe Right(0)
     }
 
     "encode GameStateUpdated with a type discriminator, roomId, and state" in {
       val roomId = UUID.randomUUID()
       val state = GameStateConverters.serializeGame(TicTacToe.empty(UUID.randomUUID(), UUID.randomUUID()), None)
-      val json = (PlayerEvent.GameStateUpdated(roomId, state): PlayerEvent).asJson
+      val json = (PlayerEvent.GameStateUpdated(roomId, state, spectatorCount = 2): PlayerEvent).asJson
       json.hcursor.get[String]("type") shouldBe Right("GameStateUpdated")
       json.hcursor.get[UUID]("roomId") shouldBe Right(roomId)
       json.asObject.flatMap(_("state")) should be(defined)
+      json.hcursor.get[Int]("spectatorCount") shouldBe Right(2)
     }
 
     "encode GameEnded with a type discriminator and result" in {

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/LobbyRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/LobbyRoutesSpec.scala
@@ -284,7 +284,7 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
       Get("/lobby/list") ~> routes ~> check {
         status shouldBe StatusCodes.OK
         val result = responseAs[GameManager.LobbiesListed]
-        result.lobbies.map(_.roomId) should contain(roomId)
+        result.lobbies.map(_.metadata.roomId) should contain(roomId)
         result.page shouldBe 1
         result.limit shouldBe 20
         result.total should be >= 1
@@ -299,7 +299,7 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
       Get("/lobby/list?gameType=tictactoe") ~> routes ~> check {
         status shouldBe StatusCodes.OK
         val result = responseAs[GameManager.LobbiesListed]
-        result.lobbies.foreach(_.gameType shouldBe GameType.TicTacToe)
+        result.lobbies.foreach(_.metadata.gameType shouldBe GameType.TicTacToe)
       }
     }
 
@@ -324,7 +324,7 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
       Get("/lobby/list?gameType=connectfour") ~> routes ~> check {
         status shouldBe StatusCodes.OK
         val result = responseAs[GameManager.LobbiesListed]
-        result.lobbies.foreach(_.gameType shouldBe GameType.ConnectFour)
+        result.lobbies.foreach(_.metadata.gameType shouldBe GameType.ConnectFour)
       }
     }
 
@@ -504,7 +504,7 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
       // the cancelled lobby is no longer joinable
       Get("/lobby/list") ~> routes ~> check {
         status shouldBe StatusCodes.OK
-        responseAs[GameManager.LobbiesListed].lobbies.map(_.roomId) should not contain roomId
+        responseAs[GameManager.LobbiesListed].lobbies.map(_.metadata.roomId) should not contain roomId
       }
     }
 


### PR DESCRIPTION
Adds a "Spectate" button to the web UI so anyone can watch a lobby, an in-progress match, or a finished room waiting on a rematch — read-only chat included — without taking a seat. A spectator already sitting in a still-open lobby can also take a seat directly from the spectator view.

### What's included
- **Spectator counts** — `LobbyUpdated` and `GameStateUpdated` now carry a live `spectatorCount` (connected subscribers minus seated players), fanned out on every join/leave/subscribe/unsubscribe so it stays current for everyone already watching.
- **Public listing of live and post-game rooms** — `GET /lobby/list` now surfaces every room the server is tracking (`WaitingForPlayers`/`ReadyToStart`/`InProgress`/`Finished`), not just joinable ones, wrapped in a new `LobbySummary` so the list can carry and sort by spectator count (most-watched first) without polluting the persisted `LobbyMetadata`.
- **Spectate button** — subscribes via the existing lobby or game subscribe endpoint (no seat required, no backend change needed there) and renders a read-only board with no chat-send box.
- **Spectator → player** — a spectator in a still-open lobby gets a "Join this game" button; it reuses the plain join endpoint, and the resulting `LobbyUpdated` push (sent to every subscriber) flips them over to a full participant automatically.

### Design notes
- Spectator count is computed only at the broadcast site (`LobbyManager`/`TurnBasedGameActor`), where the subscriber and seated-player maps are already in scope — no new persisted state.
- For an active game, the count only refreshes for already-connected viewers on the next real move rather than re-pushing a full board to everyone on every subscribe, which is unnecessary chatter for something that updates frequently anyway.
- A room no longer drops off the public list when it flips between `InProgress` and `Finished` across a rematch cycle.

### Testing
- `sbt test` — all passing across actor and server modules.
- `scalafmtCheckAll` clean.
- Manually verified the full spectate → game-handoff → spectator-count → join-as-player flow via direct HTTP/WS calls against a running server, plus a manual click-through of the web UI.