### PR TITLE
add debug WebSocket endpoint and live event log to the web UI

### DIFF
--- a/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
@@ -17,7 +17,7 @@ import com.andy327.actor.events.{EventPublisher, GameEvent, NoOpEventPublisher}
 import com.andy327.actor.game.{GameOperation, GameRegistry, GameState}
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyError, LobbyMetadata, LobbyRepository, Player}
 import com.andy327.actor.persistence.PersistenceProtocol
-import com.andy327.actor.tracing.{TraceEvent, TracingConfig, TracingInterceptor}
+import com.andy327.actor.tracing.{TraceCollector, TraceEvent, TracingConfig, TracingInterceptor}
 import com.andy327.model.core.{Game, GameError, GameType, MatchId, PlayerId, RoomId}
 import com.andy327.persistence.db.{GameRepository, MoveHistoryRepository, MoveRecord, NoOpMoveHistoryRepository}
 
@@ -145,6 +145,14 @@ object GameManager {
     * has since reconnected with a new PlayerActor.
     */
   final case class PlayerDisconnected(playerId: PlayerId, playerRef: ActorRef[PlayerActor.Command]) extends Command
+
+  // --- Tracing commands ---
+
+  /** Replies with the live `trace-collector` child ref, or `None` if tracing is disabled (the collector is never
+    * spawned in that case — see [[GameManager.apply]]). Used by the debug WebSocket route to reach
+    * [[com.andy327.actor.tracing.TraceCollector]] without GameManager needing to proxy every trace interaction.
+    */
+  final case class GetTraceCollector(replyTo: ActorRef[Option[ActorRef[TraceCollector.Command]]]) extends Command
 
   // --- Lifecycle commands ---
 
@@ -362,9 +370,11 @@ object GameManager {
     * @param publisher emit seam for analytics events (game started/move made/game completed/chat sent); defaults to
     *                  no-op
     * @param onReady optional ref that receives a [[Ready]] signal once the running state is entered (used in tests)
-    * @param tracingConfig controls whether [[tracing.TracingInterceptor]] is installed on spawned child actors;
-    *                      defaults to the `pekko-game-service.tracing` config stanza (disabled by default)
-    * @param traceEmit sink for [[tracing.TraceEvent]]s emitted by the interceptors; defaults to no-op
+    * @param tracingConfig controls whether tracing is active: when `enabled`, [[tracing.TracingInterceptor]] is
+    *                      installed on every spawned child actor and a `trace-collector` child
+    *                      ([[tracing.TraceCollector]]) is spawned to hold/distribute the resulting
+    *                      [[tracing.TraceEvent]]s — see [[GetTraceCollector]]. Defaults to the
+    *                      `pekko-game-service.tracing` config stanza (disabled by default)
     */
   @annotation.nowarn("msg=match may not be exhaustive")
   def apply(
@@ -375,11 +385,18 @@ object GameManager {
       chatRepo: ChatRepository = NoOpChatRepository,
       publisher: EventPublisher = NoOpEventPublisher,
       onReady: Option[ActorRef[Ready.type]] = None,
-      tracingConfig: TracingConfig = TracingConfig.default,
-      traceEmit: TraceEvent => Unit = _ => ()
+      tracingConfig: TracingConfig = TracingConfig.default
   )(implicit runtime: IORuntime): Behavior[Command] =
     Behaviors.withStash(capacity = 128) { stash =>
       Behaviors.setup { context =>
+        // The collector actor is only spawned when tracing is enabled, so a disabled config costs nothing at startup.
+        // Reachable from outside via GetTraceCollector (context.child("trace-collector")).
+        val traceEmit: TraceEvent => Unit =
+          if (tracingConfig.enabled) {
+            val collector = context.spawn(TraceCollector(tracingConfig.bufferSize), "trace-collector")
+            (event: TraceEvent) => collector ! TraceCollector.Record(event)
+          } else _ => ()
+
         val lobbyManager = context.spawn(
           TracingInterceptor.wrap(LobbyManager(context.self, lobbyRepo), tracingConfig, traceEmit),
           "lobby-manager"
@@ -719,6 +736,10 @@ object GameManager {
 
         case PlayerDisconnected(playerId, playerRef) =>
           playerManager ! PlayerManager.PlayerDisconnected(playerId, playerRef)
+          Behaviors.same
+
+        case GetTraceCollector(replyTo) =>
+          replyTo ! context.child("trace-collector").map(_.unsafeUpcast[TraceCollector.Command])
           Behaviors.same
 
         case SpawnGame(roomId, matchId, gameType, players, replyTo, subscribers) =>

--- a/game-service-actor/src/main/scala/com/andy327/actor/tracing/TraceCollector.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/tracing/TraceCollector.scala
@@ -1,38 +1,75 @@
 package com.andy327.actor.tracing
 
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
-import org.apache.pekko.actor.typed.{ActorRef, Behavior}
+import org.apache.pekko.actor.typed.{ActorRef, Behavior, Terminated}
 
-/** Holds the most recent [[TraceEvent]]s in a bounded in-memory buffer, for later retrieval by a debug/visualization
-  * endpoint (not yet implemented — see the `feat-trace-debug-viewer` branch).
+/** Holds the most recent [[TraceEvent]]s in a bounded in-memory buffer, and fans live events out to subscribers, for
+  * a debug/visualization endpoint.
   *
   * Each [[TracingInterceptor]] installed across the actor system sends its events here via [[Record]]. The buffer
   * retains at most `bufferSize` events, dropping the oldest once full, so memory use stays bounded regardless of how
   * long the system runs or how chatty tracing is.
   *
+  * A caller registers for live delivery via [[Subscribe]]: the existing buffer is replayed to it immediately (oldest
+  * first), then every subsequent [[Record]] is forwarded as it arrives, so there is no gap between the backlog and
+  * live events. [[Unsubscribe]] stops delivery; a subscriber is also dropped automatically if it terminates, mirroring
+  * [[com.andy327.actor.core.LobbyManager]]'s subscriber cleanup.
+  *
   * Actor relationships:
   *   - Parent: root (top-level, created by `GameServer` only when tracing is enabled)
-  *   - Receives from: every [[TracingInterceptor]] instance system-wide (`Record`)
+  *   - Receives from: every [[TracingInterceptor]] instance system-wide (`Record`); the debug WebSocket route
+  *     (`Subscribe`/`Unsubscribe`)
+  *   - Sends to: each subscribed `ActorRef[TraceEvent]` (the debug WebSocket route's outbound stream)
   */
 object TraceCollector {
   sealed trait Command
 
-  /** Append `event` to the buffer, evicting the oldest event if the buffer is already at capacity. */
+  /** Append `event` to the buffer, evicting the oldest event if the buffer is already at capacity, and forward it to
+    * every current subscriber.
+    */
   final case class Record(event: TraceEvent) extends Command
 
   /** Reply with the buffered events, oldest first. */
   final case class GetRecent(replyTo: ActorRef[Vector[TraceEvent]]) extends Command
 
+  /** Register `subscriber` for live events: the current buffer is replayed to it immediately, then every later
+    * [[Record]] is forwarded as it arrives.
+    */
+  final case class Subscribe(subscriber: ActorRef[TraceEvent]) extends Command
+
+  /** Deregister `subscriber` from live events. Idempotent — a no-op if it was not subscribed. */
+  final case class Unsubscribe(subscriber: ActorRef[TraceEvent]) extends Command
+
   /** @param bufferSize the maximum number of events retained; typically [[TracingConfig.bufferSize]] */
-  def apply(bufferSize: Int): Behavior[Command] = running(Vector.empty, bufferSize)
+  def apply(bufferSize: Int): Behavior[Command] = running(Vector.empty, bufferSize, Set.empty)
 
-  private def running(buffer: Vector[TraceEvent], bufferSize: Int): Behavior[Command] =
-    Behaviors.receiveMessage {
-      case Record(event) =>
-        running((buffer :+ event).takeRight(bufferSize), bufferSize)
+  private def running(
+      buffer: Vector[TraceEvent],
+      bufferSize: Int,
+      subscribers: Set[ActorRef[TraceEvent]]
+  ): Behavior[Command] =
+    Behaviors
+      .receive[Command] { (context, message) =>
+        message match {
+          case Record(event) =>
+            subscribers.foreach(_ ! event)
+            running((buffer :+ event).takeRight(bufferSize), bufferSize, subscribers)
 
-      case GetRecent(replyTo) =>
-        replyTo ! buffer
-        Behaviors.same
-    }
+          case GetRecent(replyTo) =>
+            replyTo ! buffer
+            Behaviors.same
+
+          case Subscribe(subscriber) =>
+            context.watch(subscriber)
+            buffer.foreach(subscriber ! _)
+            running(buffer, bufferSize, subscribers + subscriber)
+
+          case Unsubscribe(subscriber) =>
+            context.unwatch(subscriber)
+            running(buffer, bufferSize, subscribers - subscriber)
+        }
+      }
+      .receiveSignal { case (_, Terminated(ref)) =>
+        running(buffer, bufferSize, subscribers.filterNot(_ == ref))
+      }
 }

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
@@ -24,6 +24,7 @@ import com.andy327.actor.events.{EventPublisher, GameEvent}
 import com.andy327.actor.game.{GameOperation, GameStateConverters, GridGameState, MovePayload}
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyError, LobbyMetadata, LobbyRepository, Player}
 import com.andy327.actor.persistence.PersistenceProtocol
+import com.andy327.actor.tracing.{TraceCollector, TracingConfig}
 import com.andy327.model.core.{Game, GameType, MatchId, PlayerId, RoomId}
 import com.andy327.model.tictactoe.TicTacToe
 import com.andy327.persistence.db.{GameRepository, MoveHistoryRepository, MoveRecord}
@@ -1426,6 +1427,32 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       val error = responseProbe.expectMessageType[GameManager.ErrorResponse]
       error.message should include("players required")
+    }
+
+    "reply to GetTraceCollector with Some(ref) when tracing is enabled" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+      val tracingConfig = TracingConfig(enabled = true, sampleRate = 1.0, bufferSize = 100)
+
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo, tracingConfig = tracingConfig))
+
+      val responseProbe = TestProbe[Option[ActorRef[TraceCollector.Command]]]()
+      gm ! GameManager.GetTraceCollector(responseProbe.ref)
+
+      responseProbe.expectMessageType[Some[ActorRef[TraceCollector.Command]]]
+    }
+
+    "reply to GetTraceCollector with None when tracing is disabled" in {
+      val persistProbe = TestProbe[PersistenceProtocol.Command]()
+      val gameRepo = new InMemRepo
+
+      // default tracingConfig is TracingConfig.default, which is disabled unless application.conf overrides it
+      val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
+
+      val responseProbe = TestProbe[Option[ActorRef[TraceCollector.Command]]]()
+      gm ! GameManager.GetTraceCollector(responseProbe.ref)
+
+      responseProbe.expectMessage(None)
     }
 
   }

--- a/game-service-actor/src/test/scala/com/andy327/actor/tracing/TraceCollectorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/tracing/TraceCollectorSpec.scala
@@ -3,6 +3,7 @@ package com.andy327.actor.tracing
 import java.time.Instant
 
 import org.apache.pekko.actor.testkit.typed.scaladsl.ActorTestKit
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -55,6 +56,69 @@ class TraceCollectorSpec extends AnyWordSpecLike with Matchers {
       collector ! TraceCollector.GetRecent(probe.ref)
 
       probe.expectMessage(Vector(event(8), event(9), event(10)))
+    }
+
+    "replay the existing buffer to a new subscriber immediately, oldest first" in {
+      val collector = spawn(TraceCollector(bufferSize = 10))
+      collector ! TraceCollector.Record(event(1))
+      collector ! TraceCollector.Record(event(2))
+
+      val subscriber = createTestProbe[TraceEvent]()
+      collector ! TraceCollector.Subscribe(subscriber.ref)
+
+      subscriber.expectMessage(event(1))
+      subscriber.expectMessage(event(2))
+    }
+
+    "forward a live Record to a subscriber after it subscribes" in {
+      val collector = spawn(TraceCollector(bufferSize = 10))
+      val subscriber = createTestProbe[TraceEvent]()
+      collector ! TraceCollector.Subscribe(subscriber.ref)
+
+      collector ! TraceCollector.Record(event(1))
+
+      subscriber.expectMessage(event(1))
+    }
+
+    "forward a live Record to every current subscriber" in {
+      val collector = spawn(TraceCollector(bufferSize = 10))
+      val subscriberA = createTestProbe[TraceEvent]()
+      val subscriberB = createTestProbe[TraceEvent]()
+      collector ! TraceCollector.Subscribe(subscriberA.ref)
+      collector ! TraceCollector.Subscribe(subscriberB.ref)
+
+      collector ! TraceCollector.Record(event(1))
+
+      subscriberA.expectMessage(event(1))
+      subscriberB.expectMessage(event(1))
+    }
+
+    "stop forwarding events to a subscriber once it unsubscribes" in {
+      val collector = spawn(TraceCollector(bufferSize = 10))
+      val subscriber = createTestProbe[TraceEvent]()
+      collector ! TraceCollector.Subscribe(subscriber.ref)
+      collector ! TraceCollector.Unsubscribe(subscriber.ref)
+
+      collector ! TraceCollector.Record(event(1))
+
+      subscriber.expectNoMessage()
+    }
+
+    "drop a subscriber that terminates without crashing on the death-watch" in {
+      val collector = spawn(TraceCollector(bufferSize = 10))
+      // a real actor we can stop to trigger a Terminated signal in the watching TraceCollector
+      val subscriber = spawn(Behaviors.empty[TraceEvent])
+      collector ! TraceCollector.Subscribe(subscriber)
+
+      testKit.stop(subscriber)
+
+      // without a Terminated handler the watching TraceCollector would crash with a DeathPactException; instead it
+      // stays responsive and serves a subsequent command
+      val probe = createTestProbe[Vector[TraceEvent]]()
+      collector ! TraceCollector.Record(event(1))
+      collector ! TraceCollector.GetRecent(probe.ref)
+
+      probe.expectMessage(Vector(event(1)))
     }
   }
 }

