### PR TITLE
Add Pig dice game (#23)

### DIFF
--- a/game-service-actor/src/main/scala/com/andy327/actor/game/GameRegistry.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/GameRegistry.scala
@@ -3,7 +3,8 @@ package com.andy327.actor.game
 import com.andy327.actor.battleship.BattleshipActor
 import com.andy327.actor.connectfour.ConnectFourActor
 import com.andy327.actor.core.GameActor
-import com.andy327.actor.game.modules.{BattleshipModule, ConnectFourModule, GameModule, TicTacToeModule}
+import com.andy327.actor.game.modules.{BattleshipModule, ConnectFourModule, GameModule, PigModule, TicTacToeModule}
+import com.andy327.actor.pig.PigActor
 import com.andy327.actor.tictactoe.TicTacToeActor
 import com.andy327.model.core.{Game, GameType, PlayerId}
 
@@ -44,5 +45,6 @@ object GameRegistry {
     case GameType.TicTacToe   => GameModuleBundle(TicTacToeModule, TicTacToeActor)
     case GameType.ConnectFour => GameModuleBundle(ConnectFourModule, ConnectFourActor)
     case GameType.Battleship  => GameModuleBundle(BattleshipModule, BattleshipActor)
+    case GameType.Pig         => GameModuleBundle(PigModule, PigActor)
   }
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
@@ -3,6 +3,7 @@ package com.andy327.actor.game
 import com.andy327.model.battleship.{Battleship, Coord, Player1, Player2, PlayerBoard, Seat}
 import com.andy327.model.connectfour.ConnectFour
 import com.andy327.model.core.{Draw, Game, GameStatus, Mark, PlayerId, Won}
+import com.andy327.model.pig.Pig
 import com.andy327.model.tictactoe.TicTacToe
 
 /** Super-type for all serializable “view” representations of game state that can be sent to the client as part of an
@@ -78,6 +79,33 @@ object BattleshipState {
   }
 }
 
+/** Serializable view of a Pig game, pushed to all clients over WebSocket.
+  *
+  * Scores are indexed in seat order: `"P1"` → index 0, `"P2"` → index 1, etc. `viewerSeat` identifies the viewer
+  * ("P1", "P2", …) or is `None` for a spectator. `lastRoll` is absent at the start of a turn (before any roll).
+  */
+case class PigState(
+    scores: Map[String, Int],
+    currentPlayer: String,
+    turnScore: Int,
+    lastRoll: Option[Int],
+    winner: Option[String],
+    viewerSeat: Option[String]
+) extends GameState
+
+object PigState {
+
+  def of(game: Pig, viewerSeat: Option[Int]): PigState =
+    PigState(
+      scores = game.playerIds.indices.map(i => Pig.seatLabel(i) -> game.scores(i)).toMap,
+      currentPlayer = Pig.seatLabel(game.currentSeat),
+      turnScore = game.turnScore,
+      lastRoll = game.lastRoll,
+      winner = game.winner.map(Pig.seatLabel),
+      viewerSeat = viewerSeat.map(Pig.seatLabel)
+    )
+}
+
 /** Type class for converting an internal game model into a serializable GameState.
   *
   * Instances live in the companion object, which is always in implicit scope for `GameStateView[G, S]` searches, so
@@ -104,6 +132,10 @@ object GameStateView {
   /** Type class instance for serializing a Battleship game, projected per viewer (fog-of-war for hidden boards). */
   implicit val battleshipView: GameStateView[Battleship, BattleshipState] =
     (game, viewer) => BattleshipState.of(game, viewer.flatMap(game.playerFor))
+
+  /** Type class instance for serializing a Pig game (same state for every viewer; no hidden information). */
+  implicit val pigView: GameStateView[Pig, PigState] =
+    (game, viewer) => PigState.of(game, viewer.flatMap(game.playerFor))
 }
 
 /** Utility for converting internal game models to HTTP-serializable GameState representations using the GameStateView

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/MovePayload.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/MovePayload.scala
@@ -28,4 +28,10 @@ object MovePayload {
     * @param col The column index (0-based)
     */
   final case class BattleshipMove(row: Int, col: Int) extends MovePayload
