### PR TITLE
Add actor message tracing (config-gated, off by default)

### DIFF
--- a/game-service-actor/src/main/resources/reference.conf
+++ b/game-service-actor/src/main/resources/reference.conf
@@ -11,5 +11,9 @@ pekko-game-service {
     # Number of most-recent TraceEvents retained by TraceCollector's in-memory buffer. Older events are dropped once
     # this is exceeded. Ignored when enabled = false.
     buffer-size = 1000
+
+    # Per-message-type overrides of sample-rate, keyed by simple class name (e.g. "MakeMove" = 0.1). A message type
+    # with no entry here uses sample-rate. Empty by default. Ignored when enabled = false.
+    message-sample-rates {}
   }
 }

--- a/game-service-actor/src/main/resources/reference.conf
+++ b/game-service-actor/src/main/resources/reference.conf
@@ -1,0 +1,11 @@
+pekko-game-service {
+  tracing {
+    # Master switch. When false, no TracingInterceptor is installed and no TraceEvent objects
+    # are allocated, so there is zero per-message overhead in production.
+    enabled = false
+
+    # Fraction of messages to record, in [0.0, 1.0]. 1.0 captures every message; lower values
+    # reduce overhead for high-frequency actors. Ignored when enabled = false.
+    sample-rate = 1.0
+  }
+}

--- a/game-service-actor/src/main/resources/reference.conf
+++ b/game-service-actor/src/main/resources/reference.conf
@@ -1,11 +1,11 @@
 pekko-game-service {
   tracing {
-    # Master switch. When false, no TracingInterceptor is installed and no TraceEvent objects
-    # are allocated, so there is zero per-message overhead in production.
+    # Master switch. When false, no TracingInterceptor is installed and no TraceEvent objects are allocated, so there is
+    # zero per-message overhead in production.
     enabled = false
 
-    # Fraction of messages to record, in [0.0, 1.0]. 1.0 captures every message; lower values
-    # reduce overhead for high-frequency actors. Ignored when enabled = false.
+    # Fraction of messages to record, in [0.0, 1.0]. 1.0 captures every message; use a lower value to reduce overhead.
+    # Ignored when enabled = false.
     sample-rate = 1.0
   }
 }

--- a/game-service-actor/src/main/resources/reference.conf
+++ b/game-service-actor/src/main/resources/reference.conf
@@ -7,5 +7,9 @@ pekko-game-service {
     # Fraction of messages to record, in [0.0, 1.0]. 1.0 captures every message; use a lower value to reduce overhead.
     # Ignored when enabled = false.
     sample-rate = 1.0
+
+    # Number of most-recent TraceEvents retained by TraceCollector's in-memory buffer. Older events are dropped once
+    # this is exceeded. Ignored when enabled = false.
+    buffer-size = 1000
   }
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
@@ -17,6 +17,7 @@ import com.andy327.actor.events.{EventPublisher, GameEvent, NoOpEventPublisher}
 import com.andy327.actor.game.{GameOperation, GameRegistry, GameState}
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyError, LobbyMetadata, LobbyRepository, Player}
 import com.andy327.actor.persistence.PersistenceProtocol
+import com.andy327.actor.tracing.{TraceEvent, TracingConfig, TracingInterceptor}
 import com.andy327.model.core.{Game, GameError, GameType, MatchId, PlayerId, RoomId}
 import com.andy327.persistence.db.{GameRepository, MoveHistoryRepository, MoveRecord, NoOpMoveHistoryRepository}
 