--- a/game-service-server/src/main/resources/web/app.js
+++ b/game-service-server/src/main/resources/web/app.js
@@ -561,7 +561,14 @@ function sendChat(text) {
 // rejects the upgrade with 503 when tracing is disabled server-side, which surfaces here as a status line rather than
 // a console error. Every TraceEvent on this socket is plain (untagged) JSON, unlike the main socket's
 // type-discriminated push events, since this socket carries only one event shape.
+//
+// Two views share the same event stream: a scrolling Log (one row per event) and a Graph of one box per distinct
+// actor seen, which pulses on each message it receives. The graph has no edges — TraceEvent.from is always null,
+// since typed Pekko exposes no sender and a BehaviorInterceptor only observes the receiving side — so it shows which
+// actors are busy, not the flow between them.
 const TRACE_LOG_CAP = 300; // bounds DOM growth on a long-running session; oldest rows are dropped past this
+const traceNodes = new Map(); // actor path -> { el, countEl }, so repeat events update the same node in place
+const tracePulseTimers = new Map(); // actor path -> pending timeout that removes its node's pulse class
 
 function showDebug() {
   showPanel("debug");
@@ -569,6 +576,7 @@ function showDebug() {
 }
 
 function connectTraceWs() {
+  resetTraceViews();
   const proto = location.protocol === "https:" ? "wss" : "ws";
   const ws = new WebSocket(`${proto}://${location.host}/ws/trace?access_token=${encodeURIComponent(session.token)}`);
   session.traceWs = ws;
@@ -588,7 +596,8 @@ function connectTraceWs() {
     } catch (_) {
       return;
     }
-    appendTraceEvent(event);
+    appendTraceLogRow(event);
+    pulseTraceNode(event);
   };
 }
 
@@ -603,13 +612,32 @@ function disconnectTraceWs() {
   }
 }
 