+
+  /** A move for Pig: either roll the die (`"roll"`) or bank the turn score (`"hold"`).
+    *
+    * @param action `"roll"` or `"hold"`
+    */
+  final case class PigAction(action: String) extends MovePayload
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/modules/PigModule.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/modules/PigModule.scala
@@ -1,0 +1,49 @@
+package com.andy327.actor.game.modules
+
+import scala.util.Random
+
+import cats.syntax.functor._
+
+import io.circe.Decoder
+import io.circe.generic.auto._
+import org.apache.pekko.actor.typed.ActorRef
+
+import com.andy327.actor.core.{GameActor, TurnBasedGameActor}
+import com.andy327.actor.game.MovePayload.PigAction
+import com.andy327.actor.game.{GameOperation, GameState, GameStateConverters, MovePayload}
+import com.andy327.model.core.{GameError, PlayerId}
+import com.andy327.model.pig.{Hold, Pig, Roll}
+
+/** [[GameModule]] implementation for Pig.
+  *
+  * Decodes `{"action":"roll"}` / `{"action":"hold"}` request bodies, rolls the die server-side for a Roll action (so
+  * the model remains a pure function), and delegates serialization to [[GameStateConverters]].
+  */
+object PigModule extends GameModule[Pig] {
+
+  override val moveDecoder: Decoder[MovePayload] = Decoder[PigAction].widen
+
+  override def toGameCommand(
+      op: GameOperation,
+      replyTo: ActorRef[Either[GameError, GameState]]
+  ): Either[GameError, GameActor.GameCommand] = op match {
+    case GameOperation.MakeMove(playerId, PigAction("roll")) =>
+      Right(TurnBasedGameActor.MakeMove(playerId, Roll(Random.between(1, 7)), replyTo))
+
+    case GameOperation.MakeMove(playerId, PigAction("hold")) =>
+      Right(TurnBasedGameActor.MakeMove(playerId, Hold, replyTo))
+
+    case GameOperation.MakeMove(_, PigAction(unknown)) =>
+      Left(GameError.Unknown(s"Unknown Pig action: $unknown"))
+
+    case GameOperation.MakeMove(_, otherMove) =>
+      val name = Option(otherMove).map(_.getClass.getSimpleName).getOrElse("null")
+      Left(GameError.Unknown(s"Unsupported move type for Pig: $name"))
+
+    case GameOperation.GetState =>
+      Right(TurnBasedGameActor.GetState(replyTo))
+  }
+
+  override def serialize(game: Pig, viewer: Option[PlayerId]): GameState =
+    GameStateConverters.serializeGame(game, viewer)
+}

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/modules/PigModule.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/modules/PigModule.scala
@@ -16,8 +16,9 @@ import com.andy327.model.pig.{Hold, Pig, Roll}
 
 /** [[GameModule]] implementation for Pig.
   *
-  * Decodes `{"action":"roll"}` / `{"action":"hold"}` request bodies, rolls the die server-side for a Roll action (so
-  * the model remains a pure function), and delegates serialization to [[GameStateConverters]].
+  * Provides move decoding, operation-to-command mapping, and game serialization for Pig. Enables
+  * [[com.andy327.actor.core.GameManager]] and the HTTP routes to handle Pig games without any game-specific logic.
+  * The die is rolled server-side here before dispatching to the model, keeping `Pig.play` a pure function.
   */
 object PigModule extends GameModule[Pig] {
 

--- a/game-service-actor/src/main/scala/com/andy327/actor/pig/PigActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/pig/PigActor.scala
@@ -10,8 +10,8 @@ import com.andy327.model.pig.{Hold, Pig, PigMove, Roll}
 /** [[com.andy327.actor.core.GameActor]] binding for Pig.
   *
   * All behavior lives in [[com.andy327.actor.core.TurnBasedGameActor]]. The die is rolled by
-  * [[com.andy327.actor.game.modules.PigModule]] before the move reaches the model, so
-  * [[com.andy327.model.pig.Pig.play]] remains a pure function.
+  * [[com.andy327.actor.game.modules.PigModule]] before the move reaches the model, so `Pig.play`
+  * remains a pure function.
   */
 object PigActor
     extends TurnBasedGameActor[Pig, PigMove, Int, PigState](

--- a/game-service-actor/src/main/scala/com/andy327/actor/pig/PigActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/pig/PigActor.scala
@@ -1,0 +1,23 @@
+package com.andy327.actor.pig
+
+import io.circe.Encoder
+import io.circe.syntax._
+
+import com.andy327.actor.core.TurnBasedGameActor
+import com.andy327.actor.game.PigState
+import com.andy327.model.pig.{Hold, Pig, PigMove, Roll}
+
+/** [[com.andy327.actor.core.GameActor]] binding for Pig.
+  *
+  * All behavior lives in [[com.andy327.actor.core.TurnBasedGameActor]]. The die is rolled by
+  * [[com.andy327.actor.game.modules.PigModule]] before the move reaches the model, so
+  * [[com.andy327.model.pig.Pig.play]] remains a pure function.
+  */
+object PigActor
+    extends TurnBasedGameActor[Pig, PigMove, Int, PigState](
+      players => Pig.newGame(players),
+      Encoder.instance[PigMove] {
+        case Roll(result) => Map("action" -> "roll", "result" -> result.toString).asJson
+        case Hold         => Map("action" -> "hold").asJson
+      }
+    )

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/PigModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/PigModuleSpec.scala
@@ -115,6 +115,15 @@ class PigModuleSpec extends AnyWordSpecLike with Matchers {
       )
     }
 
+    "set winner in PigState when the game has ended" in {
+      val alice = Player("alice")
+      val bob = Player("bob")
+      val game = Pig.newGame(Seq(alice.id, bob.id))
+      val won = game.copy(winner = Some(0))
+      val state = PigModule.serialize(won, None).asInstanceOf[PigState]
+      state.winner shouldBe Some("P1")
+    }
+
     "set viewerSeat when serializing for a known player" in {
       val alice = Player("alice")
       val bob = Player("bob")

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/PigModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/PigModuleSpec.scala
@@ -1,0 +1,123 @@
+package com.andy327.actor.game.modules
+
+import java.util.UUID
+
+import io.circe.parser.decode
+import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import com.andy327.actor.core.{PlayerActor, TurnBasedGameActor}
+import com.andy327.actor.game.{GameOperation, GameState, MovePayload, PigState}
+import com.andy327.actor.lobby.Player
+import com.andy327.actor.pig.PigActor
+import com.andy327.model.core.GameError
+import com.andy327.model.pig.{Hold, Pig, Roll}
+
+class PigModuleSpec extends AnyWordSpecLike with Matchers {
+  private val testKit = ActorTestKit()
+  import testKit._
+
+  "PigModule" should {
+    "successfully decode a roll action JSON" in {
+      val json = """{"action":"roll"}"""
+      decode[MovePayload](json)(PigModule.moveDecoder) shouldBe Right(MovePayload.PigAction("roll"))
+    }
+
+    "successfully decode a hold action JSON" in {
+      val json = """{"action":"hold"}"""
+      decode[MovePayload](json)(PigModule.moveDecoder) shouldBe Right(MovePayload.PigAction("hold"))
+    }
+
+    "fail to decode an invalid Pig move JSON" in {
+      val json = """{"bad":"data"}"""
+      decode[MovePayload](json)(PigModule.moveDecoder).isLeft shouldBe true
+    }
+
+    "convert a roll GameOperation.MakeMove to a Roll GameCommand with a valid die value" in {
+      val alice = Player("alice")
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+
+      val result = PigModule.toGameCommand(
+        GameOperation.MakeMove(alice.id, MovePayload.PigAction("roll")),
+        replyProbe.ref
+      )
+
+      result match {
+        case Right(TurnBasedGameActor.MakeMove(playerId, Roll(result), reply)) =>
+          playerId shouldBe alice.id
+          result should ((be >= 1).and(be <= 6))
+          reply shouldBe replyProbe.ref
+
+        case other => fail(s"Unexpected result: $other")
+      }
+    }
+
+    "convert a hold GameOperation.MakeMove to a Hold GameCommand" in {
+      val alice = Player("alice")
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+
+      val result = PigModule.toGameCommand(
+        GameOperation.MakeMove(alice.id, MovePayload.PigAction("hold")),
+        replyProbe.ref
+      )
+
+      result match {
+        case Right(TurnBasedGameActor.MakeMove(playerId, Hold, reply)) =>
+          playerId shouldBe alice.id
+          reply shouldBe replyProbe.ref
+
+        case other => fail(s"Unexpected result: $other")
+      }
+    }
+
+    "return an error for an unknown action string" in {
+      val alice = Player("alice")
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+
+      val Left(err) = PigModule.toGameCommand(
+        GameOperation.MakeMove(alice.id, MovePayload.PigAction("bad")),
+        replyProbe.ref
+      )
+
+      err.message should include("Unknown Pig action: bad")
+    }
+
+    "convert GetState to a GetState GameCommand" in {
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+
+      val result = PigModule.toGameCommand(GameOperation.GetState, replyProbe.ref)
+
+      result shouldBe Right(TurnBasedGameActor.GetState(replyProbe.ref))
+    }
+
+    "produce a Subscribe command for a given PlayerActor ref" in {
+      val playerProbe = TestProbe[PlayerActor.Command]()
+      val playerId = UUID.randomUUID()
+
+      val result = PigActor.subscribeCommand(playerProbe.ref, playerId)
+
+      result shouldBe TurnBasedGameActor.Subscribe(playerProbe.ref, playerId)
+    }
+
+    "serialize a Pig game to PigState" in {
+      val alice = Player("alice")
+      val bob = Player("bob")
+      val game = Pig.newGame(Seq(alice.id, bob.id))
+      PigModule.serialize(game, None) shouldBe a[PigState]
+    }
+
+    "return error when passing unsupported MovePayload to toGameCommand" in {
+      val alice = Player("alice")
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val unsupportedMove = null.asInstanceOf[MovePayload]
+
+      val Left(err) = PigModule.toGameCommand(
+        GameOperation.MakeMove(alice.id, unsupportedMove),
+        replyProbe.ref
+      )
+
+      err.message should include("Unsupported move type for Pig")
+    }
+  }
+}

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/PigModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/PigModuleSpec.scala
@@ -100,11 +100,27 @@ class PigModuleSpec extends AnyWordSpecLike with Matchers {
       result shouldBe TurnBasedGameActor.Subscribe(playerProbe.ref, playerId)
     }
 
-    "serialize a Pig game to PigState" in {
+    "serialize a Pig game to PigState with correct initial field values" in {
       val alice = Player("alice")
       val bob = Player("bob")
       val game = Pig.newGame(Seq(alice.id, bob.id))
-      PigModule.serialize(game, None) shouldBe a[PigState]
+      val state = PigModule.serialize(game, None)
+      state shouldBe PigState(
+        scores = Map("P1" -> 0, "P2" -> 0),
+        currentPlayer = "P1",
+        turnScore = 0,
+        lastRoll = None,
+        winner = None,
+        viewerSeat = None
+      )
+    }
+
+    "set viewerSeat when serializing for a known player" in {
+      val alice = Player("alice")
+      val bob = Player("bob")
+      val game = Pig.newGame(Seq(alice.id, bob.id))
+      val state = PigModule.serialize(game, Some(alice.id)).asInstanceOf[PigState]
+      state.viewerSeat shouldBe Some("P1")
     }
 
     "return error when passing unsupported MovePayload to toGameCommand" in {

--- a/game-service-model/src/main/scala/com/andy327/model/core/GameType.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/core/GameType.scala
@@ -31,6 +31,11 @@ object GameType {
     val (minPlayers, maxPlayers) = (2, 2)
   }
 
+  /** A press-your-luck dice game for 2–8 players: roll to accumulate points, but a 1 busts your turn. */
+  case object Pig extends GameType {
+    val (minPlayers, maxPlayers) = (2, 8)
+  }
+
   /** Parses a string into a GameType instance.
     *
     * @param s the name of the game type (case-insensitive)
@@ -40,6 +45,7 @@ object GameType {
     case "tictactoe"   => Some(TicTacToe)
     case "connectfour" => Some(ConnectFour)
     case "battleship"  => Some(Battleship)
+    case "pig"         => Some(Pig)
     case _             => None
   }
 }

--- a/game-service-model/src/main/scala/com/andy327/model/core/GameTypeTag.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/core/GameTypeTag.scala
@@ -2,6 +2,7 @@ package com.andy327.model.core
 
 import com.andy327.model.battleship.Battleship
 import com.andy327.model.connectfour.ConnectFour
+import com.andy327.model.pig.Pig
 import com.andy327.model.tictactoe.TicTacToe
 
 /** Type class used to associate a specific game model type (e.g., TicTacToe) with its corresponding GameType (e.g.,
@@ -31,5 +32,9 @@ object GameTypeTag {
 
   implicit val battleshipTag: GameTypeTag[Battleship] = new GameTypeTag[Battleship] {
     override val value: GameType = GameType.Battleship
+  }
+
+  implicit val pigTag: GameTypeTag[Pig] = new GameTypeTag[Pig] {
+    override val value: GameType = GameType.Pig
   }
 }

--- a/game-service-model/src/main/scala/com/andy327/model/pig/GameError.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/pig/GameError.scala
@@ -1,0 +1,8 @@
+package com.andy327.model.pig
+
+import com.andy327.model.core.GameError
+
+/** The player attempted to Hold without having rolled at all this turn. */
+case object NothingToHold extends GameError {
+  val message = "You must roll at least once before holding."
+}

--- a/game-service-model/src/main/scala/com/andy327/model/pig/Pig.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/pig/Pig.scala
@@ -1,0 +1,124 @@
+package com.andy327.model.pig
+
+import com.andy327.model.core.GameError.{GameOver, InvalidTurn}
+import com.andy327.model.core.{Game, GameError, GameStatus, InProgress, PlayerId, Won}
+
+object Pig {
+
+  /** Points needed to win. */
+  val WinScore: Int = 100
+
+  /** Creates a fresh game with all scores at zero. */
+  def newGame(playerIds: Seq[PlayerId]): Pig =
+    Pig(
+      playerIds = playerIds.toVector,
+      scores = Vector.fill(playerIds.size)(0),
+      currentSeat = 0,
+      turnScore = 0,
+      lastRoll = None,
+      winner = None,
+      moveCount = 0
+    )
+
+  /** Human-readable seat label for a zero-based seat index. */
+  def seatLabel(seat: Int): String = s"P${seat + 1}"
+}
+
+/** An instance of a Pig dice game.
+  *
+  * On each turn the current player may Roll (accumulate points, but rolling a 1 busts the turn) or Hold (bank their
+  * turn total). The first player to reach [[Pig.WinScore]] banked points wins. The die is rolled by the server before
+  * applying a [[Roll]] move, so the model itself is pure and every [[Roll]] already carries its result.
+  *
+  * @param playerIds ordered list of participating players; the seat index into this vector is the game's player token
+  * @param scores banked points per seat, indexed in the same order as `playerIds`
+  * @param currentSeat zero-based index of the player whose turn it is
+  * @param turnScore points accumulated this turn, not yet banked; lost on a roll of 1
+  * @param lastRoll the die value from the most recent roll, or None before any roll has been made
+  * @param winner the winning seat index once the game is over, otherwise None
+  * @param moveCount total rolls and holds applied so far; survives serialization for the history log
+  */
+final case class Pig(
+    playerIds: Vector[PlayerId],
+    scores: Vector[Int],
+    currentSeat: Int,
+    turnScore: Int,
+    lastRoll: Option[Int],
+    winner: Option[Int],
+    moveCount: Int
+) extends Game[PigMove, Pig, Int, GameStatus[Int], GameError] {
+
+  import Pig._
+
+  def currentState: Pig = this
+  def currentPlayer: Int = currentSeat
+  def gameStatus: GameStatus[Int] = winner.map(Won(_)).getOrElse(InProgress)
+  def players: List[PlayerId] = playerIds.toList
+
+  /** Resolves a platform player ID to the zero-based seat index, or `None` if not a participant. */
+  def playerFor(playerId: PlayerId): Option[Int] = {
+    val i = playerIds.indexOf(playerId)
+    if (i >= 0) Some(i) else None
+  }
+
+  private def nextSeat: Int = (currentSeat + 1) % playerIds.size
+
+  /** Applies a player action.
+    *
+    * Validates turn order. On `Roll`:
+    *   - result 1: bust — turn score is lost, turn passes to the next player
+    *   - result 2–6: added to `turnScore`; if the resulting banked score would reach [[Pig.WinScore]], the game ends
+    *
+    * On `Hold`: banks `turnScore` into `scores`; if that reaches [[Pig.WinScore]] the current player wins, otherwise
+    * the turn passes. Holding with zero turn score (no roll yet this turn) is rejected.
+    */
+  def play(player: Int, move: PigMove): Either[GameError, Pig] =
+    if (gameStatus != InProgress)
+      Left(GameOver)
+    else if (player != currentSeat)
+      Left(InvalidTurn)
+    else
+      move match {
+
+        case Roll(result) =>
+          if (result == 1) {
+            // bust: lose turn score, advance to next player
+            Right(copy(currentSeat = nextSeat, turnScore = 0, lastRoll = Some(1), moveCount = moveCount + 1))
+          } else {
+            Right(copy(turnScore = turnScore + result, lastRoll = Some(result), moveCount = moveCount + 1))
+          }
+
+        case Hold =>
+          if (turnScore == 0)
+            Left(NothingToHold)
+          else {
+            val banked = scores(currentSeat) + turnScore
+            val base = copy(
+              scores = scores.updated(currentSeat, banked),
+              turnScore = 0,
+              lastRoll = None,
+              moveCount = moveCount + 1
+            )
+            if (banked >= WinScore)
+              Right(base.copy(winner = Some(currentSeat)))
+            else
+              Right(base.copy(currentSeat = nextSeat))
+          }
+      }
+
+  /** The leaver forfeits; the non-leaver with the highest banked score wins (lowest seat index breaks a tie).
+    *
+    * If the leaver is the only player ahead by score, the runner-up wins — leaving never lets the leaver take the
+    * trophy.
+    */
+  override def playerLeft(playerId: PlayerId): Either[GameError, Pig] =
+    playerFor(playerId) match {
+      case None                                => Left(GameError.InvalidPlayer(playerId))
+      case Some(_) if gameStatus != InProgress => Left(GameOver)
+      case Some(leaverSeat)                    =>
+        val winnerSeat = playerIds.indices
+          .filter(_ != leaverSeat)
+          .maxBy(i => (scores(i), -i))
+        Right(copy(winner = Some(winnerSeat)))
+    }
+}

--- a/game-service-model/src/main/scala/com/andy327/model/pig/Pig.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/pig/Pig.scala
@@ -67,7 +67,7 @@ final case class Pig(
     *
     * Validates turn order. On `Roll`:
     *   - result 1: bust — turn score is lost, turn passes to the next player
-    *   - result 2–6: added to `turnScore`; if the resulting banked score would reach [[Pig.WinScore]], the game ends
+    *   - result 2–6: added to `turnScore`; the turn continues (a win can only be triggered by Hold, not Roll)
     *
     * On `Hold`: banks `turnScore` into `scores`; if that reaches [[Pig.WinScore]] the current player wins, otherwise
     * the turn passes. Holding with zero turn score (no roll yet this turn) is rejected.

--- a/game-service-model/src/main/scala/com/andy327/model/pig/package.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/pig/package.scala
@@ -1,0 +1,13 @@
+package com.andy327.model
+
+package object pig {
+
+  /** A player action on their turn. */
+  sealed trait PigMove
+
+  /** Roll the die. The server supplies the result (1–6) so the model remains pure and testable. */
+  case class Roll(result: Int) extends PigMove
+
+  /** Bank the current turn score and pass to the next player. */
+  case object Hold extends PigMove
+}

--- a/game-service-model/src/test/scala/com/andy327/model/pig/PigSpec.scala
+++ b/game-service-model/src/test/scala/com/andy327/model/pig/PigSpec.scala
@@ -1,0 +1,213 @@
+package com.andy327.model.pig
+
+import java.util.UUID
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import com.andy327.model.core.GameError.{GameOver, InvalidTurn}
+import com.andy327.model.core.{InProgress, PlayerId, Won}
+
+class PigSpec extends AnyWordSpec with Matchers {
+  val alice: PlayerId = UUID.randomUUID()
+  val bob: PlayerId = UUID.randomUUID()
+  val carol: PlayerId = UUID.randomUUID()
+
+  "A Pig game" should {
+
+    "resolve participants to their seat indices with playerFor" in {
+      val game = Pig.newGame(Seq(alice, bob))
+      game.playerFor(alice) shouldBe Some(0)
+      game.playerFor(bob) shouldBe Some(1)
+      game.playerFor(UUID.randomUUID()) shouldBe None
+    }
+
+    "list its roster in seat order with players" in {
+      Pig.newGame(Seq(alice, bob)).players shouldBe List(alice, bob)
+    }
+
+    "start with all scores at zero, no last roll, and the first player to move" in {
+      val game = Pig.newGame(Seq(alice, bob))
+      game.scores shouldBe Vector(0, 0)
+      game.turnScore shouldBe 0
+      game.lastRoll shouldBe None
+      game.currentSeat shouldBe 0
+      game.currentPlayer shouldBe 0
+      game.moveCount shouldBe 0
+      game.gameStatus shouldBe InProgress
+    }
+
+    "add a roll of 2–6 to the turn score and keep the turn" in {
+      val game = Pig.newGame(Seq(alice, bob))
+      val Right(next) = game.play(0, Roll(4))
+      next.turnScore shouldBe 4
+      next.lastRoll shouldBe Some(4)
+      next.currentSeat shouldBe 0
+      next.scores shouldBe Vector(0, 0)
+      next.gameStatus shouldBe InProgress
+    }
+
+    "accumulate turn score across multiple rolls" in {
+      val game = Pig.newGame(Seq(alice, bob))
+      val Right(after3) = game.play(0, Roll(3))
+      val Right(after5) = after3.play(0, Roll(5))
+      after5.turnScore shouldBe 8
+      after5.currentSeat shouldBe 0
+    }
+
+    "keep the game in progress when accumulated rolls would reach the win threshold before Hold" in {
+      val game = Pig.newGame(Seq(alice, bob)).copy(scores = Vector(95, 0))
+      val Right(next) = game.play(0, Roll(5))
+      next.gameStatus shouldBe InProgress
+      next.turnScore shouldBe 5
+      next.winner shouldBe None
+    }
+
+    "bust on a roll of 1 — lose the turn score and pass to the next player" in {
+      val game = Pig.newGame(Seq(alice, bob))
+      val Right(after4) = game.play(0, Roll(4))
+      val Right(bust) = after4.play(0, Roll(1))
+      bust.turnScore shouldBe 0
+      bust.lastRoll shouldBe Some(1)
+      bust.currentSeat shouldBe 1
+      bust.scores shouldBe Vector(0, 0)
+    }
+
+    "not bank any accumulated points when busting" in {
+      val game = Pig.newGame(Seq(alice, bob)).copy(scores = Vector(50, 0))
+      val Right(after6) = game.play(0, Roll(6))
+      val Right(bust) = after6.play(0, Roll(1))
+      bust.scores shouldBe Vector(50, 0)
+      bust.currentSeat shouldBe 1
+    }
+
+    "bank the turn score and advance on Hold" in {
+      val game = Pig.newGame(Seq(alice, bob))
+      val Right(rolled) = game.play(0, Roll(5))
+      val Right(held) = rolled.play(0, Hold)
+      held.scores shouldBe Vector(5, 0)
+      held.turnScore shouldBe 0
+      held.lastRoll shouldBe None
+      held.currentSeat shouldBe 1
+    }
+
+    "end the game when the banked total reaches the win threshold on Hold" in {
+      val game = Pig.newGame(Seq(alice, bob)).copy(scores = Vector(95, 0))
+      val Right(rolled) = game.play(0, Roll(5))
+      val Right(held) = rolled.play(0, Hold)
+      held.gameStatus shouldBe Won(0)
+      held.scores(0) shouldBe 100
+      held.winner shouldBe Some(0)
+    }
+
+    "end the game when the banked total exceeds the win threshold on Hold" in {
+      val game = Pig.newGame(Seq(alice, bob)).copy(scores = Vector(95, 0))
+      val Right(rolled) = game.play(0, Roll(6))
+      val Right(held) = rolled.play(0, Hold)
+      held.gameStatus shouldBe Won(0)
+      held.scores(0) shouldBe 101
+    }
+
+    "reject Hold when no roll has been made this turn" in {
+      val game = Pig.newGame(Seq(alice, bob))
+      game.play(0, Hold) shouldBe Left(NothingToHold)
+    }
+
+    "wrap the turn back to the first seat after the last" in {
+      val game = Pig.newGame(Seq(alice, bob))
+      val Right(r1) = game.play(0, Roll(3))
+      val Right(h1) = r1.play(0, Hold)
+      h1.currentSeat shouldBe 1
+      val Right(r2) = h1.play(1, Roll(2))
+      val Right(h2) = r2.play(1, Hold)
+      h2.currentSeat shouldBe 0
+    }
+
+    "advance through seats in order with three players" in {
+      val game = Pig.newGame(Seq(alice, bob, carol))
+      val Right(r0) = game.play(0, Roll(3))
+      val Right(h0) = r0.play(0, Hold)
+      h0.currentSeat shouldBe 1
+      val Right(r1) = h0.play(1, Roll(2))
+      val Right(h1) = r1.play(1, Hold)
+      h1.currentSeat shouldBe 2
+      val Right(r2) = h1.play(2, Roll(5))
+      val Right(h2) = r2.play(2, Hold)
+      h2.currentSeat shouldBe 0
+    }
+
+    "reject a move by the out-of-turn player" in {
+      val game = Pig.newGame(Seq(alice, bob))
+      game.play(1, Roll(4)) shouldBe Left(InvalidTurn)
+    }
+
+    "reject any move once the game is over" in {
+      val game = Pig.newGame(Seq(alice, bob)).copy(scores = Vector(95, 0))
+      val Right(rolled) = game.play(0, Roll(5))
+      val Right(finished) = rolled.play(0, Hold)
+      finished.gameStatus shouldBe Won(0)
+      finished.play(0, Roll(3)) shouldBe Left(GameOver)
+      finished.play(0, Hold) shouldBe Left(GameOver)
+    }
+
+    "increment moveCount on every Roll and Hold" in {
+      val game = Pig.newGame(Seq(alice, bob))
+      val Right(g1) = game.play(0, Roll(3))
+      g1.moveCount shouldBe 1
+      val Right(g2) = g1.play(0, Roll(1)) // bust
+      g2.moveCount shouldBe 2
+      val Right(g3) = g2.play(1, Roll(4))
+      g3.moveCount shouldBe 3
+      val Right(g4) = g3.play(1, Hold)
+      g4.moveCount shouldBe 4
+    }
+  }
+
+  "A leaving player" should {
+
+    "award the win to the opponent in a two-player game" in {
+      val game = Pig.newGame(Seq(alice, bob))
+      game.playerLeft(alice).map(_.gameStatus) shouldBe Right(Won(1))
+      game.playerLeft(bob).map(_.gameStatus) shouldBe Right(Won(0))
+    }
+
+    "award the win to the highest-scoring non-leaver in a multiplayer game" in {
+      val game = Pig.newGame(Seq(alice, bob, carol)).copy(scores = Vector(40, 70, 30))
+      game.playerLeft(alice).map(_.winner) shouldBe Right(Some(1))
+    }
+
+    "break a tie in favour of the lower seat index" in {
+      val game = Pig.newGame(Seq(alice, bob, carol)).copy(scores = Vector(50, 50, 30))
+      game.playerLeft(carol).map(_.winner) shouldBe Right(Some(0))
+    }
+
+    "be rejected for a non-participant" in {
+      val game = Pig.newGame(Seq(alice, bob))
+      game.playerLeft(UUID.randomUUID()) shouldBe a[Left[_, _]]
+    }
+
+    "be rejected once the game is already over" in {
+      val game = Pig.newGame(Seq(alice, bob)).copy(scores = Vector(95, 0))
+      val Right(rolled) = game.play(0, Roll(5))
+      val Right(finished) = rolled.play(0, Hold)
+      finished.playerLeft(bob) shouldBe Left(GameOver)
+    }
+  }
+
+  "Pig.newGame" should {
+
+    "seat players in the order provided" in {
+      val game = Pig.newGame(Seq(alice, bob, carol))
+      game.playerFor(alice) shouldBe Some(0)
+      game.playerFor(bob) shouldBe Some(1)
+      game.playerFor(carol) shouldBe Some(2)
+    }
+
+    "support up to 8 players" in {
+      val players = Seq.fill(8)(UUID.randomUUID())
+      val game = Pig.newGame(players)
+      game.playerIds.size shouldBe 8
+      game.scores shouldBe Vector.fill(8)(0)
+    }
+  }
+}

--- a/game-service-persistence/src/main/scala/com/andy327/persistence/db/schema/GameTypeCodecs.scala
+++ b/game-service-persistence/src/main/scala/com/andy327/persistence/db/schema/GameTypeCodecs.scala
@@ -8,6 +8,7 @@ import io.circe.{Codec, Decoder, Encoder}
 import com.andy327.model.battleship.{Battleship, Coord, Player1, Player2, PlayerBoard, Seat, Ship}
 import com.andy327.model.connectfour.{ConnectFour, Mark => ConnectFourMark, Red, Yellow}
 import com.andy327.model.core.{Game, GameType}
+import com.andy327.model.pig.Pig
 import com.andy327.model.tictactoe.{Mark, O, TicTacToe, X}
 
 /** Circe codecs and utilities for working with GameType and serialized Game state.
@@ -23,12 +24,14 @@ object GameTypeCodecs {
       case "TicTacToe"   => Right(GameType.TicTacToe)
       case "ConnectFour" => Right(GameType.ConnectFour)
       case "Battleship"  => Right(GameType.Battleship)
+      case "Pig"         => Right(GameType.Pig)
       case other         => Left(s"Unknown GameType: $other")
     },
     Encoder.encodeString.contramap[GameType] {
       case GameType.TicTacToe   => "TicTacToe"
       case GameType.ConnectFour => "ConnectFour"
       case GameType.Battleship  => "Battleship"
+      case GameType.Pig         => "Pig"
     }
   )
 
@@ -68,12 +71,14 @@ object GameTypeCodecs {
   implicit val shipCodec: Codec[Ship] = deriveCodec[Ship]
   implicit val playerBoardCodec: Codec[PlayerBoard] = deriveCodec[PlayerBoard]
   implicit val battleshipCodec: Codec[Battleship] = deriveCodec[Battleship]
+  implicit val pigCodec: Codec[Pig] = deriveCodec[Pig]
 
   /** Serializes a game instance to a JSON string using the codec for the given GameType. */
   def serializeGame(gameType: GameType, game: Game[_, _, _, _, _]): String = gameType match {
     case GameType.TicTacToe   => game.asInstanceOf[TicTacToe].asJson.noSpaces
     case GameType.ConnectFour => game.asInstanceOf[ConnectFour].asJson.noSpaces
     case GameType.Battleship  => game.asInstanceOf[Battleship].asJson.noSpaces
+    case GameType.Pig         => game.asInstanceOf[Pig].asJson.noSpaces
   }
 
   /** Deserializes a game state JSON string into a Game instance based on the provided GameType. */
@@ -82,5 +87,6 @@ object GameTypeCodecs {
       case GameType.TicTacToe   => decode[TicTacToe](json).left.map(err => new Exception(err))
       case GameType.ConnectFour => decode[ConnectFour](json).left.map(err => new Exception(err))
       case GameType.Battleship  => decode[Battleship](json).left.map(err => new Exception(err))
+      case GameType.Pig         => decode[Pig](json).left.map(err => new Exception(err))
     }
 }

--- a/game-service-persistence/src/test/scala/com/andy327/persistence/db/schema/GameTypeCodecsSpec.scala
+++ b/game-service-persistence/src/test/scala/com/andy327/persistence/db/schema/GameTypeCodecsSpec.scala
@@ -12,6 +12,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import com.andy327.model.battleship.{Battleship, Coord, Fire, Player1, Player2, PlayerBoard, Ship}
 import com.andy327.model.connectfour.{ConnectFour, Drop, Red}
 import com.andy327.model.core.{GameType, PlayerId}
+import com.andy327.model.pig.Pig
 import com.andy327.model.tictactoe.{Location, TicTacToe, X}
 
 class GameTypeCodecsSpec extends AnyWordSpec with Matchers {
@@ -135,6 +136,24 @@ class GameTypeCodecsSpec extends AnyWordSpec with Matchers {
     "return Left if Battleship game JSON is invalid" in {
       val badJson = """{ "not": "valid" }"""
       val result = deserializeGame(GameType.Battleship, badJson)
+      result.isLeft shouldBe true
+    }
+
+    "correctly encode and decode GameType.Pig" in {
+      val t: GameType = GameType.Pig
+      val json = t.asJson.noSpaces
+      json shouldBe "\"Pig\""
+      decode[GameType](json) shouldBe Right(GameType.Pig)
+    }
+
+    "round-trip a Pig game through serializeGame and deserializeGame" in {
+      val game = Pig.newGame(Seq(alice, bob))
+      val json = serializeGame(GameType.Pig, game)
+      deserializeGame(GameType.Pig, json) shouldBe Right(game)
+    }
+
+    "return Left if Pig game JSON is invalid" in {
+      val result = deserializeGame(GameType.Pig, """{ "not": "valid" }""")
       result.isLeft shouldBe true
     }
   }

--- a/game-service-persistence/src/test/scala/com/andy327/persistence/db/schema/GameTypeCodecsSpec.scala
+++ b/game-service-persistence/src/test/scala/com/andy327/persistence/db/schema/GameTypeCodecsSpec.scala
@@ -139,6 +139,10 @@ class GameTypeCodecsSpec extends AnyWordSpec with Matchers {
       result.isLeft shouldBe true
     }
 
+    "resolve \"pig\" via GameType.fromString" in {
+      GameType.fromString("pig") shouldBe Some(GameType.Pig)
+    }
+
     "correctly encode and decode GameType.Pig" in {
       val t: GameType = GameType.Pig
       val json = t.asJson.noSpaces

--- a/game-service-server/src/main/resources/web/app.js
+++ b/game-service-server/src/main/resources/web/app.js
@@ -23,7 +23,8 @@ const session = {
 const GAMES = {
   tictactoe:   { label: "Tic-Tac-Toe", maxPlayers: 2, move: (row, col) => ({ row, col }) },
   connectfour: { label: "Connect Four", maxPlayers: 2, move: (row, col) => ({ col }), columns: true },
-  battleship:  { label: "Battleship",   maxPlayers: 2, move: (row, col) => ({ row, col }) }
+  battleship:  { label: "Battleship",   maxPlayers: 2, move: (row, col) => ({ row, col }) },
+  pig:         { label: "Pig",          maxPlayers: 8, pig: true }
 };
 
 const $ = (id) => document.getElementById(id);
@@ -552,8 +553,73 @@ function sendChat(text) {
 }
 
 // --- Board rendering -------------------------------------------------------------------------------------------------
+// Sends a Pig action ("roll" or "hold") as a POST move to the server.
+async function submitPigAction(action) {
+  const game = session.game;
+  if (!game) return;
+  setError("game-error", "");
+  const res = await api(`/${game.gameType}/${game.roomId}/move`, { method: "POST", body: { action } });
+  if (!res.ok) flashError("game-error", res.data?.error || res.data || "Move rejected");
+}
+
+// Renders a Pig game state: a score table, turn info, and Roll / Hold action buttons.
+function renderPigBoard(state) {
+  const board = $("board");
+  board.classList.remove("bs-active");
+  board.innerHTML = "";
+  $("column-controls").innerHTML = "";
+
+  const over = Boolean(state.winner);
+  const spectating = Boolean(session.game && session.game.isSpectator);
+  const myTurn = !spectating && !over && state.viewerSeat !== null && state.currentPlayer === state.viewerSeat;
+
+  if (state.winner) setStatus(`${state.winner} wins!`);
+  else if (state.viewerSeat) setStatus(myTurn ? "Your turn!" : `${state.currentPlayer}'s turn…`);
+  else setStatus(`Spectating — turn: ${state.currentPlayer}`);
+
+  // Score table
+  const table = document.createElement("table");
+  table.className = "pig-scores";
+  const header = table.insertRow();
+  header.innerHTML = "<th>Player</th><th>Score</th>";
+  for (const [seat, score] of Object.entries(state.scores).sort()) {
+    const row = table.insertRow();
+    const isCurrentPlayer = seat === state.currentPlayer;
+    row.className = isCurrentPlayer && !over ? "pig-current" : "";
+    row.innerHTML = `<td>${seat}${seat === state.viewerSeat ? " (you)" : ""}</td><td>${score}</td>`;
+  }
+  board.appendChild(table);
+
+  // Turn info
+  const info = document.createElement("p");
+  info.className = "pig-turn-info";
+  const rollText = state.lastRoll != null ? `Last roll: ${state.lastRoll}` : "No roll yet this turn";
+  info.textContent = `Turn score: ${state.turnScore}  |  ${rollText}`;
+  board.appendChild(info);
+
+  // Action buttons (only for the active player)
+  if (myTurn) {
+    const actions = document.createElement("div");
+    actions.className = "pig-actions";
+
+    const rollBtn = document.createElement("button");
+    rollBtn.textContent = "Roll";
+    rollBtn.onclick = () => submitPigAction("roll");
+    actions.appendChild(rollBtn);
+
+    const holdBtn = document.createElement("button");
+    holdBtn.textContent = "Hold";
+    holdBtn.disabled = state.turnScore === 0;
+    holdBtn.onclick = () => submitPigAction("hold");
+    actions.appendChild(holdBtn);
+
+    board.appendChild(actions);
+  }
+}
+
 // Renders any game-state view pushed from the server. Battleship states (identified by `state.board1`) are handled
-// separately; all other games use the shared grid renderer below.
+// separately; Pig states (identified by `state.scores` being an object) use their own renderer; all other games use
+// the shared grid renderer below.
 function renderBoard(state) {
   // a board push means we're now (or still) watching a live game, however we got here
   if (session.game) session.game.isLive = true;
@@ -564,6 +630,11 @@ function renderBoard(state) {
 
   if (state.board1 !== undefined) {
     renderBattleshipBoard(state);
+    return;
+  }
+
+  if (state.scores !== undefined && !Array.isArray(state.scores)) {
+    renderPigBoard(state);
     return;
   }
 

--- a/game-service-server/src/main/resources/web/index.html
+++ b/game-service-server/src/main/resources/web/index.html
@@ -53,6 +53,7 @@
       <button data-gametype="tictactoe">Tic-Tac-Toe</button>
       <button data-gametype="connectfour">Connect Four</button>
       <button data-gametype="battleship">Battleship</button>
+      <button data-gametype="pig">Pig</button>
     </div>
 
     <h3>Your games &amp; lobbies</h3>
@@ -67,6 +68,7 @@
         <option value="tictactoe">Tic-Tac-Toe</option>
         <option value="connectfour">Connect Four</option>
         <option value="battleship">Battleship</option>
+        <option value="pig">Pig</option>
       </select>
     </div>
     <ul id="lobby-list"></ul>

--- a/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
@@ -143,6 +143,7 @@ object GameServer {
       new GameRoutes(GameType.TicTacToe, system).routes,
       new GameRoutes(GameType.ConnectFour, system).routes,
       new GameRoutes(GameType.Battleship, system).routes,
+      new GameRoutes(GameType.Pig, system).routes,
       new WebSocketRoutes(system).routes,
       new MetricsRoutes(metricsRegistry).routes,
       // Static web UI; composed last so its catch-all resource lookup never shadows an API route

--- a/game-service-server/src/main/scala/com/andy327/server/analytics/GameMetrics.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/analytics/GameMetrics.scala
@@ -69,5 +69,6 @@ class GameMetrics(registry: CollectorRegistry) {
     case GameType.TicTacToe   => "tictactoe"
     case GameType.ConnectFour => "connectfour"
     case GameType.Battleship  => "battleship"
+    case GameType.Pig         => "pig"
   }
 }

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -22,7 +22,7 @@ import com.andy327.actor.core.GameManager.{
 }
 import com.andy327.actor.core.LobbyManager.LobbySummary
 import com.andy327.actor.core.PlayerEvent
-import com.andy327.actor.game.{BattleshipState, GameState, GridGameState}
+import com.andy327.actor.game.{BattleshipState, GameState, GridGameState, PigState}
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyCodecs, LobbyMetadata, Player}
 import com.andy327.persistence.db.MoveRecord
 import com.andy327.persistence.db.PlayerHistoryRepository.GameResult
@@ -108,12 +108,15 @@ object JsonProtocol extends CirceSupport {
 
   implicit val battleshipStateCodec: Codec[BattleshipState] = deriveCodec[BattleshipState]
 
+  implicit val pigStateCodec: Codec[PigState] = deriveCodec[PigState]
+
   /** Encoder for the polymorphic `GameState` hierarchy (grid games share `GridGameState`;
-    * Battleship has its own per-viewer `BattleshipState`).
+    * Battleship has its own per-viewer `BattleshipState`; Pig has `PigState`).
     */
   implicit val gameStateEncoder: Encoder[GameState] = Encoder.instance {
     case s: GridGameState   => s.asJson
     case s: BattleshipState => s.asJson
+    case s: PigState        => s.asJson
   }
 
   // Entity unmarshallers, declared per-type so they don't shadow the predefined `String` unmarshaller (see

--- a/game-service-server/src/test/scala/com/andy327/server/analytics/GameMetricsSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/analytics/GameMetricsSpec.scala
@@ -65,6 +65,13 @@ class GameMetricsSpec extends AnyWordSpec with Matchers {
       ) shouldBe Some(1.0)
     }
 
+    "label Pig events with the \"pig\" game type" in {
+      val (registry, metrics) = fixture
+      metrics.record(GameStarted(UUID.randomUUID(), GameType.Pig, 3))
+
+      sample(registry, "games_started_total", Array("game_type"), Array("pig")) shouldBe Some(1.0)
+    }
+
     "label lobby chat as \"lobby\" and in-game chat by game type" in {
       val (registry, metrics) = fixture
       metrics.record(ChatSent(UUID.randomUUID(), Some(GameType.Battleship)))

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -19,7 +19,7 @@ import com.andy327.actor.core.GameManager.{
   SubscribeAcknowledged
 }
 import com.andy327.actor.core.PlayerEvent
-import com.andy327.actor.game.{BattleshipState, GameState, GameStateConverters, GridGameState}
+import com.andy327.actor.game.{BattleshipState, GameState, GameStateConverters, GridGameState, PigState}
 import com.andy327.actor.lobby._
 import com.andy327.model.battleship.Battleship
 import com.andy327.model.connectfour.ConnectFour
@@ -125,6 +125,20 @@ class SerializationSpec extends AnyWordSpec with Matchers {
       val json = state.asJson
       json.hcursor.get[Option[String]]("viewerSeat") shouldBe Right(None)
       json.hcursor.downField("board1").focus should be(defined)
+    }
+
+    "encode a PigState branch" in {
+      val state: GameState = PigState(
+        scores = Map("P1" -> 0, "P2" -> 0),
+        currentPlayer = "P1",
+        turnScore = 0,
+        lastRoll = None,
+        winner = None,
+        viewerSeat = None
+      )
+      val json = state.asJson
+      json.hcursor.downField("scores").focus should be(defined)
+      json.hcursor.get[String]("currentPlayer") shouldBe Right("P1")
     }
   }
 


### PR DESCRIPTION
Implements Pig (#23) end-to-end: model, backend wiring, and web UI. Pig is a press-your-luck dice game for 2–8 players — roll to accumulate turn points, but rolling a 1 busts the turn; hold to bank and win once you reach 100.

### What's included
- **Model** — `Pig` game model with `Roll`/`Hold` moves, bust-on-1, win-on-hold-at-100, and `playerLeft` tiebreaking by highest banked score (lowest seat breaks ties). `GameType.Pig` registered with 2–8 player bounds; `GameTypeTag` and `GameTypeCodecs` persistence round-trip added.
- **Actor / module** — `PigActor` bound to `TurnBasedGameActor`; `PigModule` decodes `{"action":"roll"}` / `{"action":"hold"}`, dispatches to game commands, and handles unknown action errors. `PigState` view type carries seat-labelled scores and optional viewer seat; `GameRegistry` wired.
- **Server** — `JsonProtocol` codec and `gameStateEncoder` branch for `PigState`; `GameMetrics` label; routes registered in `GameServer`.
- **Web UI** — Pig button in the new-game bar, filter option, score table, and Roll/Hold controls.

### Design notes
- The die is rolled in `PigModule.toGameCommand` rather than in the model, keeping `Pig.play` a pure function testable with exact die values.
- Seat tokens are `Int` indices (displayed as P1–P8) rather than a fixed sealed trait, enabling variable player counts without enumerating seats up front.

### Testing
- `PigSpec` — turn logic, bust, win-on-hold, no-win-on-roll, multi-player rotation, `playerLeft` tiebreaking, `moveCount`
- `PigModuleSpec` — decode, action dispatch, unknown action error, `PigState` field values, winner path, viewer seat
- `GameTypeCodecsSpec` — `fromString("pig")`, GameType encode/decode, persistence round-trip
- `GameMetricsSpec` / `SerializationSpec` — `"pig"` label, `PigState` encoder branch