@@ -361,6 +362,9 @@ object GameManager {
     * @param publisher emit seam for analytics events (game started/move made/game completed/chat sent); defaults to
     *                  no-op
     * @param onReady optional ref that receives a [[Ready]] signal once the running state is entered (used in tests)
+    * @param tracingConfig controls whether [[tracing.TracingInterceptor]] is installed on spawned child actors;
+    *                      defaults to the `pekko-game-service.tracing` config stanza (disabled by default)
+    * @param traceEmit sink for [[tracing.TraceEvent]]s emitted by the interceptors; defaults to no-op
     */
   @annotation.nowarn("msg=match may not be exhaustive")
   def apply(
@@ -370,12 +374,20 @@ object GameManager {
       moveRepo: MoveHistoryRepository = NoOpMoveHistoryRepository,
       chatRepo: ChatRepository = NoOpChatRepository,
       publisher: EventPublisher = NoOpEventPublisher,
-      onReady: Option[ActorRef[Ready.type]] = None
+      onReady: Option[ActorRef[Ready.type]] = None,
+      tracingConfig: TracingConfig = TracingConfig.default,
+      traceEmit: TraceEvent => Unit = _ => ()
   )(implicit runtime: IORuntime): Behavior[Command] =
     Behaviors.withStash(capacity = 128) { stash =>
       Behaviors.setup { context =>
-        val lobbyManager = context.spawn(LobbyManager(context.self, lobbyRepo), "lobby-manager")
-        val playerManager = context.spawn(PlayerManager(), "player-manager")
+        val lobbyManager = context.spawn(
+          TracingInterceptor.wrap(LobbyManager(context.self, lobbyRepo), tracingConfig, traceEmit),
+          "lobby-manager"
+        )
+        val playerManager = context.spawn(
+          TracingInterceptor.wrap(PlayerManager(tracingConfig, traceEmit), tracingConfig, traceEmit),
+          "player-manager"
+        )
 
         val restoreIO = for {
           games <- IO.defer(gameRepo.loadAllGames())
@@ -400,7 +412,9 @@ object GameManager {
           chatRepo,
           stash,
           publisher,
-          onReady
+          onReady,
+          tracingConfig,
+          traceEmit
         )
       }
     }
@@ -419,6 +433,8 @@ object GameManager {
     * @param stash buffer holding commands received before the restore completes; drained into [[running]]
     * @param publisher emit seam for analytics events (game started/move made/game completed/chat sent)
     * @param onReady optional ref signalled once the running state is entered (used in tests)
+    * @param tracingConfig forwarded to [[running]] for wrapping game actor spawns on [[SpawnGame]]
+    * @param traceEmit forwarded to [[running]] as the sink for [[TraceEvent]]s on game actor spawns
     */
   private def initializing(
       lobbyManager: ActorRef[LobbyManager.Command],
@@ -429,7 +445,9 @@ object GameManager {
       chatRepo: ChatRepository,
       stash: StashBuffer[Command],
       publisher: EventPublisher,
-      onReady: Option[ActorRef[Ready.type]]
+      onReady: Option[ActorRef[Ready.type]],
+      tracingConfig: TracingConfig,
+      traceEmit: TraceEvent => Unit
   )(implicit runtime: IORuntime): Behavior[Command] = Behaviors.receive { (context, message) =>
     message match {
       case RestoreGames(games, lobbies) =>
@@ -450,7 +468,10 @@ object GameManager {
         val restoredActors = resolved.map { case (roomId, matchId, gameType, game) =>
           val gameActor = GameRegistry.forType(gameType).actor
           val behavior = gameActor.fromSnapshot(matchId, roomId, game, persistActor, context.self, publisher)
-          val actorRef = context.spawn(behavior, s"game-$matchId").unsafeUpcast[GameActor.GameCommand]
+          val actorRef = context.spawn(
+            TracingInterceptor.wrap(behavior, tracingConfig, traceEmit),
+            s"game-$matchId"
+          ).unsafeUpcast[GameActor.GameCommand]
           roomId -> (gameType, matchId, actorRef)
         }.toMap
 
@@ -475,7 +496,9 @@ object GameManager {
             gameRepo,
             moveRepo,
             chatRepo,
-            publisher
+            publisher,
+            tracingConfig,
+            traceEmit
           )(runtime)
         )
 
@@ -504,6 +527,8 @@ object GameManager {
     * @param moveRepo repository read to serve move-history queries
     * @param chatRepo repository written on each chat message and read to serve backscroll
     * @param publisher emit seam for analytics events (game started/move made/game completed/chat sent)
+    * @param tracingConfig passed to [[TracingInterceptor.wrap]] at each game-actor spawn site
+    * @param traceEmit sink for [[TraceEvent]]s produced by the game actor interceptors
     */
   private def running(
       activeGames: Map[RoomId, (GameType, MatchId, ActorRef[GameActor.GameCommand])],
@@ -515,7 +540,9 @@ object GameManager {
       gameRepo: GameRepository,
       moveRepo: MoveHistoryRepository,
       chatRepo: ChatRepository,
-      publisher: EventPublisher
+      publisher: EventPublisher,
+      tracingConfig: TracingConfig,
+      traceEmit: TraceEvent => Unit
   )(implicit runtime: IORuntime): Behavior[Command] =
     Behaviors.receive { (context, message) =>
       message match {
@@ -706,7 +733,10 @@ object GameManager {
             val bundle = GameRegistry.forType(gameType)
             val (game, behavior) =
               bundle.actor.create(matchId, roomId, players, persistActor, context.self, publisher)
-            val actorRef = context.spawn(behavior, s"game-$matchId").unsafeUpcast[GameActor.GameCommand]
+            val actorRef = context.spawn(
+              TracingInterceptor.wrap(behavior, tracingConfig, traceEmit),
+              s"game-$matchId"
+            ).unsafeUpcast[GameActor.GameCommand]
 
             subscribers.foreach { case (pid, ref) => actorRef ! bundle.actor.subscribeCommand(ref, pid) }
 
@@ -732,7 +762,9 @@ object GameManager {
               gameRepo,
               moveRepo,
               chatRepo,
-              publisher
+              publisher,
+              tracingConfig,
+              traceEmit
             )
           }
 
@@ -755,7 +787,9 @@ object GameManager {
                 gameRepo,
                 moveRepo,
                 chatRepo,
-                publisher
+                publisher,
+                tracingConfig,
+                traceEmit
               )
             case None =>
               context.log.warn(s"Received GameCompleted for unknown room: $roomId")
@@ -773,7 +807,9 @@ object GameManager {
             gameRepo,
             moveRepo,
             chatRepo,
-            publisher
+            publisher,
+            tracingConfig,
+            traceEmit
           )
 
         case RunGameOperation(roomId, op, replyTo) =>

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
@@ -433,8 +433,9 @@ object GameManager {
     * @param stash buffer holding commands received before the restore completes; drained into [[running]]
     * @param publisher emit seam for analytics events (game started/move made/game completed/chat sent)
     * @param onReady optional ref signalled once the running state is entered (used in tests)
-    * @param tracingConfig forwarded to [[running]] for wrapping game actor spawns on [[SpawnGame]]
-    * @param traceEmit forwarded to [[running]] as the sink for [[TraceEvent]]s on game actor spawns
+    * @param tracingConfig used to wrap each restored game actor's spawn on [[RestoreGames]], then forwarded to
+    *                      [[running]] for wrapping spawns on [[SpawnGame]]
+    * @param traceEmit sink for [[TraceEvent]]s from the restored-actor interceptors, then forwarded to [[running]]
     */
   private def initializing(
       lobbyManager: ActorRef[LobbyManager.Command],

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/PlayerManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/PlayerManager.scala
@@ -4,6 +4,7 @@ import org.apache.pekko.actor.typed.scaladsl.Behaviors
 import org.apache.pekko.actor.typed.{ActorRef, Behavior}
 
 import com.andy327.actor.lobby.Player
+import com.andy327.actor.tracing.{TraceEvent, TracingConfig, TracingInterceptor}
 import com.andy327.model.core.PlayerId
 
 /** A child actor of GameManager that tracks one PlayerActor per connected player.
@@ -42,22 +43,35 @@ object PlayerManager {
     */
   final case class PlayerDisconnected(playerId: PlayerId, playerRef: ActorRef[PlayerActor.Command]) extends Command
 
-  def apply(): Behavior[Command] = running(Map.empty, 0)
+  def apply(
+      tracingConfig: TracingConfig = TracingConfig.default,
+      traceEmit: TraceEvent => Unit = _ => ()
+  ): Behavior[Command] = running(Map.empty, 0, tracingConfig, traceEmit)
 
   /** Tracks the live player registry.
     *
     * @param players map from PlayerId to the currently running PlayerActor ref
     * @param spawnCount monotonically increasing counter appended to child names to satisfy Pekko's uniqueness
     *                   constraint during the brief overlap when an old actor is still stopping on reconnect
+    * @param tracingConfig passed to [[TracingInterceptor.wrap]] when spawning each [[PlayerActor]]
+    * @param traceEmit sink for [[TraceEvent]]s produced by the player-actor interceptors
     */
-  private def running(players: Map[PlayerId, ActorRef[PlayerActor.Command]], spawnCount: Int): Behavior[Command] =
+  private def running(
+      players: Map[PlayerId, ActorRef[PlayerActor.Command]],
+      spawnCount: Int,
+      tracingConfig: TracingConfig,
+      traceEmit: TraceEvent => Unit
+  ): Behavior[Command] =
     Behaviors.receive { (context, message) =>
       message match {
         case RegisterPlayer(player, sessionOut, replyTo) =>
           players.get(player.id).foreach(_ ! PlayerActor.Disconnect)
-          val ref = context.spawn(PlayerActor(player, sessionOut), s"player-${player.id}-$spawnCount")
+          val ref = context.spawn(
+            TracingInterceptor.wrap(PlayerActor(player, sessionOut), tracingConfig, traceEmit),
+            s"player-${player.id}-$spawnCount"
+          )
           replyTo ! ref
-          running(players + (player.id -> ref), spawnCount + 1)
+          running(players + (player.id -> ref), spawnCount + 1, tracingConfig, traceEmit)
 
         case LookupPlayer(playerId, replyTo) =>
           replyTo ! players.get(playerId)
@@ -66,7 +80,7 @@ object PlayerManager {
         case PlayerDisconnected(playerId, playerRef) =>
           if (players.get(playerId).contains(playerRef)) {
             playerRef ! PlayerActor.Disconnect
-            running(players - playerId, spawnCount)
+            running(players - playerId, spawnCount, tracingConfig, traceEmit)
           } else {
             context.log.debug(s"Ignoring stale PlayerDisconnected for $playerId")
             Behaviors.same

--- a/game-service-actor/src/main/scala/com/andy327/actor/tracing/TraceCollector.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/tracing/TraceCollector.scala
@@ -1,0 +1,38 @@
+package com.andy327.actor.tracing
+
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko.actor.typed.{ActorRef, Behavior}
+
+/** Holds the most recent [[TraceEvent]]s in a bounded in-memory buffer, for later retrieval by a debug/visualization
+  * endpoint (not yet implemented — see the `feat-trace-debug-viewer` branch).
+  *
+  * Each [[TracingInterceptor]] installed across the actor system sends its events here via [[Record]]. The buffer
+  * retains at most `bufferSize` events, dropping the oldest once full, so memory use stays bounded regardless of how
+  * long the system runs or how chatty tracing is.
+  *
+  * Actor relationships:
+  *   - Parent: root (top-level, created by `GameServer` only when tracing is enabled)
+  *   - Receives from: every [[TracingInterceptor]] instance system-wide (`Record`)
+  */
+object TraceCollector {
+  sealed trait Command
+
+  /** Append `event` to the buffer, evicting the oldest event if the buffer is already at capacity. */
+  final case class Record(event: TraceEvent) extends Command
+
+  /** Reply with the buffered events, oldest first. */
+  final case class GetRecent(replyTo: ActorRef[Vector[TraceEvent]]) extends Command
+
+  /** @param bufferSize the maximum number of events retained; typically [[TracingConfig.bufferSize]] */
+  def apply(bufferSize: Int): Behavior[Command] = running(Vector.empty, bufferSize)
+
+  private def running(buffer: Vector[TraceEvent], bufferSize: Int): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case Record(event) =>
+        running((buffer :+ event).takeRight(bufferSize), bufferSize)
+
+      case GetRecent(replyTo) =>
+        replyTo ! buffer
+        Behaviors.same
+    }
+}

--- a/game-service-actor/src/main/scala/com/andy327/actor/tracing/TraceEvent.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/tracing/TraceEvent.scala
@@ -4,8 +4,12 @@ import java.time.Instant
 
 /** A single actor message receipt recorded by the tracing layer.
   *
-  * @param from actor path of the message sender; `None` when the sender cannot be determined (e.g. dead-letters or
-  *             system messages)
+  * @param from actor path of the message sender. Always `None` under the current [[TracingInterceptor]]
+  *             implementation: typed Pekko exposes no sender on a received message (protocols carry `replyTo`
+  *             explicitly instead of an implicit envelope sender), and a `BehaviorInterceptor` only observes the
+  *             receiving side, so there is no hook to capture who sent a message. The field is kept on the model
+  *             because a sender is required to draw edges in a flow visualization; populating it will need a
+  *             different or additional capture mechanism, which is out of scope for this branch.
   * @param to actor path of the receiving actor
   * @param messageType simple class name of the received message
   * @param timestamp wall-clock time at which the interceptor observed the message

--- a/game-service-actor/src/main/scala/com/andy327/actor/tracing/TraceEvent.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/tracing/TraceEvent.scala
@@ -1,0 +1,18 @@
+package com.andy327.actor.tracing
+
+import java.time.Instant
+
+/** A single actor message receipt recorded by the tracing layer.
+  *
+  * @param from actor path of the message sender; `None` when the sender cannot be determined (e.g. dead-letters or
+  *             system messages)
+  * @param to actor path of the receiving actor
+  * @param messageType simple class name of the received message
+  * @param timestamp wall-clock time at which the interceptor observed the message
+  */
+final case class TraceEvent(
+    from: Option[String],
+    to: String,
+    messageType: String,
+    timestamp: Instant
+)

--- a/game-service-actor/src/main/scala/com/andy327/actor/tracing/TracingConfig.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/tracing/TracingConfig.scala
@@ -11,8 +11,9 @@ import com.typesafe.config.{Config, ConfigFactory}
   * @param enabled master switch; must be `true` for any tracing to occur
   * @param sampleRate fraction of messages to record, in [0.0, 1.0]; 1.0 records every message, lower values reduce
   *                   overhead for high-frequency actors (e.g. a bot sending moves rapidly)
+  * @param bufferSize number of most-recent [[TraceEvent]]s retained by [[TraceCollector]]'s in-memory buffer
   */
-final case class TracingConfig(enabled: Boolean, sampleRate: Double)
+final case class TracingConfig(enabled: Boolean, sampleRate: Double, bufferSize: Int)
 
 object TracingConfig {
   private val Namespace = "pekko-game-service.tracing"
@@ -20,7 +21,8 @@ object TracingConfig {
   def fromConfig(config: Config): TracingConfig =
     TracingConfig(
       enabled = config.getBoolean(s"$Namespace.enabled"),
-      sampleRate = config.getDouble(s"$Namespace.sample-rate")
+      sampleRate = config.getDouble(s"$Namespace.sample-rate"),
+      bufferSize = config.getInt(s"$Namespace.buffer-size")
     )
 
   /** Loads from the standard `ConfigFactory.load()` resolution chain (application.conf → reference.conf). */

--- a/game-service-actor/src/main/scala/com/andy327/actor/tracing/TracingConfig.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/tracing/TracingConfig.scala
@@ -1,5 +1,7 @@
 package com.andy327.actor.tracing
 
+import scala.jdk.CollectionConverters._
+
 import com.typesafe.config.{Config, ConfigFactory}
 
 /** Controls whether actor message tracing is active and how aggressively it samples.
@@ -9,21 +11,49 @@ import com.typesafe.config.{Config, ConfigFactory}
   * no per-message overhead in production.
   *
   * @param enabled master switch; must be `true` for any tracing to occur
-  * @param sampleRate fraction of messages to record, in [0.0, 1.0]; 1.0 records every message, lower values reduce
-  *                   overhead for high-frequency actors (e.g. a bot sending moves rapidly)
+  * @param sampleRate default fraction of messages to record, in [0.0, 1.0]; 1.0 records every message, lower values
+  *                   reduce overhead for high-frequency actors (e.g. a bot sending moves rapidly). Applies to any
+  *                   message type with no entry in `messageSampleRates`
   * @param bufferSize number of most-recent [[TraceEvent]]s retained by [[TraceCollector]]'s in-memory buffer
+  * @param messageSampleRates per-message-type overrides of `sampleRate`, keyed by simple class name (e.g.
+  *                           `"MakeMove"`). Lets a specific high-frequency message type be sampled down (or up)
+  *                           without changing the rate applied to every other message type
   */
-final case class TracingConfig(enabled: Boolean, sampleRate: Double, bufferSize: Int)
+final case class TracingConfig(
+    enabled: Boolean,
+    sampleRate: Double,
+    bufferSize: Int,
+    messageSampleRates: Map[String, Double] = Map.empty
+) {
+
+  /** The sample rate to apply to a message named `messageType`: its entry in [[messageSampleRates]] if present,
+    * otherwise the default [[sampleRate]].
+    */
+  def sampleRateFor(messageType: String): Double = messageSampleRates.getOrElse(messageType, sampleRate)
+}
 
 object TracingConfig {
   private val Namespace = "pekko-game-service.tracing"
 
-  def fromConfig(config: Config): TracingConfig =
+  def fromConfig(config: Config): TracingConfig = {
+    val overridesPath = s"$Namespace.message-sample-rates"
+    val messageSampleRates =
+      if (config.hasPath(overridesPath))
+        config
+          .getConfig(overridesPath)
+          .entrySet()
+          .asScala
+          .map(entry => entry.getKey -> entry.getValue.unwrapped().asInstanceOf[Number].doubleValue())
+          .toMap
+      else Map.empty[String, Double]
+
     TracingConfig(
       enabled = config.getBoolean(s"$Namespace.enabled"),
       sampleRate = config.getDouble(s"$Namespace.sample-rate"),
-      bufferSize = config.getInt(s"$Namespace.buffer-size")
+      bufferSize = config.getInt(s"$Namespace.buffer-size"),
+      messageSampleRates = messageSampleRates
     )
+  }
 
   /** Loads from the standard `ConfigFactory.load()` resolution chain (application.conf → reference.conf). */
   lazy val default: TracingConfig = fromConfig(ConfigFactory.load())

--- a/game-service-actor/src/main/scala/com/andy327/actor/tracing/TracingConfig.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/tracing/TracingConfig.scala
@@ -1,0 +1,28 @@
+package com.andy327.actor.tracing
+
+import com.typesafe.config.{Config, ConfigFactory}
+
+/** Controls whether actor message tracing is active and how aggressively it samples.
+  *
+  * Loaded from the `pekko-game-service.tracing` stanza in `application.conf` (or the reference defaults). When
+  * `enabled` is `false` no [[TraceEvent]] objects are allocated and no `TracingInterceptor` is installed, so there is
+  * no per-message overhead in production.
+  *
+  * @param enabled master switch; must be `true` for any tracing to occur
+  * @param sampleRate fraction of messages to record, in [0.0, 1.0]; 1.0 records every message, lower values
+  *                   reduce overhead for high-frequency actors (e.g. a bot sending moves rapidly)
+  */
+final case class TracingConfig(enabled: Boolean, sampleRate: Double)
+
+object TracingConfig {
+  private val Namespace = "pekko-game-service.tracing"
+
+  def fromConfig(config: Config): TracingConfig =
+    TracingConfig(
+      enabled = config.getBoolean(s"$Namespace.enabled"),
+      sampleRate = config.getDouble(s"$Namespace.sample-rate")
+    )
+
+  /** Loads from the standard [[ConfigFactory.load()]] resolution chain (application.conf → reference.conf). */
+  lazy val default: TracingConfig = fromConfig(ConfigFactory.load())
+}

--- a/game-service-actor/src/main/scala/com/andy327/actor/tracing/TracingConfig.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/tracing/TracingConfig.scala
@@ -9,8 +9,8 @@ import com.typesafe.config.{Config, ConfigFactory}
   * no per-message overhead in production.
   *
   * @param enabled master switch; must be `true` for any tracing to occur
-  * @param sampleRate fraction of messages to record, in [0.0, 1.0]; 1.0 records every message, lower values
-  *                   reduce overhead for high-frequency actors (e.g. a bot sending moves rapidly)
+  * @param sampleRate fraction of messages to record, in [0.0, 1.0]; 1.0 records every message, lower values reduce
+  *                   overhead for high-frequency actors (e.g. a bot sending moves rapidly)
   */
 final case class TracingConfig(enabled: Boolean, sampleRate: Double)
 
@@ -23,6 +23,6 @@ object TracingConfig {
       sampleRate = config.getDouble(s"$Namespace.sample-rate")
     )
 
-  /** Loads from the standard [[ConfigFactory.load()]] resolution chain (application.conf → reference.conf). */
+  /** Loads from the standard `ConfigFactory.load()` resolution chain (application.conf → reference.conf). */
   lazy val default: TracingConfig = fromConfig(ConfigFactory.load())
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/tracing/TracingInterceptor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/tracing/TracingInterceptor.scala
@@ -1,0 +1,54 @@
+package com.andy327.actor.tracing
+
+import java.time.Instant
+
+import scala.reflect.ClassTag
+import scala.util.Random
+
+import org.apache.pekko.actor.typed.BehaviorInterceptor.{ReceiveTarget, SignalTarget}
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko.actor.typed.{Behavior, BehaviorInterceptor, Signal, TypedActorContext}
+
+/** A [[BehaviorInterceptor]] that emits a [[TraceEvent]] for each message received by the wrapped actor.
+  *
+  * Install via [[TracingInterceptor.wrap]]; that helper is a no-op when `config.enabled` is `false`, so disabled
+  * tracing costs nothing after startup — no interceptor is instantiated, no events are allocated.
+  *
+  * Because typed Pekko does not expose the sender on received messages, `TraceEvent.from` is always `None`. The `to`
+  * field is the receiving actor's path, available via the interceptor context.
+  *
+  * `isSame` uses reference equality so that each interceptor instance is treated as distinct by Pekko's
+  * interceptor-deduplication logic, allowing the same class to be applied independently to different actors.
+  */
+final private class TracingInterceptor[T](config: TracingConfig, emit: TraceEvent => Unit)(implicit
+    ct: ClassTag[T]
+) extends BehaviorInterceptor[T, T](ct.runtimeClass.asInstanceOf[Class[T]]) {
+
+  override def aroundReceive(ctx: TypedActorContext[T], msg: T, target: ReceiveTarget[T]): Behavior[T] = {
+    if (config.sampleRate >= 1.0 || Random.nextDouble() < config.sampleRate)
+      emit(
+        TraceEvent(
+          from = None,
+          to = ctx.asScala.self.path.toString,
+          messageType = msg.getClass.getSimpleName,
+          timestamp = Instant.now()
+        )
+      )
+    target(ctx, msg)
+  }
+
+  override def aroundSignal(ctx: TypedActorContext[T], signal: Signal, target: SignalTarget[T]): Behavior[T] =
+    target(ctx, signal)
+
+  override def isSame(other: BehaviorInterceptor[Any, Any]): Boolean = this eq other
+}
+
+object TracingInterceptor {
+
+  /** Wraps `behavior` with the tracing interceptor when `config.enabled` is `true`; returns `behavior` unchanged
+    * otherwise. Callers use this at every actor spawn point so the gating lives in one place.
+    */
+  def wrap[T: ClassTag](behavior: Behavior[T], config: TracingConfig, emit: TraceEvent => Unit): Behavior[T] =
+    if (!config.enabled) behavior
+    else Behaviors.intercept(() => new TracingInterceptor[T](config, emit))(behavior)
+}

--- a/game-service-actor/src/main/scala/com/andy327/actor/tracing/TracingInterceptor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/tracing/TracingInterceptor.scala
@@ -8,8 +8,8 @@ import org.apache.pekko.actor.typed.BehaviorInterceptor.{ReceiveTarget, SignalTa
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
 import org.apache.pekko.actor.typed.{Behavior, BehaviorInterceptor, Signal, TypedActorContext}
 
-/** A [[BehaviorInterceptor]] that passes every message received by the wrapped actor straight through, while
-  * emitting a [[TraceEvent]] for it (subject to `config.sampleRate`).
+/** A [[BehaviorInterceptor]] that passes every message received by the wrapped actor straight through, while emitting a
+  * [[TraceEvent]] for it (subject to the message type's effective sample rate, see [[TracingConfig.sampleRateFor]]).
   *
   * Install via [[TracingInterceptor.wrap]]; that helper is a no-op when `config.enabled` is `false`, so disabled
   * tracing costs nothing after startup — no interceptor is instantiated, no events are allocated.
@@ -17,9 +17,9 @@ import org.apache.pekko.actor.typed.{Behavior, BehaviorInterceptor, Signal, Type
   * Because typed Pekko does not expose the sender on received messages, `TraceEvent.from` is always `None`. The `to`
   * field is the receiving actor's path, available via the interceptor context.
   *
-  * Passes `classOf[AnyRef]` (via an unchecked cast to `Class[T]`) as the `interceptMessageClass` constructor
-  * argument, so Pekko's runtime `isInstance` check accepts every message regardless of the concrete command type —
-  * safe because `aroundReceive` only ever receives messages the actor's own mailbox has already typed as `T`.
+  * Passes `classOf[AnyRef]` (via an unchecked cast to `Class[T]`) as the `interceptMessageClass` constructor argument,
+  * so Pekko's runtime `isInstance` check accepts every message regardless of the concrete command type — safe because
+  * `aroundReceive` only ever receives messages the actor's own mailbox has already typed as `T`.
   *
   * `isSame` uses reference equality so that each interceptor instance is treated as distinct by Pekko's
   * interceptor-deduplication logic, allowing the same class to be applied independently to different actors.
@@ -28,12 +28,14 @@ final private class TracingInterceptor[T](config: TracingConfig, emit: TraceEven
     extends BehaviorInterceptor[T, T](classOf[AnyRef].asInstanceOf[Class[T]]) {
 
   override def aroundReceive(ctx: TypedActorContext[T], msg: T, target: ReceiveTarget[T]): Behavior[T] = {
-    if (config.sampleRate >= 1.0 || Random.nextDouble() < config.sampleRate)
+    val messageType = msg.getClass.getSimpleName
+    val rate = config.sampleRateFor(messageType)
+    if (rate >= 1.0 || Random.nextDouble() < rate)
       emit(
         TraceEvent(
           from = None,
           to = ctx.asScala.self.path.toString,
-          messageType = msg.getClass.getSimpleName,
+          messageType = messageType,
           timestamp = Instant.now()
         )
       )

--- a/game-service-actor/src/main/scala/com/andy327/actor/tracing/TracingInterceptor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/tracing/TracingInterceptor.scala
@@ -8,7 +8,8 @@ import org.apache.pekko.actor.typed.BehaviorInterceptor.{ReceiveTarget, SignalTa
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
 import org.apache.pekko.actor.typed.{Behavior, BehaviorInterceptor, Signal, TypedActorContext}
 
-/** A [[BehaviorInterceptor]] that emits a [[TraceEvent]] for each message received by the wrapped actor.
+/** A [[BehaviorInterceptor]] that passes every message received by the wrapped actor straight through, while
+  * emitting a [[TraceEvent]] for it (subject to `config.sampleRate`).
   *
   * Install via [[TracingInterceptor.wrap]]; that helper is a no-op when `config.enabled` is `false`, so disabled
   * tracing costs nothing after startup — no interceptor is instantiated, no events are allocated.
@@ -16,9 +17,9 @@ import org.apache.pekko.actor.typed.{Behavior, BehaviorInterceptor, Signal, Type
   * Because typed Pekko does not expose the sender on received messages, `TraceEvent.from` is always `None`. The `to`
   * field is the receiving actor's path, available via the interceptor context.
   *
-  * Uses `classOf[AnyRef]` as the `interceptMessageClass` so the interceptor fires for every received message
-  * regardless of the concrete command type. This avoids requiring a `ClassTag` at call sites where the actor's
-  * command type is a path-dependent abstract type member (e.g. `bundle.actor.Command` in [[GameManager]]).
+  * Passes `classOf[AnyRef]` (via an unchecked cast to `Class[T]`) as the `interceptMessageClass` constructor
+  * argument, so Pekko's runtime `isInstance` check accepts every message regardless of the concrete command type —
+  * safe because `aroundReceive` only ever receives messages the actor's own mailbox has already typed as `T`.
   *
   * `isSame` uses reference equality so that each interceptor instance is treated as distinct by Pekko's
   * interceptor-deduplication logic, allowing the same class to be applied independently to different actors.

--- a/game-service-actor/src/main/scala/com/andy327/actor/tracing/TracingInterceptor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/tracing/TracingInterceptor.scala
@@ -2,7 +2,6 @@ package com.andy327.actor.tracing
 
 import java.time.Instant
 
-import scala.reflect.ClassTag
 import scala.util.Random
 
 import org.apache.pekko.actor.typed.BehaviorInterceptor.{ReceiveTarget, SignalTarget}
@@ -17,12 +16,15 @@ import org.apache.pekko.actor.typed.{Behavior, BehaviorInterceptor, Signal, Type
   * Because typed Pekko does not expose the sender on received messages, `TraceEvent.from` is always `None`. The `to`
   * field is the receiving actor's path, available via the interceptor context.
   *
+  * Uses `classOf[AnyRef]` as the `interceptMessageClass` so the interceptor fires for every received message
+  * regardless of the concrete command type. This avoids requiring a `ClassTag` at call sites where the actor's
+  * command type is a path-dependent abstract type member (e.g. `bundle.actor.Command` in [[GameManager]]).
+  *
   * `isSame` uses reference equality so that each interceptor instance is treated as distinct by Pekko's
   * interceptor-deduplication logic, allowing the same class to be applied independently to different actors.
   */
-final private class TracingInterceptor[T](config: TracingConfig, emit: TraceEvent => Unit)(implicit
-    ct: ClassTag[T]
-) extends BehaviorInterceptor[T, T](ct.runtimeClass.asInstanceOf[Class[T]]) {
+final private class TracingInterceptor[T](config: TracingConfig, emit: TraceEvent => Unit)
+    extends BehaviorInterceptor[T, T](classOf[AnyRef].asInstanceOf[Class[T]]) {
 
   override def aroundReceive(ctx: TypedActorContext[T], msg: T, target: ReceiveTarget[T]): Behavior[T] = {
     if (config.sampleRate >= 1.0 || Random.nextDouble() < config.sampleRate)
@@ -48,7 +50,7 @@ object TracingInterceptor {
   /** Wraps `behavior` with the tracing interceptor when `config.enabled` is `true`; returns `behavior` unchanged
     * otherwise. Callers use this at every actor spawn point so the gating lives in one place.
     */
-  def wrap[T: ClassTag](behavior: Behavior[T], config: TracingConfig, emit: TraceEvent => Unit): Behavior[T] =
+  def wrap[T](behavior: Behavior[T], config: TracingConfig, emit: TraceEvent => Unit): Behavior[T] =
     if (!config.enabled) behavior
     else Behaviors.intercept(() => new TracingInterceptor[T](config, emit))(behavior)
 }

--- a/game-service-actor/src/test/scala/com/andy327/actor/tracing/TraceCollectorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/tracing/TraceCollectorSpec.scala
@@ -1,0 +1,60 @@
+package com.andy327.actor.tracing
+
+import java.time.Instant
+
+import org.apache.pekko.actor.testkit.typed.scaladsl.ActorTestKit
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class TraceCollectorSpec extends AnyWordSpecLike with Matchers {
+  private val testKit = ActorTestKit()
+  import testKit._
+
+  private def event(n: Int): TraceEvent =
+    TraceEvent(from = None, to = s"actor-$n", messageType = "Ping", timestamp = Instant.ofEpochMilli(n.toLong))
+
+  "TraceCollector" should {
+    "reply with an empty buffer before any events are recorded" in {
+      val collector = spawn(TraceCollector(bufferSize = 10))
+      val probe = createTestProbe[Vector[TraceEvent]]()
+
+      collector ! TraceCollector.GetRecent(probe.ref)
+
+      probe.expectMessage(Vector.empty)
+    }
+
+    "return recorded events oldest first" in {
+      val collector = spawn(TraceCollector(bufferSize = 10))
+      val probe = createTestProbe[Vector[TraceEvent]]()
+
+      collector ! TraceCollector.Record(event(1))
+      collector ! TraceCollector.Record(event(2))
+      collector ! TraceCollector.Record(event(3))
+      collector ! TraceCollector.GetRecent(probe.ref)
+
+      probe.expectMessage(Vector(event(1), event(2), event(3)))
+    }
+
+    "drop the oldest event once the buffer exceeds its capacity" in {
+      val collector = spawn(TraceCollector(bufferSize = 2))
+      val probe = createTestProbe[Vector[TraceEvent]]()
+
+      collector ! TraceCollector.Record(event(1))
+      collector ! TraceCollector.Record(event(2))
+      collector ! TraceCollector.Record(event(3))
+      collector ! TraceCollector.GetRecent(probe.ref)
+
+      probe.expectMessage(Vector(event(2), event(3)))
+    }
+
+    "never exceed bufferSize even after many more events than capacity" in {
+      val collector = spawn(TraceCollector(bufferSize = 3))
+      val probe = createTestProbe[Vector[TraceEvent]]()
+
+      (1 to 10).foreach(n => collector ! TraceCollector.Record(event(n)))
+      collector ! TraceCollector.GetRecent(probe.ref)
+
+      probe.expectMessage(Vector(event(8), event(9), event(10)))
+    }
+  }
+}

--- a/game-service-actor/src/test/scala/com/andy327/actor/tracing/TracingConfigSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/tracing/TracingConfigSpec.scala
@@ -1,0 +1,69 @@
+package com.andy327.actor.tracing
+
+import com.typesafe.config.ConfigFactory
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class TracingConfigSpec extends AnyWordSpecLike with Matchers {
+
+  "TracingConfig.fromConfig" should {
+    "parse enabled, sample-rate, and buffer-size" in {
+      val config = ConfigFactory.parseString("""
+        pekko-game-service.tracing {
+          enabled = true
+          sample-rate = 0.5
+          buffer-size = 250
+        }
+      """)
+
+      val tracingConfig = TracingConfig.fromConfig(config)
+
+      tracingConfig.enabled shouldBe true
+      tracingConfig.sampleRate shouldBe 0.5
+      tracingConfig.bufferSize shouldBe 250
+    }
+
+    "default messageSampleRates to empty when message-sample-rates is absent" in {
+      val config = ConfigFactory.parseString("""
+        pekko-game-service.tracing {
+          enabled = false
+          sample-rate = 1.0
+          buffer-size = 1000
+        }
+      """)
+
+      TracingConfig.fromConfig(config).messageSampleRates shouldBe Map.empty
+    }
+
+    "parse message-sample-rates into a Map[String, Double]" in {
+      val config = ConfigFactory.parseString("""
+        pekko-game-service.tracing {
+          enabled = true
+          sample-rate = 1.0
+          buffer-size = 1000
+          message-sample-rates {
+            "MakeMove" = 0.1
+            "Subscribe" = 0.25
+          }
+        }
+      """)
+
+      TracingConfig.fromConfig(config).messageSampleRates shouldBe Map("MakeMove" -> 0.1, "Subscribe" -> 0.25)
+    }
+  }
+
+  "TracingConfig.sampleRateFor" should {
+    "return the override for a message type present in messageSampleRates" in {
+      val config = TracingConfig(enabled = true, sampleRate = 1.0, bufferSize = 1000, Map("MakeMove" -> 0.1))
+
+      config.sampleRateFor("MakeMove") shouldBe 0.1
+    }
+
+    "fall back to sampleRate for a message type with no override" in {
+      val config = TracingConfig(enabled = true, sampleRate = 0.7, bufferSize = 1000, Map("MakeMove" -> 0.1))
+
+      config.sampleRateFor("Subscribe") shouldBe 0.7
+    }
+  }
+}

--- a/game-service-actor/src/test/scala/com/andy327/actor/tracing/TracingInterceptorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/tracing/TracingInterceptorSpec.scala
@@ -1,0 +1,143 @@
+package com.andy327.actor.tracing
+
+import scala.collection.mutable.ListBuffer
+
+import org.apache.pekko.actor.testkit.typed.scaladsl.ActorTestKit
+import org.apache.pekko.actor.typed.ActorRef
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class TracingInterceptorSpec extends AnyWordSpecLike with Matchers {
+  private val testKit = ActorTestKit()
+  import testKit._
+
+  // A minimal command type for the wrapped behavior under test.
+  sealed private trait Cmd
+  private case class Ping(replyTo: ActorRef[String]) extends Cmd
+  private case class Pong(replyTo: ActorRef[String]) extends Cmd
+
+  // A behavior that replies "pong" to Ping and "ping" to Pong.
+  private val echoBehavior: Behaviors.Receive[Cmd] =
+    Behaviors.receiveMessage {
+      case Ping(r) => r ! "pong"; Behaviors.same
+      case Pong(r) => r ! "ping"; Behaviors.same
+    }
+
+  private val enabled = TracingConfig(enabled = true, sampleRate = 1.0)
+  private val disabled = TracingConfig(enabled = false, sampleRate = 1.0)
+  private val zeroRate = TracingConfig(enabled = true, sampleRate = 0.0)
+
+  "TracingInterceptor.wrap" when {
+
+    "config is disabled" should {
+      "pass messages through to the wrapped behavior unchanged" in {
+        val emitted = ListBuffer.empty[TraceEvent]
+        val probe = createTestProbe[String]()
+        val actor = spawn(TracingInterceptor.wrap[Cmd](echoBehavior, disabled, emitted += _))
+
+        actor ! Ping(probe.ref)
+        probe.expectMessage("pong")
+
+        actor ! Pong(probe.ref)
+        probe.expectMessage("ping")
+      }
+
+      "never emit any TraceEvents" in {
+        val emitted = ListBuffer.empty[TraceEvent]
+        val probe = createTestProbe[String]()
+        val actor = spawn(TracingInterceptor.wrap[Cmd](echoBehavior, disabled, emitted += _))
+
+        actor ! Ping(probe.ref)
+        probe.expectMessage("pong")
+        actor ! Pong(probe.ref)
+        probe.expectMessage("ping")
+
+        emitted shouldBe empty
+      }
+    }
+
+    "config is enabled with sampleRate = 1.0" should {
+      "pass every message through to the wrapped behavior" in {
+        val emitted = ListBuffer.empty[TraceEvent]
+        val probe = createTestProbe[String]()
+        val actor = spawn(TracingInterceptor.wrap[Cmd](echoBehavior, enabled, emitted += _))
+
+        actor ! Ping(probe.ref)
+        probe.expectMessage("pong")
+        actor ! Pong(probe.ref)
+        probe.expectMessage("ping")
+      }
+
+      "emit one TraceEvent per message" in {
+        val emitted = ListBuffer.empty[TraceEvent]
+        val probe = createTestProbe[String]()
+        val actor = spawn(TracingInterceptor.wrap[Cmd](echoBehavior, enabled, emitted += _))
+
+        actor ! Ping(probe.ref)
+        probe.expectMessage("pong")
+        actor ! Pong(probe.ref)
+        probe.expectMessage("ping")
+
+        emitted should have size 2
+      }
+
+      "populate messageType from the concrete message class" in {
+        val emitted = ListBuffer.empty[TraceEvent]
+        val probe = createTestProbe[String]()
+        val actor = spawn(TracingInterceptor.wrap[Cmd](echoBehavior, enabled, emitted += _))
+
+        actor ! Ping(probe.ref)
+        probe.expectMessage("pong")
+
+        emitted.head.messageType shouldBe "Ping"
+      }
+
+      "set to to the receiving actor's path" in {
+        val emitted = ListBuffer.empty[TraceEvent]
+        val probe = createTestProbe[String]()
+        val actor = spawn(TracingInterceptor.wrap[Cmd](echoBehavior, enabled, emitted += _))
+
+        actor ! Ping(probe.ref)
+        probe.expectMessage("pong")
+
+        emitted.head.to should include(actor.path.name)
+      }
+
+      "set from to None (typed Pekko does not expose the sender)" in {
+        val emitted = ListBuffer.empty[TraceEvent]
+        val probe = createTestProbe[String]()
+        val actor = spawn(TracingInterceptor.wrap[Cmd](echoBehavior, enabled, emitted += _))
+
+        actor ! Ping(probe.ref)
+        probe.expectMessage("pong")
+
+        emitted.head.from shouldBe None
+      }
+    }
+
+    "config is enabled with sampleRate = 0.0" should {
+      "still pass every message through to the wrapped behavior" in {
+        val emitted = ListBuffer.empty[TraceEvent]
+        val probe = createTestProbe[String]()
+        val actor = spawn(TracingInterceptor.wrap[Cmd](echoBehavior, zeroRate, emitted += _))
+
+        actor ! Ping(probe.ref)
+        probe.expectMessage("pong")
+      }
+
+      "never emit any TraceEvents" in {
+        val emitted = ListBuffer.empty[TraceEvent]
+        val probe = createTestProbe[String]()
+        val actor = spawn(TracingInterceptor.wrap[Cmd](echoBehavior, zeroRate, emitted += _))
+
+        actor ! Ping(probe.ref)
+        probe.expectMessage("pong")
+        actor ! Pong(probe.ref)
+        probe.expectMessage("ping")
+
+        emitted shouldBe empty
+      }
+    }
+  }
+}

--- a/game-service-actor/src/test/scala/com/andy327/actor/tracing/TracingInterceptorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/tracing/TracingInterceptorSpec.scala
@@ -139,5 +139,45 @@ class TracingInterceptorSpec extends AnyWordSpecLike with Matchers {
         emitted shouldBe empty
       }
     }
+
+    "config has a per-message-type override" should {
+      "never emit for the overridden type when its rate is 0.0, while still emitting for other types" in {
+        val emitted = ListBuffer.empty[TraceEvent]
+        val probe = createTestProbe[String]()
+        val config = TracingConfig(
+          enabled = true,
+          sampleRate = 1.0,
+          bufferSize = 1000,
+          messageSampleRates = Map("Ping" -> 0.0)
+        )
+        val actor = spawn(TracingInterceptor.wrap[Cmd](echoBehavior, config, emitted += _))
+
+        actor ! Ping(probe.ref)
+        probe.expectMessage("pong")
+        actor ! Pong(probe.ref)
+        probe.expectMessage("ping")
+
+        emitted.map(_.messageType) shouldBe List("Pong")
+      }
+
+      "always emit for the overridden type when its rate is 1.0, even though the default sampleRate is 0.0" in {
+        val emitted = ListBuffer.empty[TraceEvent]
+        val probe = createTestProbe[String]()
+        val config = TracingConfig(
+          enabled = true,
+          sampleRate = 0.0,
+          bufferSize = 1000,
+          messageSampleRates = Map("Ping" -> 1.0)
+        )
+        val actor = spawn(TracingInterceptor.wrap[Cmd](echoBehavior, config, emitted += _))
+
+        actor ! Ping(probe.ref)
+        probe.expectMessage("pong")
+        actor ! Pong(probe.ref)
+        probe.expectMessage("ping")
+
+        emitted.map(_.messageType) shouldBe List("Ping")
+      }
+    }
   }
 }

--- a/game-service-actor/src/test/scala/com/andy327/actor/tracing/TracingInterceptorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/tracing/TracingInterceptorSpec.scala
@@ -24,9 +24,9 @@ class TracingInterceptorSpec extends AnyWordSpecLike with Matchers {
       case Pong(r) => r ! "ping"; Behaviors.same
     }
 
-  private val enabled = TracingConfig(enabled = true, sampleRate = 1.0)
-  private val disabled = TracingConfig(enabled = false, sampleRate = 1.0)
-  private val zeroRate = TracingConfig(enabled = true, sampleRate = 0.0)
+  private val enabled = TracingConfig(enabled = true, sampleRate = 1.0, bufferSize = 1000)
+  private val disabled = TracingConfig(enabled = false, sampleRate = 1.0, bufferSize = 1000)
+  private val zeroRate = TracingConfig(enabled = true, sampleRate = 0.0, bufferSize = 1000)
 
   "TracingInterceptor.wrap" when {
 

--- a/game-service-server/src/main/resources/application.conf
+++ b/game-service-server/src/main/resources/application.conf
@@ -52,13 +52,17 @@ auth {
 }
 
 # Actor message tracing — disabled by default (zero overhead when off).
-# Uncomment and set enabled = true to activate; lower sample-rate to reduce overhead for high-frequency actors. See
-# TracingConfig for full documentation.
+# Uncomment and set enabled = true to activate. sample-rate is the default applied to every message type;
+# message-sample-rates overrides it per message type (e.g. to sample down a hot type like MakeMove without losing
+# visibility into everything else). See TracingConfig for full documentation.
 #
 # pekko-game-service.tracing {
 #   enabled = true
-#   sample-rate = 0.1
+#   sample-rate = 1.0
 #   buffer-size = 1000
+#   message-sample-rates {
+#     "MakeMove" = 0.1
+#   }
 # }
 
 pekko.http.server {

--- a/game-service-server/src/main/resources/application.conf
+++ b/game-service-server/src/main/resources/application.conf
@@ -51,6 +51,15 @@ auth {
   }
 }
 
+# Actor message tracing — disabled by default (zero overhead when off).
+# Uncomment and set enabled = true to activate; lower sample-rate to reduce overhead for
+# high-frequency actors. See TracingConfig for full documentation.
+#
+# pekko-game-service.tracing {
+#   enabled = true
+#   sample-rate = 0.1
+# }
+
 pekko.http.server {
   # Send a WebSocket ping if no data has flowed for this duration, keeping
   # connections alive during long pauses between moves.

--- a/game-service-server/src/main/resources/application.conf
+++ b/game-service-server/src/main/resources/application.conf
@@ -58,6 +58,7 @@ auth {
 # pekko-game-service.tracing {
 #   enabled = true
 #   sample-rate = 0.1
+#   buffer-size = 1000
 # }
 
 pekko.http.server {

--- a/game-service-server/src/main/resources/application.conf
+++ b/game-service-server/src/main/resources/application.conf
@@ -52,8 +52,8 @@ auth {
 }
 
 # Actor message tracing — disabled by default (zero overhead when off).
-# Uncomment and set enabled = true to activate; lower sample-rate to reduce overhead for
-# high-frequency actors. See TracingConfig for full documentation.
+# Uncomment and set enabled = true to activate; lower sample-rate to reduce overhead for high-frequency actors. See
+# TracingConfig for full documentation.
 #
 # pekko-game-service.tracing {
 #   enabled = true

--- a/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
@@ -21,6 +21,7 @@ import com.andy327.actor.core.GameManager
 import com.andy327.actor.events.{EventPublisher, NoOpEventPublisher}
 import com.andy327.actor.lobby.{LobbyRepository, RedisLobbyRepository}
 import com.andy327.actor.persistence.PostgresActor
+import com.andy327.actor.tracing.{TraceCollector, TraceEvent, TracingConfig}
 import com.andy327.model.core.GameType
 import com.andy327.persistence.db.postgres.{
   PostgresGameRepository,
@@ -128,7 +129,25 @@ object GameServer {
   )(implicit runtime: IORuntime): IO[(ActorSystem[GameManager.Command], Http.ServerBinding)] = IO.defer {
     val rootBehavior = Behaviors.setup[GameManager.Command] { context =>
       val persistActor = context.spawn(PostgresActor(gameRepo, moveRepo, playerHistoryRepo), "postgres-persistence")
-      GameManager(persistActor, gameRepo, lobbyRepo, moveRepo, chatRepo, publisher)
+
+      // The collector actor is only spawned when tracing is enabled, so a disabled config costs nothing at startup.
+      val tracingConfig = TracingConfig.default
+      val traceEmit: TraceEvent => Unit =
+        if (tracingConfig.enabled) {
+          val collector = context.spawn(TraceCollector(tracingConfig.bufferSize), "trace-collector")
+          (event: TraceEvent) => collector ! TraceCollector.Record(event)
+        } else _ => ()
+
+      GameManager(
+        persistActor,
+        gameRepo,
+        lobbyRepo,
+        moveRepo,
+        chatRepo,
+        publisher,
+        tracingConfig = tracingConfig,
+        traceEmit = traceEmit
+      )
     }
 
     // Pekko actor system


### PR DESCRIPTION
Adds an instrumentation layer that can record every message an actor receives, as a foundation for a later real-time "flight map" visualization of message flow (tracked separately on `feat-trace-debug-viewer`). This branch is instrumentation only — no networking, no UI.

### Design
- `TracingInterceptor` is a `BehaviorInterceptor[T, T]` wrapped conditionally around `Behaviors.setup` at each actor spawn point, so it catches every message regardless of call site without touching individual `tell`s.
- Fully config-gated via `TracingConfig` (`pekko-game-service.tracing`, disabled by default): when `enabled = false`, no interceptor is installed and no `TraceEvent` is ever allocated — zero per-message overhead in production, gated once at startup rather than per message.
- `TraceCollector` holds the most recent events in a bounded in-memory buffer (`buffer-size`, default 1000), evicting oldest-first. Only spawned when tracing is enabled.
- Per-message-type sample-rate overrides (`message-sample-rates`) let a hot message type (e.g. `MakeMove`) be sampled down without losing visibility into everything else.

### Known limitation
`TraceEvent.from` is always `None`. Typed Pekko exposes no sender on a received message (protocols carry `replyTo` explicitly instead of an implicit envelope sender), and a `BehaviorInterceptor` only observes the receiving side, so there's currently no hook to capture who sent a message. The field is kept on the model since a flow visualization needs both ends of an edge; populating it will need a different/additional capture mechanism, likely as part of `feat-trace-debug-viewer`.