+// Clears both views and any pending pulse timers, so a fresh connect's buffer replay doesn't pile up on top of
+// whatever a previous connection (e.g. before a logout/login cycle) already rendered.
+function resetTraceViews() {
+  $("trace-log-body").innerHTML = "";
+  $("trace-graph").innerHTML = "";
+  traceNodes.clear();
+  for (const timer of tracePulseTimers.values()) clearTimeout(timer);
+  tracePulseTimers.clear();
+}
+
 function setDebugStatus(text) {
   $("debug-status").textContent = text;
 }
 
+// Switch between the Log and Graph views; both keep accumulating state in the background regardless of which is
+// visible, so toggling back and forth never loses anything.
+function showTraceView(name) {
+  $("trace-log-wrap").classList.toggle("hidden", name !== "log");
+  $("trace-graph").classList.toggle("hidden", name !== "graph");
+  $("trace-view-log").classList.toggle("active", name === "log");
+  $("trace-view-graph").classList.toggle("active", name === "graph");
+}
+
 // Render one TraceEvent as a row, appended at the bottom (the server streams oldest first), capped to
 // TRACE_LOG_CAP rows so a chatty server can't grow the table unboundedly.
-function appendTraceEvent(event) {
+function appendTraceLogRow(event) {
   const body = $("trace-log-body");
   const tr = document.createElement("tr");
 
@@ -631,6 +659,42 @@ function appendTraceEvent(event) {
 
   const wrap = $("trace-log-wrap");
   wrap.scrollTop = wrap.scrollHeight; // keep the latest event in view
+}
+
+// Find or create the node for event.to (tracked by traceNodes, keyed by the full actor path), bump its message
+// count, and briefly flag it as "pulse" so the CSS transition highlights it. A re-trigger while already pulsing
+// just restarts the clear timer.
+const TRACE_PULSE_MS = 500;
+function pulseTraceNode(event) {
+  let node = traceNodes.get(event.to);
+  if (!node) {
+    const el = document.createElement("div");
+    el.className = "trace-node";
+    el.title = event.to;
+
+    const path = document.createElement("span");
+    path.className = "trace-node-path";
+    path.textContent = shortActorPath(event.to);
+
+    const countEl = document.createElement("span");
+    countEl.className = "trace-node-count";
+
+    el.append(path, countEl);
+    $("trace-graph").appendChild(el);
+
+    node = { el, countEl, count: 0 };
+    traceNodes.set(event.to, node);
+  }
+
+  node.count += 1;
+  node.countEl.textContent = `(${node.count})`;
+
+  node.el.classList.add("pulse");
+  clearTimeout(tracePulseTimers.get(event.to));
+  tracePulseTimers.set(
+    event.to,
+    setTimeout(() => node.el.classList.remove("pulse"), TRACE_PULSE_MS)
+  );
 }
 
 // Actor paths are full URIs like "pekko://GameManagerSystem/user/lobby-manager"; showing just the "user/..." tail
@@ -901,6 +965,8 @@ $("to-login").addEventListener("click", (e) => {
 $("logout").addEventListener("click", logout);
 $("debug-nav").addEventListener("click", showDebug);
 $("debug-back-to-lobby").addEventListener("click", enterLobby);
+$("trace-view-log").addEventListener("click", () => showTraceView("log"));
+$("trace-view-graph").addEventListener("click", () => showTraceView("graph"));
 
 for (const button of document.querySelectorAll("[data-gametype]")) {
   button.addEventListener("click", () => createGame(button.dataset.gametype));

--- a/game-service-server/src/main/resources/web/app.js
+++ b/game-service-server/src/main/resources/web/app.js
@@ -561,14 +561,7 @@ function sendChat(text) {
 // rejects the upgrade with 503 when tracing is disabled server-side, which surfaces here as a status line rather than
 // a console error. Every TraceEvent on this socket is plain (untagged) JSON, unlike the main socket's
 // type-discriminated push events, since this socket carries only one event shape.
-//
-// Two views share the same event stream: a scrolling Log (one row per event) and a Graph of one box per distinct
-// actor seen, which pulses on each message it receives. The graph has no edges — TraceEvent.from is always null,
-// since typed Pekko exposes no sender and a BehaviorInterceptor only observes the receiving side — so it shows which
-// actors are busy, not the flow between them.
 const TRACE_LOG_CAP = 300; // bounds DOM growth on a long-running session; oldest rows are dropped past this
-const traceNodes = new Map(); // actor path -> { el, countEl }, so repeat events update the same node in place
-const tracePulseTimers = new Map(); // actor path -> pending timeout that removes its node's pulse class
 
 function showDebug() {
   showPanel("debug");
@@ -576,7 +569,6 @@ function showDebug() {
 }
 
 function connectTraceWs() {
-  resetTraceViews();
   const proto = location.protocol === "https:" ? "wss" : "ws";
   const ws = new WebSocket(`${proto}://${location.host}/ws/trace?access_token=${encodeURIComponent(session.token)}`);
   session.traceWs = ws;
@@ -596,8 +588,7 @@ function connectTraceWs() {
     } catch (_) {
       return;
     }
-    appendTraceLogRow(event);
-    pulseTraceNode(event);
+    appendTraceEvent(event);
   };
 }
 
@@ -612,32 +603,13 @@ function disconnectTraceWs() {
   }
 }
 
-// Clears both views and any pending pulse timers, so a fresh connect's buffer replay doesn't pile up on top of
-// whatever a previous connection (e.g. before a logout/login cycle) already rendered.
-function resetTraceViews() {
-  $("trace-log-body").innerHTML = "";
-  $("trace-graph").innerHTML = "";
-  traceNodes.clear();
-  for (const timer of tracePulseTimers.values()) clearTimeout(timer);
-  tracePulseTimers.clear();
-}
-
 function setDebugStatus(text) {
   $("debug-status").textContent = text;
 }
 
-// Switch between the Log and Graph views; both keep accumulating state in the background regardless of which is
-// visible, so toggling back and forth never loses anything.
-function showTraceView(name) {
-  $("trace-log-wrap").classList.toggle("hidden", name !== "log");
-  $("trace-graph").classList.toggle("hidden", name !== "graph");
-  $("trace-view-log").classList.toggle("active", name === "log");
-  $("trace-view-graph").classList.toggle("active", name === "graph");
-}
-
 // Render one TraceEvent as a row, appended at the bottom (the server streams oldest first), capped to
 // TRACE_LOG_CAP rows so a chatty server can't grow the table unboundedly.
-function appendTraceLogRow(event) {
+function appendTraceEvent(event) {
   const body = $("trace-log-body");
   const tr = document.createElement("tr");
 
@@ -659,42 +631,6 @@ function appendTraceLogRow(event) {
 
   const wrap = $("trace-log-wrap");
   wrap.scrollTop = wrap.scrollHeight; // keep the latest event in view
-}
-
-// Find or create the node for event.to (tracked by traceNodes, keyed by the full actor path), bump its message
-// count, and briefly flag it as "pulse" so the CSS transition highlights it. A re-trigger while already pulsing
-// just restarts the clear timer.
-const TRACE_PULSE_MS = 500;
-function pulseTraceNode(event) {
-  let node = traceNodes.get(event.to);
-  if (!node) {
-    const el = document.createElement("div");
-    el.className = "trace-node";
-    el.title = event.to;
-
-    const path = document.createElement("span");
-    path.className = "trace-node-path";
-    path.textContent = shortActorPath(event.to);
-
-    const countEl = document.createElement("span");
-    countEl.className = "trace-node-count";
-
-    el.append(path, countEl);
-    $("trace-graph").appendChild(el);
-
-    node = { el, countEl, count: 0 };
-    traceNodes.set(event.to, node);
-  }
-
-  node.count += 1;
-  node.countEl.textContent = `(${node.count})`;
-
-  node.el.classList.add("pulse");
-  clearTimeout(tracePulseTimers.get(event.to));
-  tracePulseTimers.set(
-    event.to,
-    setTimeout(() => node.el.classList.remove("pulse"), TRACE_PULSE_MS)
-  );
 }
 
 // Actor paths are full URIs like "pekko://GameManagerSystem/user/lobby-manager"; showing just the "user/..." tail
@@ -965,8 +901,6 @@ $("to-login").addEventListener("click", (e) => {
 $("logout").addEventListener("click", logout);
 $("debug-nav").addEventListener("click", showDebug);
 $("debug-back-to-lobby").addEventListener("click", enterLobby);
-$("trace-view-log").addEventListener("click", () => showTraceView("log"));
-$("trace-view-graph").addEventListener("click", () => showTraceView("graph"));
 
 for (const button of document.querySelectorAll("[data-gametype]")) {
   button.addEventListener("click", () => createGame(button.dataset.gametype));

--- a/game-service-server/src/main/resources/web/app.js
+++ b/game-service-server/src/main/resources/web/app.js
@@ -15,6 +15,7 @@ const session = {
   token: null,
   me: null, // { id, name }
   ws: null,
+  traceWs: null,
   game: null // { roomId, gameType, isHost }
 };
 
@@ -93,6 +94,7 @@ async function establishSession() {
   await connectWs();
   $("whoami").textContent = `Signed in as ${session.me.name}`;
   $("logout").classList.remove("hidden");
+  $("debug-nav").classList.remove("hidden");
   return true;
 }
 
@@ -135,8 +137,10 @@ function logout() {
     }
     session.ws = null;
   }
+  disconnectTraceWs();
   $("whoami").textContent = "";
   $("logout").classList.add("hidden");
+  $("debug-nav").classList.add("hidden");
   showPanel("login");
 }
 
@@ -551,6 +555,97 @@ function sendChat(text) {
   session.ws.send(JSON.stringify({ type: "ChatSend", roomId: session.game.roomId, text }));
 }
 
+// --- Debug trace log ---------------------------------------------------------------------------------------------
+// Live view of actor message tracing (see TraceRoutes). A second, independent socket from the main one above — opened
+// lazily on first visit to the Debug panel rather than at sign-in, since most sessions never open it. The server
+// rejects the upgrade with 503 when tracing is disabled server-side, which surfaces here as a status line rather than
+// a console error. Every TraceEvent on this socket is plain (untagged) JSON, unlike the main socket's
+// type-discriminated push events, since this socket carries only one event shape.
+const TRACE_LOG_CAP = 300; // bounds DOM growth on a long-running session; oldest rows are dropped past this
+
+function showDebug() {
+  showPanel("debug");
+  if (!session.traceWs) connectTraceWs();
+}
+
+function connectTraceWs() {
+  const proto = location.protocol === "https:" ? "wss" : "ws";
+  const ws = new WebSocket(`${proto}://${location.host}/ws/trace?access_token=${encodeURIComponent(session.token)}`);
+  session.traceWs = ws;
+  setDebugStatus("Connecting…");
+  ws.onopen = () => setDebugStatus("Connected — streaming live trace events.");
+  ws.onerror = () => {
+    /* the close handler below reports the failure; nothing additional to do here */
+  };
+  ws.onclose = () => {
+    session.traceWs = null;
+    setDebugStatus("Disconnected (tracing may be disabled on this server).");
+  };
+  ws.onmessage = (ev) => {
+    let event;
+    try {
+      event = JSON.parse(ev.data);
+    } catch (_) {
+      return;
+    }
+    appendTraceEvent(event);
+  };
+}
+
+function disconnectTraceWs() {
+  if (session.traceWs) {
+    try {
+      session.traceWs.close();
+    } catch (_) {
+      /* ignore */
+    }
+    session.traceWs = null;
+  }
+}
+
+function setDebugStatus(text) {
+  $("debug-status").textContent = text;
+}
+
+// Render one TraceEvent as a row, appended at the bottom (the server streams oldest first), capped to
+// TRACE_LOG_CAP rows so a chatty server can't grow the table unboundedly.
+function appendTraceEvent(event) {
+  const body = $("trace-log-body");
+  const tr = document.createElement("tr");
+
+  const time = document.createElement("td");
+  time.textContent = formatTraceTime(event.timestamp);
+
+  const to = document.createElement("td");
+  to.className = "trace-to";
+  to.textContent = shortActorPath(event.to);
+  to.title = event.to; // full path on hover, since the cell itself is truncated
+
+  const type = document.createElement("td");
+  type.className = "trace-type";
+  type.textContent = event.messageType;
+
+  tr.append(time, to, type);
+  body.appendChild(tr);
+  while (body.children.length > TRACE_LOG_CAP) body.removeChild(body.firstChild);
+
+  const wrap = $("trace-log-wrap");
+  wrap.scrollTop = wrap.scrollHeight; // keep the latest event in view
+}
+
+// Actor paths are full URIs like "pekko://GameManagerSystem/user/lobby-manager"; showing just the "user/..." tail
+// keeps the column readable. Falls back to the full string if it doesn't match the expected shape.
+function shortActorPath(path) {
+  const match = path.match(/\/user\/.*$/);
+  return match ? match[0].slice(1) : path;
+}
+
+function formatTraceTime(iso) {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleTimeString([], { hour12: false }) + "." + String(d.getMilliseconds()).padStart(3, "0");
+}
+
 // --- Board rendering -------------------------------------------------------------------------------------------------
 // Renders any game-state view pushed from the server. Battleship states (identified by `state.board1`) are handled
 // separately; all other games use the shared grid renderer below.
@@ -740,7 +835,7 @@ async function copyInviteLink() {
 
 // --- View helpers ----------------------------------------------------------------------------------------------------
 function showPanel(name) {
-  for (const id of ["login", "lobby", "game"]) $(id).classList.toggle("hidden", id !== name);
+  for (const id of ["login", "lobby", "game", "debug"]) $(id).classList.toggle("hidden", id !== name);
 }
 
 function setStatus(text) {
@@ -804,6 +899,8 @@ $("to-login").addEventListener("click", (e) => {
   showAuthMode("login");
 });
 $("logout").addEventListener("click", logout);
+$("debug-nav").addEventListener("click", showDebug);
+$("debug-back-to-lobby").addEventListener("click", enterLobby);
 
 for (const button of document.querySelectorAll("[data-gametype]")) {
   button.addEventListener("click", () => createGame(button.dataset.gametype));

--- a/game-service-server/src/main/resources/web/index.html
+++ b/game-service-server/src/main/resources/web/index.html
@@ -11,6 +11,7 @@
     <h1>Pekko Game Service</h1>
     <div class="header-right">
       <span id="whoami" class="whoami"></span>
+      <button id="debug-nav" class="hidden">Debug</button>
       <button id="logout" class="hidden">Log out</button>
     </div>
   </header>
@@ -101,6 +102,23 @@
         <input id="chat-input" type="text" placeholder="Message…" autocomplete="off" maxlength="500" />
         <button type="submit">Send</button>
       </form>
+    </div>
+  </section>
+
+  <!-- Debug screen: live actor message trace log (requires tracing enabled server-side). -->
+  <section id="debug" class="panel hidden">
+    <h2>Trace Debug</h2>
+    <p id="debug-status" class="status"></p>
+    <div id="trace-log-wrap">
+      <table id="trace-log">
+        <thead>
+          <tr><th>Time</th><th>To</th><th>Message</th></tr>
+        </thead>
+        <tbody id="trace-log-body"></tbody>
+      </table>
+    </div>
+    <div class="row">
+      <button id="debug-back-to-lobby">← Lobby</button>
     </div>
   </section>
 

--- a/game-service-server/src/main/resources/web/index.html
+++ b/game-service-server/src/main/resources/web/index.html
@@ -109,11 +109,6 @@
   <section id="debug" class="panel hidden">
     <h2>Trace Debug</h2>
     <p id="debug-status" class="status"></p>
-    <div class="row">
-      <button id="trace-view-log" class="trace-view-btn active">Log</button>
-      <button id="trace-view-graph" class="trace-view-btn">Graph</button>
-    </div>
-
     <div id="trace-log-wrap">
       <table id="trace-log">
         <thead>
@@ -122,11 +117,6 @@
         <tbody id="trace-log-body"></tbody>
       </table>
     </div>
-
-    <!-- One node per distinct actor seen, pulsing on each message it receives. No edges: TraceEvent.from is always
-         null (typed Pekko exposes no sender), so there is no flow data to draw between nodes yet. -->
-    <div id="trace-graph" class="hidden"></div>
-
     <div class="row">
       <button id="debug-back-to-lobby">← Lobby</button>
     </div>

--- a/game-service-server/src/main/resources/web/index.html
+++ b/game-service-server/src/main/resources/web/index.html
@@ -109,6 +109,11 @@
   <section id="debug" class="panel hidden">
     <h2>Trace Debug</h2>
     <p id="debug-status" class="status"></p>
+    <div class="row">
+      <button id="trace-view-log" class="trace-view-btn active">Log</button>
+      <button id="trace-view-graph" class="trace-view-btn">Graph</button>
+    </div>
+
     <div id="trace-log-wrap">
       <table id="trace-log">
         <thead>
@@ -117,6 +122,11 @@
         <tbody id="trace-log-body"></tbody>
       </table>
     </div>
+
+    <!-- One node per distinct actor seen, pulsing on each message it receives. No edges: TraceEvent.from is always
+         null (typed Pekko exposes no sender), so there is no flow data to draw between nodes yet. -->
+    <div id="trace-graph" class="hidden"></div>
+
     <div class="row">
       <button id="debug-back-to-lobby">← Lobby</button>
     </div>

--- a/game-service-server/src/main/resources/web/style.css
+++ b/game-service-server/src/main/resources/web/style.css
@@ -35,6 +35,7 @@ header h1 { font-size: 1.2rem; margin: 0; }
 
 .whoami { color: var(--muted); font-size: 0.9rem; }
 
+#debug-nav,
 #logout { padding: 0.3rem 0.7rem; font-size: 0.85rem; }
 
 .panel {
@@ -196,6 +197,44 @@ button:disabled { opacity: 0.5; cursor: default; }
 .chat-who { color: var(--muted); font-weight: 600; margin-right: 0.4rem; }
 .chat-msg.own .chat-who { color: var(--accent); }
 .chat-text { color: var(--text); }
+
+/* Debug: live actor message trace log. */
+#trace-log-wrap {
+  max-height: 360px;
+  overflow-y: auto;
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  margin: 0.75rem 0;
+}
+
+#trace-log { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+
+#trace-log th,
+#trace-log td {
+  text-align: left;
+  padding: 0.3rem 0.6rem;
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
+}
+
+#trace-log th {
+  color: var(--muted);
+  font-weight: 600;
+  position: sticky;
+  top: 0;
+  background: var(--panel);
+}
+
+#trace-log td.trace-to {
+  font-family: ui-monospace, monospace;
+  font-size: 0.8rem;
+  max-width: 320px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+#trace-log td.trace-type { color: var(--accent); font-weight: 600; }
 
 #chat-input { flex: 1; }
 

--- a/game-service-server/src/main/resources/web/style.css
+++ b/game-service-server/src/main/resources/web/style.css
@@ -236,6 +236,41 @@ button:disabled { opacity: 0.5; cursor: default; }
 
 #trace-log td.trace-type { color: var(--accent); font-weight: 600; }
 
+/* Log/Graph view toggle: the inactive button is dimmed to look unselected without a separate disabled state. */
+.trace-view-btn { opacity: 0.6; }
+.trace-view-btn.active { opacity: 1; background: var(--accent); border-color: var(--accent); }
+
+/* Debug: node-pulse graph. One box per distinct actor seen; no edges, since TraceEvent.from is always null. */
+#trace-graph {
+  display: flex;
+  flex-wrap: wrap;
+  align-content: flex-start;
+  gap: 0.5rem;
+  min-height: 120px;
+  max-height: 360px;
+  overflow-y: auto;
+  padding: 0.75rem;
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  margin: 0.75rem 0;
+}
+
+.trace-node {
+  padding: 0.4rem 0.6rem;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  font-size: 0.8rem;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.trace-node-path { font-family: ui-monospace, monospace; color: var(--text); }
+.trace-node-count { color: var(--muted); margin-left: 0.4rem; }
+
+/* Briefly highlights a node when it receives a message; the class is added and removed by app.js on each event. */
+.trace-node.pulse { background: var(--accent-dim); border-color: var(--accent); }
+
 #chat-input { flex: 1; }
 
 /* Battleship: override the single-board grid when two boards are shown side by side. */

--- a/game-service-server/src/main/resources/web/style.css
+++ b/game-service-server/src/main/resources/web/style.css
@@ -236,41 +236,6 @@ button:disabled { opacity: 0.5; cursor: default; }
 
 #trace-log td.trace-type { color: var(--accent); font-weight: 600; }
 
-/* Log/Graph view toggle: the inactive button is dimmed to look unselected without a separate disabled state. */
-.trace-view-btn { opacity: 0.6; }
-.trace-view-btn.active { opacity: 1; background: var(--accent); border-color: var(--accent); }
-
-/* Debug: node-pulse graph. One box per distinct actor seen; no edges, since TraceEvent.from is always null. */
-#trace-graph {
-  display: flex;
-  flex-wrap: wrap;
-  align-content: flex-start;
-  gap: 0.5rem;
-  min-height: 120px;
-  max-height: 360px;
-  overflow-y: auto;
-  padding: 0.75rem;
-  background: var(--bg);
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  margin: 0.75rem 0;
-}
-
-.trace-node {
-  padding: 0.4rem 0.6rem;
-  background: var(--panel);
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  font-size: 0.8rem;
-  transition: background 0.15s ease, border-color 0.15s ease;
-}
-
-.trace-node-path { font-family: ui-monospace, monospace; color: var(--text); }
-.trace-node-count { color: var(--muted); margin-left: 0.4rem; }
-
-/* Briefly highlights a node when it receives a message; the class is added and removed by app.js on each event. */
-.trace-node.pulse { background: var(--accent-dim); border-color: var(--accent); }
-
 #chat-input { flex: 1; }
 
 /* Battleship: override the single-board grid when two boards are shown side by side. */

--- a/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
@@ -21,7 +21,6 @@ import com.andy327.actor.core.GameManager
 import com.andy327.actor.events.{EventPublisher, NoOpEventPublisher}
 import com.andy327.actor.lobby.{LobbyRepository, RedisLobbyRepository}
 import com.andy327.actor.persistence.PostgresActor
-import com.andy327.actor.tracing.{TraceCollector, TraceEvent, TracingConfig}
 import com.andy327.model.core.GameType
 import com.andy327.persistence.db.postgres.{
   PostgresGameRepository,
@@ -129,25 +128,7 @@ object GameServer {
   )(implicit runtime: IORuntime): IO[(ActorSystem[GameManager.Command], Http.ServerBinding)] = IO.defer {
     val rootBehavior = Behaviors.setup[GameManager.Command] { context =>
       val persistActor = context.spawn(PostgresActor(gameRepo, moveRepo, playerHistoryRepo), "postgres-persistence")
-
-      // The collector actor is only spawned when tracing is enabled, so a disabled config costs nothing at startup.
-      val tracingConfig = TracingConfig.default
-      val traceEmit: TraceEvent => Unit =
-        if (tracingConfig.enabled) {
-          val collector = context.spawn(TraceCollector(tracingConfig.bufferSize), "trace-collector")
-          (event: TraceEvent) => collector ! TraceCollector.Record(event)
-        } else _ => ()
-
-      GameManager(
-        persistActor,
-        gameRepo,
-        lobbyRepo,
-        moveRepo,
-        chatRepo,
-        publisher,
-        tracingConfig = tracingConfig,
-        traceEmit = traceEmit
-      )
+      GameManager(persistActor, gameRepo, lobbyRepo, moveRepo, chatRepo, publisher)
     }
 
     // Pekko actor system
@@ -164,8 +145,7 @@ object GameServer {
       new GameRoutes(GameType.Battleship, system).routes,
       new WebSocketRoutes(system).routes,
       new MetricsRoutes(metricsRegistry).routes,
-      // Static web UI; composed last so its catch-all resource lookup never shadows an API route
-      new StaticRoutes().routes
+      new StaticRoutes().routes // Web UI; composed last so its catch-all resource lookup doesn't shadow an API route
     )
 
     // Start HTTP server

--- a/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
@@ -46,6 +46,7 @@ import com.andy327.server.http.routes.{
   MetricsRoutes,
   PlayerRoutes,
   StaticRoutes,
+  TraceRoutes,
   WebSocketRoutes
 }
 import com.andy327.server.pubsub.RedisPubSubResource
@@ -144,6 +145,7 @@ object GameServer {
       new GameRoutes(GameType.ConnectFour, system).routes,
       new GameRoutes(GameType.Battleship, system).routes,
       new WebSocketRoutes(system).routes,
+      new TraceRoutes(system).routes,
       new MetricsRoutes(metricsRegistry).routes,
       new StaticRoutes().routes // Web UI; composed last so its catch-all resource lookup doesn't shadow an API route
     )

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -1,6 +1,6 @@
 package com.andy327.server.http.json
 
-import io.circe.generic.semiauto.deriveCodec
+import io.circe.generic.semiauto.{deriveCodec, deriveEncoder}
 import io.circe.syntax._
 import io.circe.{Codec, Decoder, Encoder, Json}
 import org.apache.pekko.http.scaladsl.unmarshalling.FromEntityUnmarshaller
@@ -24,6 +24,7 @@ import com.andy327.actor.core.LobbyManager.LobbySummary
 import com.andy327.actor.core.PlayerEvent
 import com.andy327.actor.game.{BattleshipState, GameState, GridGameState}
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyCodecs, LobbyMetadata, Player}
+import com.andy327.actor.tracing.TraceEvent
 import com.andy327.persistence.db.MoveRecord
 import com.andy327.persistence.db.PlayerHistoryRepository.GameResult
 import com.andy327.persistence.db.schema.GameTypeCodecs.gameTypeCodec
@@ -76,6 +77,9 @@ object JsonProtocol extends CirceSupport {
   implicit val unsubscribeAcknowledgedCodec: Codec[UnsubscribeAcknowledged] = deriveCodec[UnsubscribeAcknowledged]
 
   implicit val moveRecordCodec: Codec[MoveRecord] = deriveCodec[MoveRecord]
+
+  // Write-only: pushed over the debug trace WebSocket (TraceRoutes), never read back from a request body.
+  implicit val traceEventEncoder: Encoder[TraceEvent] = deriveEncoder[TraceEvent]
 
   implicit val moveHistoryCodec: Codec[MoveHistory] = deriveCodec[MoveHistory]
 

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/TraceRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/TraceRoutes.scala
@@ -1,0 +1,85 @@
+package com.andy327.server.http.routes
+
+import scala.concurrent.duration._
+
+import io.circe.syntax._
+import org.apache.pekko.actor.typed.scaladsl.AskPattern._
+import org.apache.pekko.actor.typed.{ActorRef, ActorSystem}
+import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.model.ws.{Message, TextMessage}
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.stream.scaladsl.{Flow, Sink}
+import org.apache.pekko.stream.typed.scaladsl.ActorSource
+import org.apache.pekko.stream.{Materializer, OverflowStrategy}
+import org.apache.pekko.util.Timeout
+
+import com.andy327.actor.core.GameManager
+import com.andy327.actor.tracing.{TraceCollector, TraceEvent}
+import com.andy327.server.http.auth.JwtPlayerDirectives._
+import com.andy327.server.http.json.JsonProtocol._
+
+/** Debug HTTP route that streams live `TraceEvent`s for actor message tracing visualization.
+  *
+  * On connect the client must supply a valid JWT, exactly like [[WebSocketRoutes]] (Bearer header, or `access_token`
+  * query parameter for browser clients). After authenticating, GameManager is asked for the live `trace-collector`
+  * ref; if tracing is disabled (`None`), the request is rejected with 503 rather than upgrading to a socket that
+  * would never receive anything. Otherwise the connection upgrades and the existing buffer plus every subsequent
+  * `TraceEvent` is streamed to the client as JSON text frames, oldest first. The socket is push-only: inbound client
+  * frames are accepted but ignored, since the debug viewer has no client-to-server protocol.
+  *
+  * Route Summary:
+  *   - GET /ws/trace - Stream live TraceEvents (Auth: Bearer token, or `access_token` query parameter)
+  *
+  * Actor relationships:
+  *   - Sends to: `GameManager` (`GetTraceCollector` on connect), the resolved `trace-collector`
+  *     (`TraceCollector.Subscribe` on connect, `TraceCollector.Unsubscribe` on close)
+  */
+class TraceRoutes(gameManager: ActorSystem[GameManager.Command]) {
+  implicit private val system: ActorSystem[GameManager.Command] = gameManager
+  implicit private val timeout: Timeout = Timeout(5.seconds)
+  implicit private val mat: Materializer = Materializer(system)
+  private val ec = system.executionContext
+
+  val routes: Route = path("ws" / "trace") {
+    authenticatePlayerAllowingQueryParam { _ =>
+      onSuccess(gameManager ? GameManager.GetTraceCollector) {
+        case Some(collector) => handleWebSocketMessages(buildFlow(collector))
+        case None            => complete(StatusCodes.ServiceUnavailable -> "tracing is disabled")
+      }
+    }
+  }
+
+  /** Render a TraceEvent as a JSON text frame for delivery to the client. */
+  private def render(event: TraceEvent): String = event.asJson.noSpaces
+
+  /** Builds a push-only WebSocket Flow that streams `TraceEvent`s from `collector`.
+    *
+    * Pre-materializes an ActorSource over `TraceEvent` to obtain a ref before the stream starts, then subscribes it
+    * to `collector` (which immediately replays its buffer, then forwards every later event). Inbound frames are
+    * accepted and discarded. On stream termination (WebSocket closed by either side), the source ref is unsubscribed
+    * from `collector`.
+    */
+  private def buildFlow(collector: ActorRef[TraceCollector.Command]): Flow[Message, Message, Any] = {
+    val (traceOut, source) = ActorSource
+      .actorRef[TraceEvent](
+        completionMatcher = PartialFunction.empty,
+        failureMatcher = PartialFunction.empty,
+        bufferSize = 256,
+        overflowStrategy = OverflowStrategy.dropHead
+      )
+      .preMaterialize()
+
+    collector ! TraceCollector.Subscribe(traceOut)
+
+    val inbound: Sink[Message, Any] = Sink.ignore
+
+    val outbound = source
+      .map(event => TextMessage(render(event)))
+      .watchTermination() { (_, done) =>
+        done.onComplete(_ => collector ! TraceCollector.Unsubscribe(traceOut))(ec)
+      }
+
+    Flow.fromSinkAndSource(inbound, outbound)
+  }
+}

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/WebSocketRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/WebSocketRoutes.scala
@@ -34,7 +34,8 @@ import com.andy327.server.http.json.JsonProtocol._
   * disconnect or replacement on reconnect), it completes the stream via `PlayerActor.SessionComplete`, closing the
   * WebSocket from the server side.
   *
-  * Route: GET /ws (Auth: Bearer token, or `access_token` query parameter)
+  * Route Summary:
+  *   - GET /ws - Upgrade to a WebSocket session (Auth: Bearer token, or `access_token` query parameter)
   *
   * Actor relationships:
   *   - Sends to: `GameManager` (`RegisterPlayer` on connect, `SendChat` on an inbound chat frame, `PlayerDisconnected`

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/TraceRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/TraceRoutesSpec.scala
@@ -1,0 +1,113 @@
+package com.andy327.server.http.routes
+
+import java.time.Instant
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+
+import org.apache.pekko.actor.testkit.typed.scaladsl.ActorTestKit
+import org.apache.pekko.actor.typed.scaladsl.AskPattern._
+import org.apache.pekko.actor.typed.{ActorSystem, Scheduler}
+import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.model.headers.RawHeader
+import org.apache.pekko.http.scaladsl.testkit.{ScalatestRouteTest, WSProbe}
+import org.apache.pekko.util.Timeout
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import com.andy327.actor.core.{GameManager, InMemRepo}
+import com.andy327.actor.lobby.{LobbyMetadata, LobbyRepository, Player}
+import com.andy327.actor.persistence.PersistenceProtocol
+import com.andy327.actor.tracing.{TraceCollector, TraceEvent, TracingConfig}
+import com.andy327.model.core.RoomId
+import com.andy327.server.testutil.AuthTestHelper.createTestToken
+
+class TraceRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
+  implicit val runtime: IORuntime = IORuntime.global
+  implicit val askTimeout: Timeout = Timeout(5.seconds)
+
+  private val noOpLobbyRepo: LobbyRepository = new LobbyRepository {
+    override def saveLobby(metadata: LobbyMetadata): IO[Unit] = IO.unit
+    override def deleteLobby(roomId: RoomId): IO[Unit] = IO.unit
+    override def loadAllLobbies(): IO[List[LobbyMetadata]] = IO.pure(Nil)
+  }
+
+  private val typedKit = ActorTestKit()
+  private val persistProbe = typedKit.createTestProbe[PersistenceProtocol.Command]()
+
+  private val disabledSystem: ActorSystem[GameManager.Command] =
+    ActorSystem(GameManager(persistProbe.ref, new InMemRepo, noOpLobbyRepo), "TraceRoutesSpecDisabledSystem")
+  private val disabledRoutes = new TraceRoutes(disabledSystem).routes
+
+  private val enabledTracingConfig = TracingConfig(enabled = true, sampleRate = 1.0, bufferSize = 100)
+  private val enabledSystem: ActorSystem[GameManager.Command] = ActorSystem(
+    GameManager(persistProbe.ref, new InMemRepo, noOpLobbyRepo, tracingConfig = enabledTracingConfig),
+    "TraceRoutesSpecEnabledSystem"
+  )
+  private val enabledRoutes = new TraceRoutes(enabledSystem).routes
+  implicit private val scheduler: Scheduler = enabledSystem.scheduler
+
+  "TraceRoutes" should {
+    "reject a connection with no Authorization header" in {
+      val wsClient = WSProbe()
+      WS("/ws/trace", wsClient.flow) ~> disabledRoutes ~> check {
+        status shouldBe StatusCodes.Unauthorized
+      }
+    }
+
+    "reject a connection with an invalid token" in {
+      val wsClient = WSProbe()
+      WS("/ws/trace", wsClient.flow) ~> addHeader(RawHeader("Authorization", "Bearer not-a-real-token")) ~>
+      disabledRoutes ~> check {
+        status shouldBe StatusCodes.Unauthorized
+      }
+    }
+
+    "reject an authenticated connection with 503 when tracing is disabled" in {
+      val alice = Player("alice")
+      val token = createTestToken(alice)
+      val wsClient = WSProbe()
+
+      WS("/ws/trace", wsClient.flow) ~> addHeader(RawHeader("Authorization", s"Bearer $token")) ~>
+      disabledRoutes ~> check {
+        status shouldBe StatusCodes.ServiceUnavailable
+      }
+    }
+
+    "upgrade the connection to WebSocket with a valid token when tracing is enabled" in {
+      val alice = Player("alice")
+      val token = createTestToken(alice)
+      val wsClient = WSProbe()
+
+      WS("/ws/trace", wsClient.flow) ~> addHeader(RawHeader("Authorization", s"Bearer $token")) ~>
+      enabledRoutes ~> check {
+        isWebSocketUpgrade shouldBe true
+      }
+    }
+
+    "push a TraceEvent recorded on the collector through the socket as a JSON frame" in {
+      val alice = Player("alice")
+      val token = createTestToken(alice)
+      val wsClient = WSProbe()
+
+      WS("/ws/trace", wsClient.flow) ~> addHeader(RawHeader("Authorization", s"Bearer $token")) ~>
+      enabledRoutes ~> check {
+        isWebSocketUpgrade shouldBe true
+
+        val collectorFuture = enabledSystem ? GameManager.GetTraceCollector
+        val collector = Await.result(collectorFuture, 3.seconds).get
+
+        val event = TraceEvent(from = None, to = "actor-1", messageType = "Ping", timestamp = Instant.now())
+        collector ! TraceCollector.Record(event)
+
+        // the collector replays its pre-existing buffer on subscribe (e.g. RestoreLobbies from system startup,
+        // since the shared enabledSystem's own actors are traced too), so the synthetic event isn't necessarily first
+        val frame = LazyList.continually(wsClient.expectMessage().asTextMessage.getStrictText).find(_.contains("Ping"))
+        frame.get should include("actor-1")
+      }
+    }
+  }
+}


### PR DESCRIPTION
This branch started out planning a node-pulse graph view on top of the event log, showing which actors receive messages, plus edges representing message flow between them. Getting real edges turned out to require sender information that Pekko typed simply doesn't expose to a `BehaviorInterceptor` — the only ways to get it were either an invasive rewrite of actor-to-actor tell call sites (undermining the whole point of this feature being a zero-touch wrap-around) or reaching into Pekko's private internals (fragile, unsupported across versions). Rather than accept either trade-off for a debug-only, normally-disabled feature, this branch pivoted to shipping just the event log; the graph-view commit was reverted after landing, and `TraceEvent.from` — never populatable under this design — is being dropped in a follow-up commit on main now that this merges cleanly.

`TraceCollector` gains `Subscribe`/`Unsubscribe`, extending the branch `feat-actor-message-tracing` shipped: a subscriber is replayed the existing buffer immediately, then forwarded every later Record as it arrives, so there is no gap between backlog and live events; a subscriber is dropped automatically if it terminates, mirroring `LobbyManager`'s existing subscriber cleanup. `GameManager.GetTraceCollector` exposes the collector to the HTTP layer via `context.child`, which also meant moving trace-collector ownership fully into `GameManager.apply` — it previously lived in `GameServer`'s wrapper, where `GameManager` could never actually reach it via `context.child`.

`TraceRoutes` adds `GET /ws/trace`, gated by the same JWT auth as the main `/ws` endpoint. It asks `GameManager` for the live collector on connect and rejects with `503` if tracing is disabled rather than upgrading to a socket that would never receive anything; otherwise it streams the buffer replay plus every subsequent `TraceEvent` as JSON text frames. The web UI gets a new Debug panel (nav button next to Log out, shown once signed in) with a scrolling log table of timestamp/to/messageType, opened lazily on first visit rather than at sign-in since most sessions never open it.
