### PR TITLE
Add Mastermind code-breaking game (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 **Pekko Game Service** is a backend for hosting multiplayer turn-based games. Players authenticate, gather in lobbies, and play matches whose moves are validated server-side and pushed to every participant in real time over WebSockets. Game state is the single source of truth held in a per-game actor, persisted to PostgreSQL, and cached in Redis so matches survive restarts.
 
-The architecture is built around the actor model: each game is an isolated actor that serializes its own moves (no race conditions), and new game types plug in through a small `Game` trait plus a module registry. Games with hidden information (e.g. Battleship's fog of war) are supported through per-viewer state projection, so each player — and any spectator — only ever receives the slice of state they're allowed to see.
+The architecture is built around the actor model: each game is an isolated actor that serializes its own moves (no race conditions), and new game types plug in through a small `Game` trait plus a module registry. Games with hidden information (e.g. Battleship's fog of war, or Mastermind's hidden code) are supported through per-viewer state projection, so each player — and any spectator — only ever receives the slice of state they're allowed to see.
 
 Although it runs as a single instance today, the system is **designed for horizontal scale from the ground up**, and the actor model is the foundation for getting there. A few choices made early reflect that intent: each match is an independent, self-contained game actor — a natural unit of sharding that can be relocated to any node without changing its logic; all durable state lives outside the process (PostgreSQL as system of record, Redis as a shared write-through cache), so instances hold no irreplaceable in-memory state and stay interchangeable; the HTTP layer is stateless and authenticates every request with a self-contained JWT, so REST traffic needs no sticky sessions; and analytics are decoupled over a Redis pub/sub channel rather than computed inline, letting the consumer side scale and evolve independently of gameplay. The remaining step — distributing those game actors across a cluster via Pekko Cluster Sharding — is on the [Roadmap](#roadmap), and the seams it needs are already in place.
 
@@ -23,7 +23,7 @@ Although it runs as a single instance today, the system is **designed for horizo
 - 🔐 Credentialed accounts — register, log in, and change password (Argon2-hashed), issuing expiring JWTs for player actions
 - 🏛️ Full lobby lifecycle — create, join, leave, list, and start matches
 - 🔁 Post-game rooms — a finished match keeps its room alive for chat, and the host can start a same-roster rematch; idle/empty rooms are evicted automatically
-- 🎲 Multiple game types — Tic-Tac-Toe, Connect Four, and Battleship
+- 🎲 Multiple game types — Tic-Tac-Toe, Connect Four, Battleship, Pig, and Mastermind
 - ✅ Server-side move validation (turn order and legality enforced by the game model)
 - ⚡ Real-time state delivery to all participants over WebSockets
 - 🌫️ Per-viewer / fog-of-war state projection for hidden-information games and spectators
@@ -280,7 +280,7 @@ On startup `GameManager` doesn't accept traffic blindly — it kicks off an asyn
 
 ### Per-viewer projection (fog of war)
 
-A game actor never ships its raw internal state to anyone. When it needs to send state out — as a move reply or a push — it renders a **view** for a specific viewer through a `GameStateView` type class: `serialize(game, Some(playerId))` for that player's own view, `serialize(game, None)` for a public/spectator view. Full-information games (Tic-Tac-Toe, Connect Four) ignore the viewer and show everyone the same board. For Battleship the projection is where fog of war is enforced: your own ships are visible to you, your opponent's are hidden, and a spectator sees both boards fogged. No code path can leak hidden state, because the unredacted model never leaves the actor.
+A game actor never ships its raw internal state to anyone. When it needs to send state out — as a move reply or a push — it renders a **view** for a specific viewer through a `GameStateView` type class: `serialize(game, Some(playerId))` for that player's own view, `serialize(game, None)` for a public/spectator view. Full-information games (Tic-Tac-Toe, Connect Four, Pig) ignore the viewer and show everyone the same board. For Battleship the projection is where fog of war is enforced: your own ships are visible to you, your opponent's are hidden, and a spectator sees both boards fogged. Mastermind works the same way — the codemaker's secret code is hidden from the codebreaker (and spectators) until the game ends. No code path can leak hidden state, because the unredacted model never leaves the actor.
 
 ### Real-time delivery
 
@@ -347,7 +347,7 @@ Planned work, in rough priority order:
 - **Horizontal scaling (Pekko Cluster Sharding)** — today the service is single-instance (lobbies, game actors, and player sessions live in one JVM). The target is to shard game and lobby entities across a Pekko cluster so play is location-transparent across nodes. Cluster messaging would carry cross-instance delivery between game actors and player sessions directly, while the analytics event stream survives unchanged. Kept deliberately out of the main architecture diagram above so it reflects what's actually deployed.
 - **Authentication hardening** — the credentialed auth in place covers registration, login, and password change, with Argon2id hashing, short-lived tokens, and login timing-equalization to blunt email enumeration. Considered and deliberately deferred: **token revocation** — JWTs are stateless, so a password change or "log out" doesn't invalidate already-issued tokens before they expire; closing that needs a per-account token version baked into the claim (or a `jti` denylist in Redis) checked at validation time. **Password reset** (forgot-password) — needs an out-of-band channel (email) and a single-use, TTL'd reset-token store (a natural fit for Redis), so it's gated on an email integration. **Rate limiting / lockout** on the auth endpoints to slow credential stuffing, and **email-address verification** at registration, are likewise out of scope for now. The short token TTL keeps the revocation gap small in the meantime.
 - **OAuth / social login** — a second `IdentityProvider` (e.g. Google/GitHub) plus a callback route, resolving an external identity to the same `Account` and reusing token issuance and the account store unchanged. The `IdentityProvider` seam exists precisely so this is additive; the open design questions are account-linking policy (same email via password and OAuth) and how non-browser clients complete the redirect.
-- **More game types** — additional turn-based games beyond the current three (e.g. Pig, Liar's Dice, Mastermind, Texas Hold 'Em).
+- **More game types** — additional turn-based games beyond the current five (e.g. Liar's Dice, Texas Hold 'Em).
 - **AI opponent** — a bot player for single-player matches and testing.
 - **Load testing** — throughput/latency benchmarking, plus retention policies for snapshots and move logs.
 

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/GameRegistry.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/GameRegistry.scala
@@ -3,7 +3,15 @@ package com.andy327.actor.game
 import com.andy327.actor.battleship.BattleshipActor
 import com.andy327.actor.connectfour.ConnectFourActor
 import com.andy327.actor.core.GameActor
-import com.andy327.actor.game.modules.{BattleshipModule, ConnectFourModule, GameModule, PigModule, TicTacToeModule}
+import com.andy327.actor.game.modules.{
+  BattleshipModule,
+  ConnectFourModule,
+  GameModule,
+  MastermindModule,
+  PigModule,
+  TicTacToeModule
+}
+import com.andy327.actor.mastermind.MastermindActor
 import com.andy327.actor.pig.PigActor
 import com.andy327.actor.tictactoe.TicTacToeActor
 import com.andy327.model.core.{Game, GameType, PlayerId}
@@ -46,5 +54,6 @@ object GameRegistry {
     case GameType.ConnectFour => GameModuleBundle(ConnectFourModule, ConnectFourActor)
     case GameType.Battleship  => GameModuleBundle(BattleshipModule, BattleshipActor)
     case GameType.Pig         => GameModuleBundle(PigModule, PigActor)
+    case GameType.Mastermind  => GameModuleBundle(MastermindModule, MastermindActor)
   }
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
@@ -3,6 +3,7 @@ package com.andy327.actor.game
 import com.andy327.model.battleship.{Battleship, Coord, Player1, Player2, PlayerBoard, Seat}
 import com.andy327.model.connectfour.ConnectFour
 import com.andy327.model.core.{Draw, Game, GameStatus, Mark, PlayerId, Won}
+import com.andy327.model.mastermind.{Codemaker, Mastermind, Role}
 import com.andy327.model.pig.Pig
 import com.andy327.model.tictactoe.TicTacToe
 
@@ -106,6 +107,47 @@ object PigState {
     )
 }
 
+/** One codebreaker guess in a Mastermind view: the guessed colors and its black/white peg feedback. */
+case class GuessResult(pegs: List[String], black: Int, white: Int)
+
+/** Serializable, per-viewer view of a Mastermind game.
+  *
+  * The `secret` is projected for the requesting viewer: the codemaker always sees their own code, and everyone
+  * (codebreaker and spectators) sees it once the game is over — but never before, so guessing stays honest. Guesses and
+  * their feedback are public. `currentPlayer` is `"codemaker"` while the code is unset and `"codebreaker"` afterwards.
+  *
+  * @param guesses the codebreaker's guesses with feedback, oldest first
+  * @param secret the revealed code (color names), or `None` while it is still hidden from this viewer
+  * @param guessesRemaining guesses the codebreaker has left before the codemaker wins by default
+  * @param viewerRole the viewer's role (`"codemaker"`/`"codebreaker"`), or `None` for a spectator
+  */
+case class MastermindState(
+    guesses: List[GuessResult],
+    secret: Option[List[String]],
+    currentPlayer: String,
+    winner: Option[String],
+    guessesRemaining: Int,
+    viewerRole: Option[String]
+) extends GameState
+
+object MastermindState {
+
+  /** Builds the view of `game` for the given viewer role (`None` = spectator). The secret is included only for the
+    * codemaker or once the game has ended.
+    */
+  def of(game: Mastermind, viewerRole: Option[Role]): MastermindState = {
+    val reveal = game.winner.isDefined || viewerRole.contains(Codemaker)
+    MastermindState(
+      guesses = game.guesses.map(a => GuessResult(a.guess.map(_.name).toList, a.feedback.black, a.feedback.white)),
+      secret = if (reveal) game.secret.map(_.map(_.name).toList) else None,
+      currentPlayer = game.currentPlayer.label,
+      winner = game.winner.map(_.label),
+      guessesRemaining = Mastermind.MaxGuesses - game.guesses.size,
+      viewerRole = viewerRole.map(_.label)
+    )
+  }
+}
+
 /** Type class for converting an internal game model into a serializable GameState.
   *
   * Instances live in the companion object, which is always in implicit scope for `GameStateView[G, S]` searches, so
@@ -136,6 +178,10 @@ object GameStateView {
   /** Type class instance for serializing a Pig game (same state for every viewer; no hidden information). */
   implicit val pigView: GameStateView[Pig, PigState] =
     (game, viewer) => PigState.of(game, viewer.flatMap(game.playerFor))
+
+  /** Type class instance for serializing a Mastermind game, projected per viewer (the secret is hidden until reveal). */
+  implicit val mastermindView: GameStateView[Mastermind, MastermindState] =
+    (game, viewer) => MastermindState.of(game, viewer.flatMap(game.playerFor))
 }
 
 /** Utility for converting internal game models to HTTP-serializable GameState representations using the GameStateView

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/MovePayload.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/MovePayload.scala
@@ -34,4 +34,11 @@ object MovePayload {
     * @param action `"roll"` or `"hold"`
     */
   final case class PigAction(action: String) extends MovePayload
+
+  /** A move for Mastermind: the codemaker sets the code (`"setcode"`) or the codebreaker guesses it (`"guess"`).
+    *
+    * @param action `"setcode"` or `"guess"`
+    * @param pegs the color names making up the code or guess (e.g. `["red","blue","red","green"]`)
+    */
+  final case class MastermindAction(action: String, pegs: List[String]) extends MovePayload
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/modules/MastermindModule.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/modules/MastermindModule.scala
@@ -15,8 +15,8 @@ import com.andy327.model.mastermind.{Guess, Mastermind, Peg, SetCode}
 /** [[GameModule]] implementation for Mastermind.
   *
   * Provides move decoding, operation-to-command mapping, and per-viewer serialization for Mastermind. The peg color
-  * names carried in the payload are resolved to [[com.andy327.model.mastermind.Peg]] values here; an unrecognized color
-  * is rejected as an `Unknown` error so it never reaches the model.
+  * names carried in the payload are resolved to `Peg` values here; an unrecognized color is rejected as an `Unknown`
+  * error so it never reaches the model.
   */
 object MastermindModule extends GameModule[Mastermind] {
 

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/modules/MastermindModule.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/modules/MastermindModule.scala
@@ -1,0 +1,57 @@
+package com.andy327.actor.game.modules
+
+import cats.syntax.functor._
+
+import io.circe.Decoder
+import io.circe.generic.auto._
+import org.apache.pekko.actor.typed.ActorRef
+
+import com.andy327.actor.core.{GameActor, TurnBasedGameActor}
+import com.andy327.actor.game.MovePayload.MastermindAction
+import com.andy327.actor.game.{GameOperation, GameState, GameStateConverters, MovePayload}
+import com.andy327.model.core.{GameError, PlayerId}
+import com.andy327.model.mastermind.{Guess, Mastermind, Peg, SetCode}
+
+/** [[GameModule]] implementation for Mastermind.
+  *
+  * Provides move decoding, operation-to-command mapping, and per-viewer serialization for Mastermind. The peg color
+  * names carried in the payload are resolved to [[com.andy327.model.mastermind.Peg]] values here; an unrecognized color
+  * is rejected as an `Unknown` error so it never reaches the model.
+  */
+object MastermindModule extends GameModule[Mastermind] {
+
+  override val moveDecoder: Decoder[MovePayload] = Decoder[MastermindAction].widen
+
+  override def toGameCommand(
+      op: GameOperation,
+      replyTo: ActorRef[Either[GameError, GameState]]
+  ): Either[GameError, GameActor.GameCommand] = op match {
+    case GameOperation.MakeMove(playerId, MastermindAction(action, pegs)) =>
+      parsePegs(pegs).flatMap { parsed =>
+        action.toLowerCase match {
+          case "setcode" => Right(TurnBasedGameActor.MakeMove(playerId, SetCode(parsed), replyTo))
+          case "guess"   => Right(TurnBasedGameActor.MakeMove(playerId, Guess(parsed), replyTo))
+          case other     => Left(GameError.Unknown(s"Unknown Mastermind action: $other"))
+        }
+      }
+
+    case GameOperation.MakeMove(_, otherMove) =>
+      val name = Option(otherMove).map(_.getClass.getSimpleName).getOrElse("null")
+      Left(GameError.Unknown(s"Unsupported move type for Mastermind: $name"))
+
+    case GameOperation.GetState =>
+      Right(TurnBasedGameActor.GetState(replyTo))
+  }
+
+  /** Resolves each color name to a [[Peg]], failing with an `Unknown` error naming the first invalid color. */
+  private def parsePegs(pegs: List[String]): Either[GameError, Vector[Peg]] =
+    pegs.foldRight[Either[GameError, List[Peg]]](Right(Nil)) { (name, acc) =>
+      for {
+        rest <- acc
+        peg <- Peg.fromName(name).toRight(GameError.Unknown(s"Invalid peg color: $name"))
+      } yield peg :: rest
+    }.map(_.toVector)
+
+  override def serialize(game: Mastermind, viewer: Option[PlayerId]): GameState =
+    GameStateConverters.serializeGame(game, viewer)
+}

--- a/game-service-actor/src/main/scala/com/andy327/actor/mastermind/MastermindActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/mastermind/MastermindActor.scala
@@ -1,0 +1,26 @@
+package com.andy327.actor.mastermind
+
+import io.circe.syntax._
+import io.circe.{Encoder, Json}
+
+import com.andy327.actor.core.TurnBasedGameActor
+import com.andy327.actor.game.MastermindState
+import com.andy327.model.mastermind.{Guess, Mastermind, MastermindMove, Role, SetCode}
+
+/** [[core.GameActor]] binding for Mastermind.
+  *
+  * All behavior lives in [[core.TurnBasedGameActor]]; the rules (setting the code, scoring guesses, winning by cracking
+  * or exhausting guesses) live in `model.mastermind.Mastermind`, and the per-viewer projection that hides the secret
+  * lives in `GameStateView[Mastermind, MastermindState]`. The codemaker (seat 0) sets the code first.
+  *
+  * The move-log encoder deliberately redacts the code from a [[SetCode]]: the history log is served publicly via
+  * `GET /{gameType}/{roomId}/history`, so logging the pegs would let the codebreaker read the answer mid-game.
+  */
+object MastermindActor
+    extends TurnBasedGameActor[Mastermind, MastermindMove, Role, MastermindState](
+      players => Mastermind.newGame(players),
+      Encoder.instance[MastermindMove] {
+        case SetCode(_)  => Json.obj("action" -> "setcode".asJson) // pegs redacted: never leak the secret to /history
+        case Guess(pegs) => Json.obj("action" -> "guess".asJson, "pegs" -> pegs.map(_.name).asJson)
+      }
+    )

--- a/game-service-actor/src/main/scala/com/andy327/actor/mastermind/MastermindActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/mastermind/MastermindActor.scala
@@ -13,7 +13,7 @@ import com.andy327.model.mastermind.{Guess, Mastermind, MastermindMove, Role, Se
   * or exhausting guesses) live in `model.mastermind.Mastermind`, and the per-viewer projection that hides the secret
   * lives in `GameStateView[Mastermind, MastermindState]`. The codemaker (seat 0) sets the code first.
   *
-  * The move-log encoder deliberately redacts the code from a [[SetCode]]: the history log is served publicly via
+  * The move-log encoder deliberately redacts the code from a `SetCode`: the history log is served publicly via
   * `GET /{gameType}/{roomId}/history`, so logging the pegs would let the codebreaker read the answer mid-game.
   */
 object MastermindActor

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/MastermindModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/MastermindModuleSpec.scala
@@ -1,0 +1,134 @@
+package com.andy327.actor.game.modules
+
+import java.util.UUID
+
+import io.circe.parser.decode
+import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import com.andy327.actor.core.{PlayerActor, TurnBasedGameActor}
+import com.andy327.actor.game.{GameOperation, GameRegistry, GameState, GuessResult, MastermindState, MovePayload}
+import com.andy327.actor.lobby.Player
+import com.andy327.actor.mastermind.MastermindActor
+import com.andy327.model.core.{GameError, GameType}
+import com.andy327.model.mastermind.{Attempt, Codebreaker, Feedback, Guess, Mastermind, Peg, SetCode}
+
+class MastermindModuleSpec extends AnyWordSpecLike with Matchers {
+  private val testKit = ActorTestKit()
+  import testKit._
+
+  "MastermindModule" should {
+    "successfully decode a valid Mastermind move JSON" in {
+      val json = """{"action":"setcode","pegs":["red","green","yellow","blue"]}"""
+      decode[MovePayload](json)(MastermindModule.moveDecoder) shouldBe
+        Right(MovePayload.MastermindAction("setcode", List("red", "green", "yellow", "blue")))
+    }
+
+    "fail to decode an invalid Mastermind move JSON" in {
+      decode[MovePayload]("""{"bad":"data"}""")(MastermindModule.moveDecoder).isLeft shouldBe true
+    }
+
+    "convert a setcode operation to a SetCode GameCommand" in {
+      val alice = Player("alice")
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val move = MovePayload.MastermindAction("setcode", List("red", "green", "yellow", "blue"))
+
+      MastermindModule.toGameCommand(GameOperation.MakeMove(alice.id, move), replyProbe.ref) match {
+        case Right(TurnBasedGameActor.MakeMove(playerId, setCode, reply)) =>
+          playerId shouldBe alice.id
+          setCode shouldBe SetCode(Vector(Peg.Red, Peg.Green, Peg.Yellow, Peg.Blue))
+          reply shouldBe replyProbe.ref
+        case other => fail(s"Unexpected result: $other")
+      }
+    }
+
+    "convert a guess operation to a Guess GameCommand" in {
+      val bob = Player("bob")
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val move = MovePayload.MastermindAction("guess", List("red", "red", "blue", "green"))
+
+      MastermindModule.toGameCommand(GameOperation.MakeMove(bob.id, move), replyProbe.ref) match {
+        case Right(TurnBasedGameActor.MakeMove(_, guess, _)) =>
+          guess shouldBe Guess(Vector(Peg.Red, Peg.Red, Peg.Blue, Peg.Green))
+        case other => fail(s"Unexpected result: $other")
+      }
+    }
+
+    "reject a move naming a color that is not in the palette" in {
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val move = MovePayload.MastermindAction("guess", List("red", "chartreuse", "blue", "green"))
+
+      val Left(err) = MastermindModule.toGameCommand(GameOperation.MakeMove(UUID.randomUUID(), move), replyProbe.ref)
+      err.message should include("Invalid peg color: chartreuse")
+    }
+
+    "reject an unknown Mastermind action" in {
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val move = MovePayload.MastermindAction("peek", List("red", "green", "yellow", "blue"))
+
+      val Left(err) = MastermindModule.toGameCommand(GameOperation.MakeMove(UUID.randomUUID(), move), replyProbe.ref)
+      err.message should include("Unknown Mastermind action: peek")
+    }
+
+    "convert GetState to a GetState GameCommand" in {
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      MastermindModule.toGameCommand(GameOperation.GetState, replyProbe.ref) shouldBe
+        Right(TurnBasedGameActor.GetState(replyProbe.ref))
+    }
+
+    "return error when passing unsupported MovePayload to toGameCommand" in {
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val unsupportedMove = null.asInstanceOf[MovePayload]
+
+      val Left(err) =
+        MastermindModule.toGameCommand(GameOperation.MakeMove(UUID.randomUUID(), unsupportedMove), replyProbe.ref)
+      err.message should include("Unsupported move type for Mastermind")
+    }
+
+    "produce a Subscribe command for a given PlayerActor ref" in {
+      val playerProbe = TestProbe[PlayerActor.Command]()
+      val playerId = UUID.randomUUID()
+      MastermindActor.subscribeCommand(playerProbe.ref, playerId) shouldBe
+        TurnBasedGameActor.Subscribe(playerProbe.ref, playerId)
+    }
+
+    "serialize a Mastermind game to MastermindState" in {
+      MastermindModule.serialize(Mastermind.newGame(Seq(UUID.randomUUID(), UUID.randomUUID())), None) shouldBe
+        a[MastermindState]
+    }
+
+    "keep the codebreaker's view free of the secret while play is ongoing" in {
+      val codemaker = UUID.randomUUID()
+      val codebreaker = UUID.randomUUID()
+      val game = Mastermind(codemaker, codebreaker, Some(Vector(Peg.Red, Peg.Green, Peg.Yellow, Peg.Blue)), Nil, None)
+
+      MastermindModule.serialize(game, Some(codebreaker)).asInstanceOf[MastermindState].secret shouldBe None
+      MastermindModule.serialize(game, Some(codemaker)).asInstanceOf[MastermindState].secret shouldBe
+        Some(List("red", "green", "yellow", "blue"))
+    }
+
+    "render guesses and the winner, and reveal the secret to everyone, once the game is over" in {
+      val secret = Vector(Peg.Red, Peg.Green, Peg.Yellow, Peg.Blue)
+      val finished =
+        Mastermind(
+          UUID.randomUUID(),
+          UUID.randomUUID(),
+          Some(secret),
+          List(Attempt(secret, Feedback(4, 0))),
+          Some(Codebreaker)
+        )
+
+      val state = MastermindModule.serialize(finished, None).asInstanceOf[MastermindState]
+      state.guesses shouldBe List(GuessResult(List("red", "green", "yellow", "blue"), 4, 0))
+      state.winner shouldBe Some("codebreaker")
+      state.secret shouldBe Some(List("red", "green", "yellow", "blue")) // revealed to all (a spectator here) once over
+    }
+
+    "expose the Mastermind bundle through the GameRegistry" in {
+      val bundle = GameRegistry.forType(GameType.Mastermind)
+      bundle.module shouldBe MastermindModule
+      bundle.actor shouldBe MastermindActor
+    }
+  }
+}

--- a/game-service-model/src/main/scala/com/andy327/model/core/GameType.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/core/GameType.scala
@@ -36,6 +36,11 @@ object GameType {
     val (minPlayers, maxPlayers) = (2, 8)
   }
 
+  /** A two-player code-breaking game: one player sets a hidden color code, the other guesses it from peg feedback. */
+  case object Mastermind extends GameType {
+    val (minPlayers, maxPlayers) = (2, 2)
+  }
+
   /** Parses a string into a GameType instance.
     *
     * @param s the name of the game type (case-insensitive)
@@ -46,6 +51,7 @@ object GameType {
     case "connectfour" => Some(ConnectFour)
     case "battleship"  => Some(Battleship)
     case "pig"         => Some(Pig)
+    case "mastermind"  => Some(Mastermind)
     case _             => None
   }
 }

--- a/game-service-model/src/main/scala/com/andy327/model/core/GameTypeTag.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/core/GameTypeTag.scala
@@ -2,6 +2,7 @@ package com.andy327.model.core
 
 import com.andy327.model.battleship.Battleship
 import com.andy327.model.connectfour.ConnectFour
+import com.andy327.model.mastermind.Mastermind
 import com.andy327.model.pig.Pig
 import com.andy327.model.tictactoe.TicTacToe
 
@@ -36,5 +37,9 @@ object GameTypeTag {
 
   implicit val pigTag: GameTypeTag[Pig] = new GameTypeTag[Pig] {
     override val value: GameType = GameType.Pig
+  }
+
+  implicit val mastermindTag: GameTypeTag[Mastermind] = new GameTypeTag[Mastermind] {
+    override val value: GameType = GameType.Mastermind
   }
 }

--- a/game-service-model/src/main/scala/com/andy327/model/mastermind/GameError.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/mastermind/GameError.scala
@@ -1,0 +1,21 @@
+package com.andy327.model.mastermind
+
+import com.andy327.model.core.GameError
+
+// Mastermind-specific game errors. Errors shared by every turn-based game (InvalidPlayer, InvalidTurn, GameOver,
+// Unknown) are defined once in core.GameError.
+
+/** A code or guess did not contain exactly [[Mastermind.CodeLength]] pegs. */
+case object InvalidCodeLength extends GameError {
+  val message: String = s"A code must be exactly ${Mastermind.CodeLength} pegs."
+}
+
+/** A SetCode arrived after the secret code was already fixed. */
+case object CodeAlreadySet extends GameError {
+  val message = "The secret code has already been set."
+}
+
+/** A Guess arrived before the codemaker had set the secret code. */
+case object CodeNotSet extends GameError {
+  val message = "The secret code has not been set yet."
+}

--- a/game-service-model/src/main/scala/com/andy327/model/mastermind/Mastermind.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/mastermind/Mastermind.scala
@@ -1,0 +1,144 @@
+package com.andy327.model.mastermind
+
+import scala.util.Random
+
+import com.andy327.model.core.GameError.{GameOver, InvalidTurn}
+import com.andy327.model.core.{Game, GameError, GameStatus, InProgress, PlayerId, Won}
+
+object Mastermind {
+
+  /** Number of pegs in a code. */
+  val CodeLength: Int = 4
+
+  /** Guesses the codebreaker gets before the codemaker wins by default. */
+  val MaxGuesses: Int = 10
+
+  /** Creates a fresh game with no code set yet. `playerIds(0)` is the codemaker (who moves first, to set the code) and
+    * `playerIds(1)` is the codebreaker.
+    */
+  def newGame(playerIds: Seq[PlayerId]): Mastermind =
+    Mastermind(
+      codemakerId = playerIds(0),
+      codebreakerId = playerIds(1),
+      secret = None,
+      guesses = Nil,
+      winner = None
+    )
+
+  /** A random code, each peg drawn uniformly from the palette with duplicates allowed. Not used in normal play (the
+    * codemaker sets the code); handy for tests and future AI players.
+    *
+    * @param rng source of randomness; inject a seeded `Random` for a deterministic code
+    */
+  def randomCode(rng: Random = new Random): Vector[Peg] =
+    Vector.fill(CodeLength)(Peg.all(rng.nextInt(Peg.all.size)))
+
+  /** Computes black/white peg feedback for `guess` against `secret`.
+    *
+    * `black` counts positions holding the right color; `white` counts colors present but out of position. Duplicates
+    * are handled by summing, per color, the smaller of its counts in the secret and the guess, then subtracting the
+    * black pegs — so no color is ever counted more times than it actually appears.
+    */
+  def feedback(secret: Vector[Peg], guess: Vector[Peg]): Feedback = {
+    val black = secret.zip(guess).count { case (s, g) => s == g }
+    val totalMatches = Peg.all.map(color => math.min(secret.count(_ == color), guess.count(_ == color))).sum
+    Feedback(black, totalMatches - black)
+  }
+}
+
+/** An instance of a Mastermind game.
+  *
+  * The game is asymmetric. The codemaker sets a hidden secret code with a single [[SetCode]] move; from then on the
+  * codebreaker takes every turn, playing [[Guess]] moves and receiving black/white peg [[Feedback]] after each. The
+  * codebreaker wins by reproducing the code exactly within [[Mastermind.MaxGuesses]] guesses; if those run out first,
+  * the codemaker wins. The full secret is always retained in the model — hiding it from the codebreaker is a
+  * presentation concern handled in the server's view layer, not here.
+  *
+  * @param codemakerId the player who sets the code (seat 0)
+  * @param codebreakerId the player who guesses (seat 1)
+  * @param secret the hidden code, or None until the codemaker has set it
+  * @param guesses the codebreaker's guesses and their feedback, oldest first
+  * @param winner the winning role once the game is over, otherwise None
+  */
+final case class Mastermind(
+    codemakerId: PlayerId,
+    codebreakerId: PlayerId,
+    secret: Option[Vector[Peg]],
+    guesses: List[Attempt],
+    winner: Option[Role]
+) extends Game[MastermindMove, Mastermind, Role, GameStatus[Role], GameError] {
+
+  import Mastermind._
+
+  def currentState: Mastermind = this
+
+  /** The codemaker acts first (to set the code); once the code is set, every remaining turn belongs to the codebreaker. */
+  def currentPlayer: Role = if (secret.isEmpty) Codemaker else Codebreaker
+
+  /** Mastermind cannot draw: the codebreaker either cracks the code or exhausts their guesses (a codemaker win). */
+  def gameStatus: GameStatus[Role] = winner.map(Won(_)).getOrElse(InProgress)
+
+  /** Resolves `playerId` to `Codemaker` or `Codebreaker` based on their seat; `None` if not a participant. */
+  def playerFor(playerId: PlayerId): Option[Role] =
+    if (playerId == codemakerId) Some(Codemaker)
+    else if (playerId == codebreakerId) Some(Codebreaker)
+    else None
+
+  /** The roster in seat order: the codemaker (seat 0) then the codebreaker (seat 1). */
+  def players: List[PlayerId] = List(codemakerId, codebreakerId)
+
+  /** One move for setting the code plus one per guess; derived from state so it survives a restart. */
+  def moveCount: Int = (if (secret.isDefined) 1 else 0) + guesses.size
+
+  /** Applies a player action.
+    *
+    * Validates turn order (the codemaker only moves while no code is set; the codebreaker only after). A [[SetCode]]
+    * fixes the code once, transitioning play to the codebreaker. A [[Guess]] records its feedback; a full match wins for
+    * the codebreaker, and the [[Mastermind.MaxGuesses]]th guess without a match wins for the codemaker.
+    */
+  def play(player: Role, move: MastermindMove): Either[GameError, Mastermind] =
+    if (gameStatus != InProgress)
+      Left(GameOver)
+    else if (player != currentPlayer)
+      Left(InvalidTurn)
+    else
+      move match {
+
+        case SetCode(pegs) =>
+          // reachable when the codebreaker (whose turn it is once the code is set) sends a SetCode
+          if (secret.isDefined) Left(CodeAlreadySet)
+          else if (pegs.size != CodeLength) Left(InvalidCodeLength)
+          else Right(copy(secret = Some(pegs)))
+
+        case Guess(pegs) =>
+          secret match {
+            // reachable when the codemaker (whose turn it is before the code is set) sends a Guess
+            case None       => Left(CodeNotSet)
+            case Some(code) =>
+              if (pegs.size != CodeLength) Left(InvalidCodeLength)
+              else {
+                val fb = feedback(code, pegs)
+                val updated = copy(guesses = guesses :+ Attempt(pegs, fb))
+                if (fb.black == CodeLength)
+                  Right(updated.copy(winner = Some(Codebreaker)))
+                else if (updated.guesses.size >= MaxGuesses)
+                  Right(updated.copy(winner = Some(Codemaker)))
+                else
+                  Right(updated)
+              }
+          }
+      }
+
+  /** Forfeits the game on behalf of the leaving player: the other role is declared the winner.
+    *
+    * Rejects with [[core.GameError.InvalidPlayer]] if `playerId` is not a participant, or [[core.GameError.GameOver]]
+    * if the game has already ended.
+    */
+  override def playerLeft(playerId: PlayerId): Either[GameError, Mastermind] =
+    playerFor(playerId) match {
+      case None                                => Left(GameError.InvalidPlayer(playerId))
+      case Some(_) if gameStatus != InProgress => Left(GameOver)
+      case Some(Codemaker)                     => Right(copy(winner = Some(Codebreaker)))
+      case Some(Codebreaker)                   => Right(copy(winner = Some(Codemaker)))
+    }
+}

--- a/game-service-model/src/main/scala/com/andy327/model/mastermind/package.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/mastermind/package.scala
@@ -1,0 +1,56 @@
+package com.andy327.model
+
+package object mastermind {
+
+  /** A single code peg — one of the six colors a code or guess is built from. Serialized by its lowercase `name`. */
+  sealed trait Peg {
+    def name: String
+    override def toString: String = name
+  }
+
+  object Peg {
+    case object Red extends Peg { val name = "red" }
+    case object Yellow extends Peg { val name = "yellow" }
+    case object Blue extends Peg { val name = "blue" }
+    case object Green extends Peg { val name = "green" }
+    case object Black extends Peg { val name = "black" }
+    case object White extends Peg { val name = "white" }
+
+    /** The full palette (the classic Mastermind six), in a fixed display order. Its size is the number of colors to
+      * choose from.
+      */
+    val all: List[Peg] = List(Red, Yellow, Blue, Green, Black, White)
+
+    private val byName: Map[String, Peg] = all.map(peg => peg.name -> peg).toMap
+
+    /** Resolves a (case-insensitive) color name to its [[Peg]], or `None` if it is not a valid color. */
+    def fromName(s: String): Option[Peg] = byName.get(s.toLowerCase)
+  }
+
+  /** Which of the two asymmetric roles a player holds. The codemaker (seat 0) sets the secret code and then waits; the
+    * codebreaker (seat 1) takes every subsequent turn. The seat order rotates across rematches, so the role alternates.
+    */
+  sealed trait Role {
+    def label: String
+    override def toString: String = label
+  }
+  case object Codemaker extends Role { val label = "codemaker" }
+  case object Codebreaker extends Role { val label = "codebreaker" }
+
+  /** Scoring for one guess: `black` pegs are the right color in the right position; `white` pegs are the right color in
+    * the wrong position. Neither counts a color more times than it appears in the secret.
+    */
+  case class Feedback(black: Int, white: Int)
+
+  /** One codebreaker guess together with the feedback it earned. */
+  case class Attempt(guess: Vector[Peg], feedback: Feedback)
+
+  /** A player action. The codemaker plays [[SetCode]] once; the codebreaker plays [[Guess]] on every turn. */
+  sealed trait MastermindMove
+
+  /** The codemaker fixes the secret code (played once, before any guessing). */
+  case class SetCode(pegs: Vector[Peg]) extends MastermindMove
+
+  /** The codebreaker guesses the secret code. */
+  case class Guess(pegs: Vector[Peg]) extends MastermindMove
+}

--- a/game-service-model/src/test/scala/com/andy327/model/mastermind/MastermindSpec.scala
+++ b/game-service-model/src/test/scala/com/andy327/model/mastermind/MastermindSpec.scala
@@ -1,0 +1,175 @@
+package com.andy327.model.mastermind
+
+import java.util.UUID
+
+import scala.util.Random
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import com.andy327.model.core.GameError.{GameOver, InvalidTurn}
+import com.andy327.model.core.{InProgress, PlayerId, Won}
+
+class MastermindSpec extends AnyWordSpec with Matchers {
+  import Peg._
+
+  val alice: PlayerId = UUID.randomUUID() // codemaker (seat 0)
+  val bob: PlayerId = UUID.randomUUID() // codebreaker (seat 1)
+
+  private def newGame: Mastermind = Mastermind.newGame(Seq(alice, bob))
+
+  /** A game with the code already set, ready for the codebreaker to guess. */
+  private def withCode(code: Peg*): Mastermind = newGame.play(Codemaker, SetCode(code.toVector)).toOption.get
+
+  "A Mastermind game" should {
+
+    "resolve participants to their roles with playerFor" in {
+      newGame.playerFor(alice) shouldBe Some(Codemaker)
+      newGame.playerFor(bob) shouldBe Some(Codebreaker)
+      newGame.playerFor(UUID.randomUUID()) shouldBe None
+    }
+
+    "list its roster in seat order with players" in {
+      newGame.players shouldBe List(alice, bob)
+    }
+
+    "start awaiting the codemaker's secret code" in {
+      val game = newGame
+      game.currentPlayer shouldBe Codemaker
+      game.secret shouldBe None
+      game.moveCount shouldBe 0
+      game.gameStatus shouldBe InProgress
+    }
+
+    "fix the code and hand the turn to the codebreaker on SetCode" in {
+      val Right(next) = newGame.play(Codemaker, SetCode(Vector(Red, Green, Yellow, Blue)))
+      next.secret shouldBe Some(Vector(Red, Green, Yellow, Blue))
+      next.currentPlayer shouldBe Codebreaker
+      next.moveCount shouldBe 1
+    }
+
+    "reject a code that is not the required length" in {
+      newGame.play(Codemaker, SetCode(Vector(Red, Green))) shouldBe Left(InvalidCodeLength)
+    }
+
+    "reject the codebreaker acting before the code is set" in {
+      newGame.play(Codebreaker, Guess(Vector(Red, Red, Red, Red))) shouldBe Left(InvalidTurn)
+    }
+
+    "reject the codemaker guessing instead of setting the code" in {
+      newGame.play(Codemaker, Guess(Vector(Red, Red, Red, Red))) shouldBe Left(CodeNotSet)
+    }
+
+    "reject setting the code twice" in {
+      withCode(Red, Green, Yellow, Blue).play(Codebreaker, SetCode(Vector(Red, Red, Red, Red))) shouldBe
+        Left(CodeAlreadySet)
+    }
+
+    "record a guess with feedback and stay in progress when wrong" in {
+      val Right(next) = withCode(Red, Green, Yellow, Blue).play(Codebreaker, Guess(Vector(Red, Green, Blue, Yellow)))
+      next.guesses shouldBe List(Attempt(Vector(Red, Green, Blue, Yellow), Feedback(2, 2)))
+      next.currentPlayer shouldBe Codebreaker
+      next.gameStatus shouldBe InProgress
+      next.moveCount shouldBe 2 // set-code + one guess
+    }
+
+    "declare the codebreaker the winner on an exact match" in {
+      val Right(next) = withCode(Red, Green, Yellow, Blue).play(Codebreaker, Guess(Vector(Red, Green, Yellow, Blue)))
+      next.winner shouldBe Some(Codebreaker)
+      next.gameStatus shouldBe Won(Codebreaker)
+    }
+
+    "declare the codemaker the winner when the guesses run out" in {
+      val wrong = Guess(Vector(Green, Green, Green, Green))
+      val exhausted = (1 to Mastermind.MaxGuesses).foldLeft(withCode(Red, Red, Red, Red)) { (g, _) =>
+        g.play(Codebreaker, wrong).toOption.get
+      }
+      exhausted.guesses.size shouldBe Mastermind.MaxGuesses
+      exhausted.winner shouldBe Some(Codemaker)
+      exhausted.gameStatus shouldBe Won(Codemaker)
+    }
+
+    "reject a guess that is not the required length" in {
+      withCode(Red, Green, Yellow, Blue).play(Codebreaker, Guess(Vector(Red, Green))) shouldBe Left(InvalidCodeLength)
+    }
+
+    "reject the codemaker guessing out of turn once the code is set" in {
+      withCode(Red, Green, Yellow, Blue).play(Codemaker, Guess(Vector(Red, Green, Yellow, Blue))) shouldBe
+        Left(InvalidTurn)
+    }
+
+    "reject any further move once the game is over" in {
+      val won =
+        withCode(Red, Green, Yellow, Blue).play(Codebreaker, Guess(Vector(Red, Green, Yellow, Blue))).toOption.get
+      won.play(Codebreaker, Guess(Vector(Red, Red, Red, Red))) shouldBe Left(GameOver)
+    }
+
+    "count the set-code move and each guess in moveCount" in {
+      val Right(afterCode) = newGame.play(Codemaker, SetCode(Vector(Red, Green, Yellow, Blue)))
+      afterCode.moveCount shouldBe 1
+      val Right(afterGuess) = afterCode.play(Codebreaker, Guess(Vector(Blue, Yellow, Green, Red)))
+      afterGuess.moveCount shouldBe 2
+    }
+  }
+
+  "A Mastermind Peg" should {
+    "render with its color name" in {
+      Red.toString shouldBe "red"
+      Black.toString shouldBe "black"
+      White.toString shouldBe "white"
+    }
+  }
+
+  "A Mastermind Role" should {
+    "render with its label" in {
+      Codemaker.toString shouldBe "codemaker"
+      Codebreaker.toString shouldBe "codebreaker"
+    }
+  }
+
+  "Mastermind.feedback" should {
+
+    "count black pegs for the right color in the right position" in {
+      Mastermind.feedback(Vector(Red, Green, Yellow, Blue), Vector(Red, Green, Yellow, Blue)) shouldBe Feedback(4, 0)
+    }
+
+    "count white pegs for the right color in the wrong position" in {
+      Mastermind.feedback(Vector(Red, Green, Yellow, Blue), Vector(Blue, Yellow, Green, Red)) shouldBe Feedback(0, 4)
+    }
+
+    "not count a color more times than it appears in the secret" in {
+      // the secret has one Red; three Reds in the guess still yield a single match (the black one)
+      Mastermind.feedback(Vector(Red, Green, Green, Green), Vector(Red, Red, Red, Red)) shouldBe Feedback(1, 0)
+    }
+
+    "split repeated colors across black and white correctly" in {
+      Mastermind.feedback(Vector(Red, Red, Green, Blue), Vector(Red, Green, Red, Blue)) shouldBe Feedback(2, 2)
+    }
+  }
+
+  "A leaving player" should {
+
+    "forfeit to the other role" in {
+      newGame.playerLeft(alice).map(_.gameStatus) shouldBe Right(Won(Codebreaker))
+      newGame.playerLeft(bob).map(_.gameStatus) shouldBe Right(Won(Codemaker))
+    }
+
+    "be rejected for a non-participant" in {
+      newGame.playerLeft(UUID.randomUUID()) shouldBe a[Left[_, _]]
+    }
+
+    "be rejected once the game is already over" in {
+      val won =
+        withCode(Red, Green, Yellow, Blue).play(Codebreaker, Guess(Vector(Red, Green, Yellow, Blue))).toOption.get
+      won.playerLeft(bob) shouldBe Left(GameOver)
+    }
+  }
+
+  "Mastermind.randomCode" should {
+    "produce a code of the required length using only palette colors" in {
+      val code = Mastermind.randomCode(new Random(7))
+      code.size shouldBe Mastermind.CodeLength
+      code.foreach(Peg.all should contain(_))
+    }
+  }
+}

--- a/game-service-persistence/src/main/scala/com/andy327/persistence/db/schema/GameTypeCodecs.scala
+++ b/game-service-persistence/src/main/scala/com/andy327/persistence/db/schema/GameTypeCodecs.scala
@@ -8,6 +8,7 @@ import io.circe.{Codec, Decoder, Encoder}
 import com.andy327.model.battleship.{Battleship, Coord, Player1, Player2, PlayerBoard, Seat, Ship}
 import com.andy327.model.connectfour.{ConnectFour, Mark => ConnectFourMark, Red, Yellow}
 import com.andy327.model.core.{Game, GameType}
+import com.andy327.model.mastermind.{Attempt, Codebreaker, Codemaker, Feedback, Mastermind, Peg, Role}
 import com.andy327.model.pig.Pig
 import com.andy327.model.tictactoe.{Mark, O, TicTacToe, X}
 
@@ -25,6 +26,7 @@ object GameTypeCodecs {
       case "ConnectFour" => Right(GameType.ConnectFour)
       case "Battleship"  => Right(GameType.Battleship)
       case "Pig"         => Right(GameType.Pig)
+      case "Mastermind"  => Right(GameType.Mastermind)
       case other         => Left(s"Unknown GameType: $other")
     },
     Encoder.encodeString.contramap[GameType] {
@@ -32,6 +34,7 @@ object GameTypeCodecs {
       case GameType.ConnectFour => "ConnectFour"
       case GameType.Battleship  => "Battleship"
       case GameType.Pig         => "Pig"
+      case GameType.Mastermind  => "Mastermind"
     }
   )
 
@@ -73,12 +76,32 @@ object GameTypeCodecs {
   implicit val battleshipCodec: Codec[Battleship] = deriveCodec[Battleship]
   implicit val pigCodec: Codec[Pig] = deriveCodec[Pig]
 
+  implicit val pegCodec: Codec[Peg] = Codec.from(
+    Decoder.decodeString.emap(s => Peg.fromName(s).toRight(s"Invalid Peg: $s")),
+    Encoder.encodeString.contramap[Peg](_.name)
+  )
+
+  implicit val roleCodec: Codec[Role] = Codec.from(
+    Decoder.decodeString.emap {
+      case "codemaker"   => Right(Codemaker)
+      case "codebreaker" => Right(Codebreaker)
+      case other         => Left(s"Invalid Role: expected 'codemaker' or 'codebreaker', got '$other'")
+    },
+    Encoder.encodeString.contramap[Role](_.label)
+  )
+
+  // Declared in dependency order so each is in scope for the deriveCodec that needs it.
+  implicit val feedbackCodec: Codec[Feedback] = deriveCodec[Feedback]
+  implicit val attemptCodec: Codec[Attempt] = deriveCodec[Attempt]
+  implicit val mastermindCodec: Codec[Mastermind] = deriveCodec[Mastermind]
+
   /** Serializes a game instance to a JSON string using the codec for the given GameType. */
   def serializeGame(gameType: GameType, game: Game[_, _, _, _, _]): String = gameType match {
     case GameType.TicTacToe   => game.asInstanceOf[TicTacToe].asJson.noSpaces
     case GameType.ConnectFour => game.asInstanceOf[ConnectFour].asJson.noSpaces
     case GameType.Battleship  => game.asInstanceOf[Battleship].asJson.noSpaces
     case GameType.Pig         => game.asInstanceOf[Pig].asJson.noSpaces
+    case GameType.Mastermind  => game.asInstanceOf[Mastermind].asJson.noSpaces
   }
 
   /** Deserializes a game state JSON string into a Game instance based on the provided GameType. */
@@ -88,5 +111,6 @@ object GameTypeCodecs {
       case GameType.ConnectFour => decode[ConnectFour](json).left.map(err => new Exception(err))
       case GameType.Battleship  => decode[Battleship](json).left.map(err => new Exception(err))
       case GameType.Pig         => decode[Pig](json).left.map(err => new Exception(err))
+      case GameType.Mastermind  => decode[Mastermind](json).left.map(err => new Exception(err))
     }
 }

--- a/game-service-persistence/src/test/scala/com/andy327/persistence/db/schema/GameTypeCodecsSpec.scala
+++ b/game-service-persistence/src/test/scala/com/andy327/persistence/db/schema/GameTypeCodecsSpec.scala
@@ -12,6 +12,8 @@ import org.scalatest.wordspec.AnyWordSpec
 import com.andy327.model.battleship.{Battleship, Coord, Fire, Player1, Player2, PlayerBoard, Ship}
 import com.andy327.model.connectfour.{ConnectFour, Drop, Red}
 import com.andy327.model.core.{GameType, PlayerId}
+import com.andy327.model.mastermind.Peg.{Blue, Green, Red => MmRed, Yellow}
+import com.andy327.model.mastermind.{Codebreaker, Codemaker, Guess, Mastermind, SetCode}
 import com.andy327.model.pig.Pig
 import com.andy327.model.tictactoe.{Location, TicTacToe, X}
 
@@ -159,6 +161,73 @@ class GameTypeCodecsSpec extends AnyWordSpec with Matchers {
     "return Left if Pig game JSON is invalid" in {
       val result = deserializeGame(GameType.Pig, """{ "not": "valid" }""")
       result.isLeft shouldBe true
+    }
+
+    "resolve mastermind via GameType.fromString" in {
+      GameType.fromString("mastermind") shouldBe Some(GameType.Mastermind)
+    }
+
+    "correctly encode and decode GameType.Mastermind" in {
+      val t: GameType = GameType.Mastermind
+      val json = t.asJson.noSpaces
+      json shouldBe "\"Mastermind\""
+      decode[GameType](json) shouldBe Right(GameType.Mastermind)
+    }
+
+    "round-trip a Mastermind game through serializeGame and deserializeGame" in {
+      // set the code then guess so the round-trip exercises the Peg and Attempt codecs
+      val game = Mastermind
+        .newGame(Seq(alice, bob))
+        .play(Codemaker, SetCode(Vector(MmRed, Green, Yellow, Blue)))
+        .flatMap(_.play(Codebreaker, Guess(Vector(MmRed, Green, Blue, Yellow))))
+        .toOption
+        .get
+      val json = serializeGame(GameType.Mastermind, game)
+      deserializeGame(GameType.Mastermind, json) shouldBe Right(game)
+    }
+
+    "round-trip finished Mastermind games, exercising the Role codec for both winners" in {
+      // the winner is the only Role-typed field, so serialize a game won by each role to cover both codec branches
+      val base = Mastermind
+        .newGame(Seq(alice, bob))
+        .play(Codemaker, SetCode(Vector(MmRed, Green, Yellow, Blue)))
+        .toOption
+        .get
+      List(base.copy(winner = Some(Codebreaker)), base.copy(winner = Some(Codemaker))).foreach { game =>
+        val json = serializeGame(GameType.Mastermind, game)
+        deserializeGame(GameType.Mastermind, json) shouldBe Right(game)
+      }
+    }
+
+    "fail to decode an invalid Mastermind Peg" in {
+      val baseJson = Mastermind
+        .newGame(Seq(alice, bob))
+        .play(Codemaker, SetCode(Vector(MmRed, Green, Yellow, Blue)))
+        .toOption
+        .get
+        .asJson
+        .noSpaces
+      val corruptedJson = baseJson.replace("\"red\"", "\"chartreuse\"")
+      deserializeGame(GameType.Mastermind, corruptedJson).isLeft shouldBe true
+    }
+
+    "fail to decode an invalid Mastermind Role" in {
+      val json = serializeGame(
+        GameType.Mastermind,
+        Mastermind
+          .newGame(Seq(alice, bob))
+          .play(Codemaker, SetCode(Vector(MmRed, Green, Yellow, Blue)))
+          .toOption
+          .get
+          .copy(winner = Some(Codebreaker))
+      )
+      // the winner serializes as "codebreaker"; the field key "codebreakerId" is unaffected (no closing quote match)
+      val corrupted = json.replace("\"codebreaker\"", "\"spymaster\"")
+      deserializeGame(GameType.Mastermind, corrupted).isLeft shouldBe true
+    }
+
+    "return Left if Mastermind game JSON is invalid" in {
+      deserializeGame(GameType.Mastermind, """{ "not": "valid" }""").isLeft shouldBe true
     }
   }
 }

--- a/game-service-server/src/main/resources/web/app.js
+++ b/game-service-server/src/main/resources/web/app.js
@@ -25,7 +25,8 @@ const GAMES = {
   tictactoe:   { label: "Tic-Tac-Toe", maxPlayers: 2, move: (row, col) => ({ row, col }) },
   connectfour: { label: "Connect Four", maxPlayers: 2, move: (row, col) => ({ col }), columns: true },
   battleship:  { label: "Battleship",   maxPlayers: 2, move: (row, col) => ({ row, col }) },
-  pig:         { label: "Pig",          maxPlayers: 8, pig: true }
+  pig:         { label: "Pig",          maxPlayers: 8, pig: true },
+  mastermind:  { label: "Mastermind",   maxPlayers: 2, mastermind: true }
 };
 
 const $ = (id) => document.getElementById(id);
@@ -733,6 +734,11 @@ function renderBoard(state) {
     return;
   }
 
+  if (state.guessesRemaining !== undefined) {
+    renderMastermindBoard(state);
+    return;
+  }
+
   // Grid games (TicTacToe, ConnectFour): a single flat board of cell tokens.
   const board = $("board");
   board.classList.remove("bs-active");
@@ -849,6 +855,161 @@ async function submitMove(row, col) {
   const res = await api(`/${game.gameType}/${game.roomId}/move`, { method: "POST", body: payload });
   // Successful moves redraw via the WebSocket push; only failures need surfacing here.
   if (!res.ok) flashError("game-error", res.data?.error || res.data || "Move rejected");
+}
+
+// Mastermind: the codemaker sets a hidden 4-peg code, then the codebreaker guesses it, receiving black/white peg
+// feedback each turn. `state.secret` is only populated when the server chooses to reveal it — to the codemaker, or to
+// everyone once the game ends — so the codebreaker never sees the answer early.
+const MM_COLORS = ["red", "yellow", "blue", "green", "black", "white"];
+const MM_CODE_LENGTH = 4;
+let mastermindDraft = []; // colors picked for the pending code/guess
+let mastermindDraftRoom = null; // the room the draft belongs to, so switching games starts fresh
+let lastMastermindState = null; // most recent state, re-rendered on local peg-picker interactions
+
+// Sends the codemaker's "setcode" or the codebreaker's "guess" as a POST move; clears the draft on success.
+async function submitMastermindMove(action, pegs) {
+  const game = session.game;
+  if (!game) return;
+  setError("game-error", "");
+  const res = await api(`/${game.gameType}/${game.roomId}/move`, { method: "POST", body: { action, pegs } });
+  if (res.ok) mastermindDraft = [];
+  else flashError("game-error", res.data?.error || res.data || "Move rejected");
+}
+
+// A single colored peg (or an empty slot when `color` is null).
+function makeMmPeg(color) {
+  const peg = document.createElement("span");
+  peg.className = "mm-peg" + (color ? ` mm-${color}` : " mm-empty");
+  return peg;
+}
+
+// Feedback dots for a scored guess: `black` dark dots, then `white` light dots, padded to the code length.
+function makeMmFeedback(black, white) {
+  const wrap = document.createElement("span");
+  wrap.className = "mm-feedback";
+  for (let i = 0; i < MM_CODE_LENGTH; i++) {
+    const kind = i < black ? "black" : i < black + white ? "white" : "none";
+    const dot = document.createElement("span");
+    dot.className = `mm-dot mm-dot-${kind}`;
+    wrap.appendChild(dot);
+  }
+  return wrap;
+}
+
+function renderMastermindBoard(state) {
+  // A draft belongs to one room; entering a different game starts with empty slots.
+  if (session.game && session.game.roomId !== mastermindDraftRoom) {
+    mastermindDraft = [];
+    mastermindDraftRoom = session.game.roomId;
+  }
+  lastMastermindState = state;
+
+  const board = $("board");
+  board.classList.remove("bs-active");
+  board.innerHTML = "";
+  $("column-controls").innerHTML = "";
+
+  const over = Boolean(state.winner);
+  const role = state.viewerRole; // "codemaker" | "codebreaker" | null (spectator)
+  const spectating = Boolean(session.game && session.game.isSpectator) || role === null;
+  const iAmCodemaker = role === "codemaker";
+  const iAmCodebreaker = role === "codebreaker";
+  const needsCode = !state.secret && state.currentPlayer === "codemaker"; // codemaker has not set the code yet
+  const myTurn =
+    !over && !spectating &&
+    ((iAmCodemaker && needsCode) || (iAmCodebreaker && state.currentPlayer === "codebreaker"));
+
+  // Status line
+  if (over) setStatus(state.winner === role ? "You win!" : `The ${state.winner} wins!`);
+  else if (iAmCodemaker) setStatus(needsCode ? "Set your secret code." : "Code set — waiting for the codebreaker…");
+  else if (iAmCodebreaker) setStatus(myTurn ? "Your turn — guess the code!" : "Waiting…");
+  else setStatus(`Spectating — ${state.currentPlayer} to move`);
+
+  // Revealed secret (the codemaker always sees it; everyone sees it once the game ends)
+  if (state.secret) {
+    const secret = document.createElement("div");
+    secret.className = "mm-secret mm-row";
+    const label = document.createElement("span");
+    label.className = "mm-label";
+    label.textContent = over ? "Secret:" : "Your code:";
+    secret.appendChild(label);
+    state.secret.forEach((c) => secret.appendChild(makeMmPeg(c)));
+    board.appendChild(secret);
+  }
+
+  // Public guess history, oldest first, each with its feedback
+  const history = document.createElement("div");
+  history.className = "mm-history";
+  state.guesses.forEach((g, i) => {
+    const row = document.createElement("div");
+    row.className = "mm-row mm-guess";
+    const num = document.createElement("span");
+    num.className = "mm-num";
+    num.textContent = `${i + 1}.`;
+    row.appendChild(num);
+    g.pegs.forEach((c) => row.appendChild(makeMmPeg(c)));
+    row.appendChild(makeMmFeedback(g.black, g.white));
+    history.appendChild(row);
+  });
+  board.appendChild(history);
+
+  if (!over) {
+    const remaining = document.createElement("p");
+    remaining.className = "mm-remaining";
+    remaining.textContent = `Guesses remaining: ${state.guessesRemaining}`;
+    board.appendChild(remaining);
+  }
+
+  if (myTurn) board.appendChild(makeMmInput(needsCode ? "setcode" : "guess"));
+}
+
+// The peg-picker: four slots filled from a color palette, plus Submit / Clear. Clicking a filled slot removes that peg.
+function makeMmInput(action) {
+  const rerender = () => renderMastermindBoard(lastMastermindState);
+
+  const wrap = document.createElement("div");
+  wrap.className = "mm-input";
+
+  const slots = document.createElement("div");
+  slots.className = "mm-row mm-slots";
+  for (let i = 0; i < MM_CODE_LENGTH; i++) {
+    const peg = makeMmPeg(mastermindDraft[i] || null);
+    if (mastermindDraft[i]) {
+      peg.classList.add("mm-clickable");
+      peg.onclick = () => { mastermindDraft.splice(i, 1); rerender(); };
+    }
+    slots.appendChild(peg);
+  }
+  wrap.appendChild(slots);
+
+  const palette = document.createElement("div");
+  palette.className = "mm-row mm-palette";
+  MM_COLORS.forEach((color) => {
+    const swatch = makeMmPeg(color);
+    swatch.classList.add("mm-clickable");
+    swatch.onclick = () => {
+      if (mastermindDraft.length < MM_CODE_LENGTH) { mastermindDraft.push(color); rerender(); }
+    };
+    palette.appendChild(swatch);
+  });
+  wrap.appendChild(palette);
+
+  const actions = document.createElement("div");
+  actions.className = "row mm-actions";
+  const submit = document.createElement("button");
+  submit.textContent = action === "setcode" ? "Set code" : "Guess";
+  submit.disabled = mastermindDraft.length !== MM_CODE_LENGTH;
+  submit.onclick = () => submitMastermindMove(action, mastermindDraft.slice());
+  actions.appendChild(submit);
+
+  const clear = document.createElement("button");
+  clear.textContent = "Clear";
+  clear.disabled = mastermindDraft.length === 0;
+  clear.onclick = () => { mastermindDraft = []; rerender(); };
+  actions.appendChild(clear);
+
+  wrap.appendChild(actions);
+  return wrap;
 }
 
 // --- Deep links ------------------------------------------------------------------------------------------------------

--- a/game-service-server/src/main/resources/web/index.html
+++ b/game-service-server/src/main/resources/web/index.html
@@ -55,6 +55,7 @@
       <button data-gametype="connectfour">Connect Four</button>
       <button data-gametype="battleship">Battleship</button>
       <button data-gametype="pig">Pig</button>
+      <button data-gametype="mastermind">Mastermind</button>
     </div>
 
     <h3>Your games &amp; lobbies</h3>
@@ -70,6 +71,7 @@
         <option value="connectfour">Connect Four</option>
         <option value="battleship">Battleship</option>
         <option value="pig">Pig</option>
+        <option value="mastermind">Mastermind</option>
       </select>
     </div>
     <ul id="lobby-list"></ul>

--- a/game-service-server/src/main/resources/web/style.css
+++ b/game-service-server/src/main/resources/web/style.css
@@ -268,3 +268,53 @@ button:disabled { opacity: 0.5; cursor: default; }
 .cell.mark-ship    { background: #3a4455; border-color: #505d72; }
 .cell.mark-water   { background: #0a1624; border-color: #152336; }
 .cell.mark-unknown { background: var(--bg); }
+
+/* Mastermind: colored code pegs, a guess history with black/white feedback, and a peg-picker. */
+.mm-row { display: flex; align-items: center; gap: 0.5rem; margin: 0.35rem 0; }
+.mm-label { color: var(--muted); font-size: 0.9rem; min-width: 4.5rem; }
+.mm-num { color: var(--muted); font-size: 0.85rem; width: 1.75rem; text-align: right; }
+
+.mm-peg {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 1px solid var(--line);
+  box-sizing: border-box;
+}
+.mm-empty { background: var(--bg); border-style: dashed; }
+.mm-clickable { cursor: pointer; }
+.mm-clickable:hover { outline: 2px solid var(--accent); }
+
+.mm-red    { background: #e5484d; }
+.mm-yellow { background: #f5c451; }
+.mm-blue   { background: #4f9cf9; }
+.mm-green  { background: #46a758; }
+/* Black and white code pegs get lighter borders so they stay visible against the dark page. */
+.mm-black  { background: #14171c; border-color: #4a5568; }
+.mm-white  { background: #f5f7fa; border-color: #cbd5e1; }
+
+.mm-secret { margin-bottom: 0.75rem; }
+.mm-history { margin: 0.5rem 0; }
+.mm-guess { gap: 0.3rem; }
+.mm-remaining { color: var(--muted); font-size: 0.9rem; }
+
+/* Feedback dots, two rows of two, packed beside the guessed pegs. The key pegs sit on a neutral pad and each carries a
+   contrasting halo, so the black (right color & place) and white (right color, wrong place) markers both stand out
+   against the dark page and against each other. */
+.mm-feedback {
+  display: inline-grid;
+  grid-template-columns: repeat(2, 9px);
+  gap: 3px;
+  margin-left: 0.5rem;
+  padding: 4px;
+  background: #7c8794;
+  border-radius: 4px;
+}
+.mm-dot { width: 9px; height: 9px; border-radius: 50%; }
+.mm-dot-black { background: #0a0d12; box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.6); }
+.mm-dot-white { background: #ffffff; box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.4); }
+.mm-dot-none  { background: transparent; border: 1px solid rgba(0, 0, 0, 0.28); }
+
+.mm-input { margin-top: 0.75rem; }
+.mm-palette { gap: 0.4rem; }
+.mm-actions { margin-top: 0.5rem; }

--- a/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
@@ -145,6 +145,7 @@ object GameServer {
       new GameRoutes(GameType.ConnectFour, system).routes,
       new GameRoutes(GameType.Battleship, system).routes,
       new GameRoutes(GameType.Pig, system).routes,
+      new GameRoutes(GameType.Mastermind, system).routes,
       new WebSocketRoutes(system).routes,
       new TraceRoutes(system).routes,
       new MetricsRoutes(metricsRegistry).routes,

--- a/game-service-server/src/main/scala/com/andy327/server/analytics/GameMetrics.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/analytics/GameMetrics.scala
@@ -70,5 +70,6 @@ class GameMetrics(registry: CollectorRegistry) {
     case GameType.ConnectFour => "connectfour"
     case GameType.Battleship  => "battleship"
     case GameType.Pig         => "pig"
+    case GameType.Mastermind  => "mastermind"
   }
 }

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -22,7 +22,7 @@ import com.andy327.actor.core.GameManager.{
 }
 import com.andy327.actor.core.LobbyManager.LobbySummary
 import com.andy327.actor.core.PlayerEvent
-import com.andy327.actor.game.{BattleshipState, GameState, GridGameState, PigState}
+import com.andy327.actor.game.{BattleshipState, GameState, GridGameState, GuessResult, MastermindState, PigState}
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyCodecs, LobbyMetadata, Player}
 import com.andy327.actor.tracing.TraceEvent
 import com.andy327.persistence.db.MoveRecord
@@ -114,13 +114,18 @@ object JsonProtocol extends CirceSupport {
 
   implicit val pigStateCodec: Codec[PigState] = deriveCodec[PigState]
 
+  implicit val guessResultCodec: Codec[GuessResult] = deriveCodec[GuessResult]
+
+  implicit val mastermindStateCodec: Codec[MastermindState] = deriveCodec[MastermindState]
+
   /** Encoder for the polymorphic `GameState` hierarchy (grid games share `GridGameState`;
-    * Battleship has its own per-viewer `BattleshipState`; Pig has `PigState`).
+    * Battleship has its own per-viewer `BattleshipState`; Pig has `PigState`; Mastermind has `MastermindState`).
     */
   implicit val gameStateEncoder: Encoder[GameState] = Encoder.instance {
     case s: GridGameState   => s.asJson
     case s: BattleshipState => s.asJson
     case s: PigState        => s.asJson
+    case s: MastermindState => s.asJson
   }
 
   // Entity unmarshallers, declared per-type so they don't shadow the predefined `String` unmarshaller (see

--- a/game-service-server/src/test/scala/com/andy327/server/analytics/GameMetricsSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/analytics/GameMetricsSpec.scala
@@ -65,14 +65,21 @@ class GameMetricsSpec extends AnyWordSpec with Matchers {
       ) shouldBe Some(1.0)
     }
 
-    "label Pig events with the \"pig\" game type" in {
+    "label Pig events with the pig game type" in {
       val (registry, metrics) = fixture
       metrics.record(GameStarted(UUID.randomUUID(), GameType.Pig, 3))
 
       sample(registry, "games_started_total", Array("game_type"), Array("pig")) shouldBe Some(1.0)
     }
 
-    "label lobby chat as \"lobby\" and in-game chat by game type" in {
+    "label Mastermind events with the mastermind game type" in {
+      val (registry, metrics) = fixture
+      metrics.record(GameStarted(UUID.randomUUID(), GameType.Mastermind, 2))
+
+      sample(registry, "games_started_total", Array("game_type"), Array("mastermind")) shouldBe Some(1.0)
+    }
+
+    "label lobby chat as lobby and in-game chat by game type" in {
       val (registry, metrics) = fixture
       metrics.record(ChatSent(UUID.randomUUID(), Some(GameType.Battleship)))
       metrics.record(ChatSent(UUID.randomUUID(), None))

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/MastermindStateSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/MastermindStateSpec.scala
@@ -1,0 +1,67 @@
+package com.andy327.server.http.json
+
+import java.util.UUID
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import com.andy327.actor.game.{GuessResult, MastermindState}
+import com.andy327.model.core.PlayerId
+import com.andy327.model.mastermind.Peg.{Blue, Green, Red, Yellow}
+import com.andy327.model.mastermind.{Attempt, Codebreaker, Codemaker, Feedback, Mastermind, Role}
+
+class MastermindStateSpec extends AnyWordSpec with Matchers {
+  val alice: PlayerId = UUID.randomUUID() // codemaker
+  val bob: PlayerId = UUID.randomUUID() // codebreaker
+
+  private val code = Vector(Red, Green, Yellow, Blue)
+  private val oneGuess = List(Attempt(Vector(Red, Green, Blue, Yellow), Feedback(2, 2)))
+
+  private def game(guesses: List[Attempt] = oneGuess, winner: Option[Role] = None): Mastermind =
+    Mastermind(alice, bob, Some(code), guesses, winner)
+
+  "MastermindState.of for the codemaker" should {
+    "always reveal the secret and expose the public guess history" in {
+      val view = MastermindState.of(game(), Some(Codemaker))
+      view.viewerRole shouldBe Some("codemaker")
+      view.secret shouldBe Some(List("red", "green", "yellow", "blue"))
+      view.guesses shouldBe List(GuessResult(List("red", "green", "blue", "yellow"), 2, 2))
+      view.currentPlayer shouldBe "codebreaker"
+      view.guessesRemaining shouldBe Mastermind.MaxGuesses - 1
+    }
+  }
+
+  "MastermindState.of for the codebreaker" should {
+    "hide the secret while the game is in progress" in {
+      MastermindState.of(game(), Some(Codebreaker)).secret shouldBe None
+    }
+  }
+
+  "MastermindState.of for a spectator" should {
+    "hide the secret while the game is in progress" in {
+      val view = MastermindState.of(game(), None)
+      view.viewerRole shouldBe None
+      view.secret shouldBe None
+    }
+  }
+
+  "MastermindState.of once the game is over" should {
+    "reveal the secret to everyone, including the codebreaker" in {
+      val finished = game(winner = Some(Codebreaker))
+      MastermindState.of(finished, Some(Codebreaker)).secret shouldBe Some(List("red", "green", "yellow", "blue"))
+      MastermindState.of(finished, None).secret shouldBe Some(List("red", "green", "yellow", "blue"))
+      MastermindState.of(finished, Some(Codebreaker)).winner shouldBe Some("codebreaker")
+    }
+  }
+
+  "MastermindState.of before a code is set" should {
+    "report the codemaker to move and no secret for the codebreaker" in {
+      val fresh = Mastermind.newGame(Seq(alice, bob))
+      val view = MastermindState.of(fresh, Some(Codebreaker))
+      view.currentPlayer shouldBe "codemaker"
+      view.secret shouldBe None
+      view.guesses shouldBe empty
+      view.guessesRemaining shouldBe Mastermind.MaxGuesses
+    }
+  }
+}

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -19,7 +19,15 @@ import com.andy327.actor.core.GameManager.{
   SubscribeAcknowledged
 }
 import com.andy327.actor.core.PlayerEvent
-import com.andy327.actor.game.{BattleshipState, GameState, GameStateConverters, GridGameState, PigState}
+import com.andy327.actor.game.{
+  BattleshipState,
+  GameState,
+  GameStateConverters,
+  GridGameState,
+  GuessResult,
+  MastermindState,
+  PigState
+}
 import com.andy327.actor.lobby._
 import com.andy327.model.battleship.Battleship
 import com.andy327.model.connectfour.ConnectFour
@@ -139,6 +147,20 @@ class SerializationSpec extends AnyWordSpec with Matchers {
       val json = state.asJson
       json.hcursor.downField("scores").focus should be(defined)
       json.hcursor.get[String]("currentPlayer") shouldBe Right("P1")
+    }
+
+    "encode a MastermindState branch" in {
+      val state: GameState = MastermindState(
+        guesses = List(GuessResult(List("red", "green", "yellow", "blue"), 2, 1)),
+        secret = None,
+        currentPlayer = "codebreaker",
+        winner = None,
+        guessesRemaining = 9,
+        viewerRole = Some("codebreaker")
+      )
+      val json = state.asJson
+      json.hcursor.downField("guesses").focus should be(defined)
+      json.hcursor.get[String]("currentPlayer") shouldBe Right("codebreaker")
     }
   }
 


### PR DESCRIPTION
Implements Mastermind (#26) end-to-end: model, backend wiring, and web UI. Mastermind is a two-player code-breaking game — the codemaker sets a hidden four-peg color code, and the codebreaker gets ten guesses to crack it, receiving black/white peg feedback (right color and place / right color, wrong place) after each. It's the project's second hidden-information game after Battleship, reusing the per-viewer state projection.

### What's included
- **Model** — `Mastermind` model with `SetCode`/`Guess` moves and duplicate-aware black/white peg feedback; the codebreaker wins by cracking the code within `MaxGuesses` (10), otherwise the codemaker wins. Asymmetric roles (`Codemaker` seat 0 / `Codebreaker` seat 1), with `currentPlayer` derived from whether the code is set yet, and `playerLeft` forfeiting to the other role. `GameType.Mastermind` (2 players), `GameTypeTag`, and a `GameTypeCodecs` persistence round-trip (`Peg`/`Role`/`Feedback`/`Attempt`; no new table).
- **Actor / module** — `MastermindActor` bound to `TurnBasedGameActor`; `MastermindModule` decodes the move payload, resolves color names to `Peg`s (rejecting unknown colors), and dispatches to game commands. `MastermindState` per-viewer view; `GameRegistry` wired.
- **Server** — `JsonProtocol` codec and `gameStateEncoder` branch for `MastermindState`; `GameMetrics` `"mastermind"` label; route registered in `GameServer`.
- **Web UI** — new-game button and filter option, a color-peg picker for setting the code and guessing, a guess history with black/white feedback pegs, and the secret revealed once the game ends.
- **Docs** — README updated (features list, per-viewer projection section, and roadmap).

### Wire format
- Move: `{"action":"setcode","pegs":["red","green","yellow","blue"]}` (codemaker, once) or `{"action":"guess","pegs":[...]}` (codebreaker). Colors are the six lowercase names `red`/`yellow`/`blue`/`green`/`black`/`white`; duplicates are allowed.
- State: `MastermindState` with `guesses` (each carrying `pegs` plus `black`/`white` counts), `secret` (color names, or `null` while hidden), `currentPlayer` (`"codemaker"`/`"codebreaker"`), `winner`, `guessesRemaining`, and `viewerRole` (`null` for a spectator).

### Design notes
- **Asymmetric, but the codemaker role alternates on rematch for free.** The codemaker is seat 0, and `LobbyManager.seatOrder` already rotates seat 0 by the room's match count — so who makes the code swaps each rematch with no new machinery.
- **Player-chosen code via a lightweight setup phase.** The codemaker's first move (`SetCode`) fixes the code; every subsequent turn is the codebreaker's.
- **Hidden state stays hidden two ways.** The per-viewer `MastermindState` withholds the secret from the codebreaker and spectators until the game ends, and the (public) move-history log redacts the `SetCode` pegs — so the answer can't be read out of `/history` mid-game. Guesses are logged in full.

### Testing
- `MastermindSpec` — set-code/guess flow, feedback scoring incl. duplicate handling, win-by-crack and win-by-exhaustion, out-of-turn and wrong-phase rejections, `playerLeft`, `moveCount`, and peg/role labels.
- `MastermindModuleSpec` — move decode, setcode/guess dispatch, invalid-color and unknown-action errors, per-viewer serialization (secret hidden vs. revealed), and the `GameRegistry` bundle.
- `MastermindStateSpec` — the per-viewer projection matrix (codemaker / codebreaker / spectator, in-progress vs. finished).
- `GameTypeCodecsSpec` — `fromString`, GameType encode/decode, game round-trip, `roleCodec` for both winners, and invalid peg/role decoding.
- `GameMetricsSpec` / `SerializationSpec` — the `"mastermind"` metrics label and the `MastermindState` encoder branch.
- `scalafixAll --check`, `scalafmtCheckAll`, the full `test` suite, and `sbt doc` all green.

Closes #26