### PR TITLE
Add Liar's Dice game support (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Although it runs as a single instance today, the system is **designed for horizo
 - 🔐 Credentialed accounts — register, log in, and change password (Argon2-hashed), issuing expiring JWTs for player actions
 - 🏛️ Full lobby lifecycle — create, join, leave, list, and start matches
 - 🔁 Post-game rooms — a finished match keeps its room alive for chat, and the host can start a same-roster rematch; idle/empty rooms are evicted automatically
-- 🎲 Multiple game types — Tic-Tac-Toe, Connect Four, Battleship, Pig, and Mastermind
+- 🎲 Multiple game types — Tic-Tac-Toe, Connect Four, Battleship, Pig, Mastermind, and Liar's Dice
 - ✅ Server-side move validation (turn order and legality enforced by the game model)
 - ⚡ Real-time state delivery to all participants over WebSockets
 - 🌫️ Per-viewer / fog-of-war state projection for hidden-information games and spectators
@@ -280,7 +280,7 @@ On startup `GameManager` doesn't accept traffic blindly — it kicks off an asyn
 
 ### Per-viewer projection (fog of war)
 
-A game actor never ships its raw internal state to anyone. When it needs to send state out — as a move reply or a push — it renders a **view** for a specific viewer through a `GameStateView` type class: `serialize(game, Some(playerId))` for that player's own view, `serialize(game, None)` for a public/spectator view. Full-information games (Tic-Tac-Toe, Connect Four, Pig) ignore the viewer and show everyone the same board. For Battleship the projection is where fog of war is enforced: your own ships are visible to you, your opponent's are hidden, and a spectator sees both boards fogged. Mastermind works the same way — the codemaker's secret code is hidden from the codebreaker (and spectators) until the game ends. No code path can leak hidden state, because the unredacted model never leaves the actor.
+A game actor never ships its raw internal state to anyone. When it needs to send state out — as a move reply or a push — it renders a **view** for a specific viewer through a `GameStateView` type class: `serialize(game, Some(playerId))` for that player's own view, `serialize(game, None)` for a public/spectator view. Full-information games (Tic-Tac-Toe, Connect Four, Pig) ignore the viewer and show everyone the same board. For Battleship the projection is where fog of war is enforced: your own ships are visible to you, your opponent's are hidden, and a spectator sees both boards fogged. Mastermind works the same way — the codemaker's secret code is hidden from the codebreaker (and spectators) until the game ends. Liar's Dice is the same idea across many hands: each player sees only their own dice (everyone else's is a count), until a challenge turns every cup over and the reveal becomes public. No code path can leak hidden state, because the unredacted model never leaves the actor.
 
 ### Real-time delivery
 
@@ -347,7 +347,7 @@ Planned work, in rough priority order:
 - **Horizontal scaling (Pekko Cluster Sharding)** — today the service is single-instance (lobbies, game actors, and player sessions live in one JVM). The target is to shard game and lobby entities across a Pekko cluster so play is location-transparent across nodes. Cluster messaging would carry cross-instance delivery between game actors and player sessions directly, while the analytics event stream survives unchanged. Kept deliberately out of the main architecture diagram above so it reflects what's actually deployed.
 - **Authentication hardening** — the credentialed auth in place covers registration, login, and password change, with Argon2id hashing, short-lived tokens, and login timing-equalization to blunt email enumeration. Considered and deliberately deferred: **token revocation** — JWTs are stateless, so a password change or "log out" doesn't invalidate already-issued tokens before they expire; closing that needs a per-account token version baked into the claim (or a `jti` denylist in Redis) checked at validation time. **Password reset** (forgot-password) — needs an out-of-band channel (email) and a single-use, TTL'd reset-token store (a natural fit for Redis), so it's gated on an email integration. **Rate limiting / lockout** on the auth endpoints to slow credential stuffing, and **email-address verification** at registration, are likewise out of scope for now. The short token TTL keeps the revocation gap small in the meantime.
 - **OAuth / social login** — a second `IdentityProvider` (e.g. Google/GitHub) plus a callback route, resolving an external identity to the same `Account` and reusing token issuance and the account store unchanged. The `IdentityProvider` seam exists precisely so this is additive; the open design questions are account-linking policy (same email via password and OAuth) and how non-browser clients complete the redirect.
-- **More game types** — additional turn-based games beyond the current five (e.g. Liar's Dice, Texas Hold 'Em).
+- **More game types** — additional turn-based games beyond the current six (e.g. Texas Hold 'Em).
 - **AI opponent** — a bot player for single-player matches and testing.
 - **Load testing** — throughput/latency benchmarking, plus retention policies for snapshots and move logs.
 

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/GameRegistry.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/GameRegistry.scala
@@ -7,10 +7,12 @@ import com.andy327.actor.game.modules.{
   BattleshipModule,
   ConnectFourModule,
   GameModule,
+  LiarsDiceModule,
   MastermindModule,
   PigModule,
   TicTacToeModule
 }
+import com.andy327.actor.liarsdice.LiarsDiceActor
 import com.andy327.actor.mastermind.MastermindActor
 import com.andy327.actor.pig.PigActor
 import com.andy327.actor.tictactoe.TicTacToeActor
@@ -55,5 +57,6 @@ object GameRegistry {
     case GameType.Battleship  => GameModuleBundle(BattleshipModule, BattleshipActor)
     case GameType.Pig         => GameModuleBundle(PigModule, PigActor)
     case GameType.Mastermind  => GameModuleBundle(MastermindModule, MastermindActor)
+    case GameType.LiarsDice   => GameModuleBundle(LiarsDiceModule, LiarsDiceActor)
   }
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
@@ -3,6 +3,7 @@ package com.andy327.actor.game
 import com.andy327.model.battleship.{Battleship, Coord, Player1, Player2, PlayerBoard, Seat}
 import com.andy327.model.connectfour.ConnectFour
 import com.andy327.model.core.{Draw, Game, GameStatus, Mark, PlayerId, Won}
+import com.andy327.model.liarsdice.{Bid, LiarsDice}
 import com.andy327.model.mastermind.{Codemaker, Mastermind, Role}
 import com.andy327.model.pig.Pig
 import com.andy327.model.tictactoe.TicTacToe
@@ -148,6 +149,84 @@ object MastermindState {
   }
 }
 
+/** One bid in a Liar's Dice view: a quantity plus either a numbered face (2–6) or `None` for a wild "ones" bid. */
+case class BidView(quantity: Int, face: Option[Int])
+
+/** The public reveal of the most recently resolved challenge in a Liar's Dice view.
+  *
+  * Every seat's dice are exposed here (keyed by seat label) because a challenge is the one moment all cups come up;
+  * this snapshot is safe to show everyone and persists into the next round for reconnecting clients.
+  *
+  * @param bid the bid that was challenged
+  * @param count the true number of dice counting toward `bid` (its face plus wild ones)
+  * @param dice every seat's dice at the challenge, keyed by seat label ("P1", "P2", …)
+  * @param challenger the seat that called "Liar"
+  * @param bidder the seat whose bid was challenged
+  * @param loser the seat that lost dice
+  * @param diceLost how many dice `loser` lost (0 when a challenger meets the bid exactly)
+  */
+case class RevealView(
+    bid: BidView,
+    count: Int,
+    dice: Map[String, List[Int]],
+    challenger: String,
+    bidder: String,
+    loser: String,
+    diceLost: Int
+)
+
+/** Serializable, per-viewer view of a Liar's Dice game.
+  *
+  * The viewer sees their own current dice and every seat's dice count, but never another seat's current dice — hidden
+  * information stays hidden. `lastReveal` is the exception: it captures all dice at the moment of the last challenge,
+  * which is public once the cups come up.
+  *
+  * @param dice the viewer's own current dice, or `None` for a spectator
+  * @param diceCounts dice remaining per seat, keyed by seat label ("P1", "P2", …)
+  * @param currentBid the standing bid, or `None` at the start of a round
+  * @param currentPlayer the seat label whose turn it is
+  * @param winner the winning seat label once the game is over, otherwise `None`
+  * @param viewerSeat the viewer's seat label, or `None` for a spectator
+  * @param lastReveal the most recently resolved challenge, or `None` before any challenge
+  */
+case class LiarsDiceState(
+    dice: Option[List[Int]],
+    diceCounts: Map[String, Int],
+    currentBid: Option[BidView],
+    currentPlayer: String,
+    winner: Option[String],
+    viewerSeat: Option[String],
+    lastReveal: Option[RevealView]
+) extends GameState
+
+object LiarsDiceState {
+
+  /** Builds the view of `game` for the given viewer seat (`None` = spectator, who sees dice counts but no hand). */
+  def of(game: LiarsDice, viewerSeat: Option[Int]): LiarsDiceState = {
+    def label(seat: Int): String = LiarsDice.seatLabel(seat)
+    def bidView(bid: Bid): BidView = BidView(bid.quantity, bid.face)
+    LiarsDiceState(
+      dice = viewerSeat.map(seat => game.dice(seat).toList),
+      diceCounts = game.playerIds.indices.map(i => label(i) -> game.diceCount(i)).toMap,
+      currentBid = game.standing.map(sb => bidView(sb.bid)),
+      currentPlayer = label(game.currentSeat),
+      winner = game.winner.map(label),
+      viewerSeat = viewerSeat.map(label),
+      lastReveal = game.lastReveal.map { r =>
+        RevealView(
+          bid = bidView(r.bid),
+          count = r.count,
+          dice = game.playerIds.indices.map(i => label(i) -> r.allDice(i).toList).toMap,
+          challenger = label(r.challengerSeat),
+          bidder = label(r.bidderSeat),
+          loser = label(r.loserSeat),
+          diceLost = r.diceLost
+        )
+      }
+    )
+  }
+}
+
 /** Type class for converting an internal game model into a serializable GameState.
   *
   * Instances live in the companion object, which is always in implicit scope for `GameStateView[G, S]` searches, so
@@ -182,6 +261,10 @@ object GameStateView {
   /** Type class instance for serializing a Mastermind game, projected per viewer (the secret is hidden until reveal). */
   implicit val mastermindView: GameStateView[Mastermind, MastermindState] =
     (game, viewer) => MastermindState.of(game, viewer.flatMap(game.playerFor))
+
+  /** Type class instance for serializing a Liar's Dice game, projected per viewer (only the viewer's own dice show). */
+  implicit val liarsDiceView: GameStateView[LiarsDice, LiarsDiceState] =
+    (game, viewer) => LiarsDiceState.of(game, viewer.flatMap(game.playerFor))
 }
 
 /** Utility for converting internal game models to HTTP-serializable GameState representations using the GameStateView

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/MovePayload.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/MovePayload.scala
@@ -41,4 +41,15 @@ object MovePayload {
     * @param pegs the color names making up the code or guess (e.g. `["red","blue","red","green"]`)
     */
   final case class MastermindAction(action: String, pegs: List[String]) extends MovePayload
+
+  /** A move for Liar's Dice: raise the bid (`"bid"`) or call "Liar" (`"challenge"`).
+    *
+    * For a bid, `quantity` is required and `face` is the numbered face 2–6, or `None`/absent for a wild "ones" bid. A
+    * challenge ignores both fields. The dice a challenge re-rolls are supplied server-side, never by the client.
+    *
+    * @param action `"bid"` or `"challenge"`
+    * @param quantity the bid's quantity (dice claimed), for a `"bid"` action
+    * @param face the bid's numbered face 2–6, or `None` for a wild "ones" bid
+    */
+  final case class LiarsDiceAction(action: String, quantity: Option[Int], face: Option[Int]) extends MovePayload
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/modules/LiarsDiceModule.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/modules/LiarsDiceModule.scala
@@ -1,0 +1,58 @@
+package com.andy327.actor.game.modules
+
+import scala.util.Random
+
+import cats.syntax.functor._
+
+import io.circe.Decoder
+import io.circe.generic.auto._
+import org.apache.pekko.actor.typed.ActorRef
+
+import com.andy327.actor.core.{GameActor, TurnBasedGameActor}
+import com.andy327.actor.game.MovePayload.LiarsDiceAction
+import com.andy327.actor.game.{GameOperation, GameState, GameStateConverters, MovePayload}
+import com.andy327.model.core.{GameError, PlayerId}
+import com.andy327.model.liarsdice.{Bid, Challenge, LiarsDice, MakeBid}
+
+/** [[GameModule]] implementation for Liar's Dice.
+  *
+  * Provides move decoding, operation-to-command mapping, and per-viewer serialization for Liar's Dice. Dice are rolled
+  * server-side here — a challenge carries a fresh pool the pure model deals to the surviving hands for the next round —
+  * so `LiarsDice.play` stays a pure function. Bid well-formedness (a positive quantity, a face of 2–6) is left to the
+  * model, which rejects a malformed bid with its own `InvalidBid` error.
+  */
+object LiarsDiceModule extends GameModule[LiarsDice] {
+
+  override val moveDecoder: Decoder[MovePayload] = Decoder[LiarsDiceAction].widen
+
+  /** A flat pool of freshly rolled dice, sized to the most dice that can ever be on the table. The model deals out only
+    * the prefix each surviving hand needs; the surplus is harmless. Used for both the opening deal and each re-roll.
+    */
+  def rollPool(): List[Int] = List.fill(LiarsDice.MaxTotalDice)(Random.between(1, 7))
+
+  override def toGameCommand(
+      op: GameOperation,
+      replyTo: ActorRef[Either[GameError, GameState]]
+  ): Either[GameError, GameActor.GameCommand] = op match {
+    case GameOperation.MakeMove(playerId, LiarsDiceAction(action, quantity, face)) =>
+      action.toLowerCase match {
+        case "bid" =>
+          quantity match {
+            case Some(q) => Right(TurnBasedGameActor.MakeMove(playerId, MakeBid(Bid(q, face)), replyTo))
+            case None    => Left(GameError.Unknown("A Liar's Dice bid requires a quantity."))
+          }
+        case "challenge" => Right(TurnBasedGameActor.MakeMove(playerId, Challenge(rollPool()), replyTo))
+        case other       => Left(GameError.Unknown(s"Unknown Liar's Dice action: $other"))
+      }
+
+    case GameOperation.MakeMove(_, otherMove) =>
+      val name = Option(otherMove).map(_.getClass.getSimpleName).getOrElse("null")
+      Left(GameError.Unknown(s"Unsupported move type for Liar's Dice: $name"))
+
+    case GameOperation.GetState =>
+      Right(TurnBasedGameActor.GetState(replyTo))
+  }
+
+  override def serialize(game: LiarsDice, viewer: Option[PlayerId]): GameState =
+    GameStateConverters.serializeGame(game, viewer)
+}

--- a/game-service-actor/src/main/scala/com/andy327/actor/liarsdice/LiarsDiceActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/liarsdice/LiarsDiceActor.scala
@@ -1,0 +1,30 @@
+package com.andy327.actor.liarsdice
+
+import io.circe.syntax._
+import io.circe.{Encoder, Json}
+
+import com.andy327.actor.core.TurnBasedGameActor
+import com.andy327.actor.game.LiarsDiceState
+import com.andy327.actor.game.modules.LiarsDiceModule
+import com.andy327.model.liarsdice.{Challenge, LiarsDice, LiarsDiceMove, MakeBid}
+
+/** [[core.GameActor]] binding for Liar's Dice.
+  *
+  * All behavior lives in [[core.TurnBasedGameActor]]; the rules (bidding-track raises, wild-ones counting, per-round
+  * elimination) live in `model.liarsdice.LiarsDice`, and the per-viewer projection that hides each player's dice lives
+  * in `GameStateView[LiarsDice, LiarsDiceState]`. The starting hands are rolled here — server-side — and dealt by the
+  * pure model, mirroring how Pig supplies its die result.
+  *
+  * The move-log encoder records a bid's quantity and face but omits a challenge's re-roll pool: that pool is internal
+  * server randomness for the next round, not meaningful public history.
+  */
+object LiarsDiceActor
+    extends TurnBasedGameActor[LiarsDice, LiarsDiceMove, Int, LiarsDiceState](
+      players => LiarsDice.newGame(players, LiarsDiceModule.rollPool()),
+      Encoder.instance[LiarsDiceMove] {
+        case MakeBid(bid) =>
+          Json.obj("action" -> "bid".asJson, "quantity" -> bid.quantity.asJson, "face" -> bid.face.asJson)
+        case Challenge(_) =>
+          Json.obj("action" -> "challenge".asJson) // re-roll pool omitted from the public history log
+      }
+    )

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/LiarsDiceStateSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/LiarsDiceStateSpec.scala
@@ -1,0 +1,88 @@
+package com.andy327.actor.game
+
+import java.util.UUID
+
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import com.andy327.model.core.PlayerId
+import com.andy327.model.liarsdice.{Bid, LiarsDice, Reveal, StandingBid}
+
+class LiarsDiceStateSpec extends AnyWordSpec with Matchers with OptionValues {
+  val alice: PlayerId = UUID.randomUUID() // seat 0
+  val bob: PlayerId = UUID.randomUUID() // seat 1
+
+  private def game: LiarsDice =
+    LiarsDice(
+      playerIds = Vector(alice, bob),
+      dice = Vector(Vector(2, 3, 4), Vector(5, 6, 1)),
+      currentSeat = 0,
+      standing = Some(StandingBid(Bid(2, Some(4)), 1)),
+      lastReveal = None,
+      winner = None,
+      moveCount = 3
+    )
+
+  "LiarsDiceState.of for a seated player" should {
+    "reveal only that player's own dice, plus every seat's count" in {
+      val p1 = LiarsDiceState.of(game, Some(0))
+      p1.viewerSeat shouldBe Some("P1")
+      p1.dice shouldBe Some(List(2, 3, 4))
+      p1.diceCounts shouldBe Map("P1" -> 3, "P2" -> 3)
+
+      val p2 = LiarsDiceState.of(game, Some(1))
+      p2.dice shouldBe Some(List(5, 6, 1)) // its own hand, not seat 0's
+    }
+
+    "expose the standing bid and whose turn it is" in {
+      val view = LiarsDiceState.of(game, Some(0))
+      view.currentBid shouldBe Some(BidView(2, Some(4)))
+      view.currentPlayer shouldBe "P1"
+      view.winner shouldBe None
+    }
+  }
+
+  "LiarsDiceState.of for a spectator" should {
+    "hide every hand while still reporting the counts" in {
+      val view = LiarsDiceState.of(game, None)
+      view.viewerSeat shouldBe None
+      view.dice shouldBe None
+      view.diceCounts shouldBe Map("P1" -> 3, "P2" -> 3)
+    }
+  }
+
+  "LiarsDiceState.of with a resolved challenge" should {
+    "expose every seat's dice in the reveal — the one public moment" in {
+      val reveal = Reveal(
+        bid = Bid(3, Some(4)),
+        count = 5,
+        allDice = Vector(Vector(4, 4, 4), Vector(4, 1)),
+        challengerSeat = 1,
+        bidderSeat = 0,
+        loserSeat = 1,
+        diceLost = 2
+      )
+      // the challenger (seat 1) lost both dice, so their current hand is empty, but the reveal still shows what it held
+      val ended = game.copy(dice = Vector(Vector(4, 4, 4), Vector.empty), lastReveal = Some(reveal), winner = Some(0))
+      val view = LiarsDiceState.of(ended, Some(1))
+      val shown = view.lastReveal.value
+      shown.bid shouldBe BidView(3, Some(4))
+      shown.count shouldBe 5
+      shown.dice shouldBe Map("P1" -> List(4, 4, 4), "P2" -> List(4, 1))
+      shown.challenger shouldBe "P2"
+      shown.bidder shouldBe "P1"
+      shown.loser shouldBe "P2"
+      shown.diceLost shouldBe 2
+      view.winner shouldBe Some("P1")
+      view.diceCounts shouldBe Map("P1" -> 3, "P2" -> 0)
+    }
+  }
+
+  "LiarsDiceState.of for a wild ones bid" should {
+    "represent a faceless bid with no face" in {
+      val onesGame = game.copy(standing = Some(StandingBid(Bid(2, None), 1)))
+      LiarsDiceState.of(onesGame, Some(0)).currentBid shouldBe Some(BidView(2, None))
+    }
+  }
+}

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/LiarsDiceModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/LiarsDiceModuleSpec.scala
@@ -1,0 +1,155 @@
+package com.andy327.actor.game.modules
+
+import java.util.UUID
+
+import io.circe.parser.decode
+import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import com.andy327.actor.core.{PlayerActor, TurnBasedGameActor}
+import com.andy327.actor.game.{GameOperation, GameRegistry, GameState, LiarsDiceState, MovePayload}
+import com.andy327.actor.liarsdice.LiarsDiceActor
+import com.andy327.actor.lobby.Player
+import com.andy327.model.core.{GameError, GameType}
+import com.andy327.model.liarsdice.{Bid, Challenge, LiarsDice, MakeBid}
+
+class LiarsDiceModuleSpec extends AnyWordSpecLike with Matchers {
+  private val testKit = ActorTestKit()
+  import testKit._
+
+  "LiarsDiceModule" should {
+    "decode a numbered bid action JSON" in {
+      val json = """{"action":"bid","quantity":3,"face":4}"""
+      decode[MovePayload](json)(LiarsDiceModule.moveDecoder) shouldBe
+        Right(MovePayload.LiarsDiceAction("bid", Some(3), Some(4)))
+    }
+
+    "decode a wild ones bid (no face) action JSON" in {
+      val json = """{"action":"bid","quantity":2}"""
+      decode[MovePayload](json)(LiarsDiceModule.moveDecoder) shouldBe
+        Right(MovePayload.LiarsDiceAction("bid", Some(2), None))
+    }
+
+    "decode a challenge action JSON" in {
+      val json = """{"action":"challenge"}"""
+      decode[MovePayload](json)(LiarsDiceModule.moveDecoder) shouldBe
+        Right(MovePayload.LiarsDiceAction("challenge", None, None))
+    }
+
+    "fail to decode an invalid Liar's Dice move JSON" in {
+      decode[MovePayload]("""{"bad":"data"}""")(LiarsDiceModule.moveDecoder).isLeft shouldBe true
+    }
+
+    "convert a numbered bid MakeMove to a MakeBid GameCommand" in {
+      val alice = Player("alice")
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+
+      val result = LiarsDiceModule.toGameCommand(
+        GameOperation.MakeMove(alice.id, MovePayload.LiarsDiceAction("bid", Some(3), Some(4))),
+        replyProbe.ref
+      )
+
+      result shouldBe Right(TurnBasedGameActor.MakeMove(alice.id, MakeBid(Bid(3, Some(4))), replyProbe.ref))
+    }
+
+    "convert a wild ones bid MakeMove to a MakeBid GameCommand with no face" in {
+      val alice = Player("alice")
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+
+      val result = LiarsDiceModule.toGameCommand(
+        GameOperation.MakeMove(alice.id, MovePayload.LiarsDiceAction("bid", Some(2), None)),
+        replyProbe.ref
+      )
+
+      result shouldBe Right(TurnBasedGameActor.MakeMove(alice.id, MakeBid(Bid(2, None)), replyProbe.ref))
+    }
+
+    "reject a bid with no quantity" in {
+      val alice = Player("alice")
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+
+      val Left(err) = LiarsDiceModule.toGameCommand(
+        GameOperation.MakeMove(alice.id, MovePayload.LiarsDiceAction("bid", None, None)),
+        replyProbe.ref
+      )
+
+      err.message should include("requires a quantity")
+    }
+
+    "convert a challenge MakeMove to a Challenge GameCommand carrying a full server-rolled pool" in {
+      val alice = Player("alice")
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+
+      val result = LiarsDiceModule.toGameCommand(
+        GameOperation.MakeMove(alice.id, MovePayload.LiarsDiceAction("challenge", None, None)),
+        replyProbe.ref
+      )
+
+      result match {
+        case Right(TurnBasedGameActor.MakeMove(playerId, Challenge(pool), reply)) =>
+          playerId shouldBe alice.id
+          pool.size shouldBe LiarsDice.MaxTotalDice
+          pool.forall(d => d >= 1 && d <= 6) shouldBe true
+          reply shouldBe replyProbe.ref
+
+        case other => fail(s"Unexpected result: $other")
+      }
+    }
+
+    "return an error for an unknown action string" in {
+      val alice = Player("alice")
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+
+      val Left(err) = LiarsDiceModule.toGameCommand(
+        GameOperation.MakeMove(alice.id, MovePayload.LiarsDiceAction("bad", None, None)),
+        replyProbe.ref
+      )
+
+      err.message should include("Unknown Liar's Dice action: bad")
+    }
+
+    "return error when passing an unsupported MovePayload to toGameCommand" in {
+      val alice = Player("alice")
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+
+      val Left(err) = LiarsDiceModule.toGameCommand(
+        GameOperation.MakeMove(alice.id, null.asInstanceOf[MovePayload]),
+        replyProbe.ref
+      )
+
+      err.message should include("Unsupported move type for Liar's Dice")
+    }
+
+    "convert GetState to a GetState GameCommand" in {
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      LiarsDiceModule.toGameCommand(GameOperation.GetState, replyProbe.ref) shouldBe
+        Right(TurnBasedGameActor.GetState(replyProbe.ref))
+    }
+
+    "produce a Subscribe command for a given PlayerActor ref" in {
+      val playerProbe = TestProbe[PlayerActor.Command]()
+      val playerId = UUID.randomUUID()
+      LiarsDiceActor.subscribeCommand(playerProbe.ref, playerId) shouldBe
+        TurnBasedGameActor.Subscribe(playerProbe.ref, playerId)
+    }
+
+    "serialize a Liar's Dice game to a LiarsDiceState for the requesting player" in {
+      val alice = Player("alice")
+      val bob = Player("bob")
+      val game = LiarsDice.newGame(Seq(alice.id, bob.id), List.fill(LiarsDice.MaxTotalDice)(4))
+      val state = LiarsDiceModule.serialize(game, Some(alice.id)).asInstanceOf[LiarsDiceState]
+      state.viewerSeat shouldBe Some("P1")
+      state.dice shouldBe Some(List.fill(5)(4))
+      state.diceCounts shouldBe Map("P1" -> 5, "P2" -> 5)
+      state.currentPlayer shouldBe "P1"
+      state.currentBid shouldBe None
+    }
+
+    "expose the Liar's Dice bundle through the GameRegistry" in {
+      val bundle = GameRegistry.forType(GameType.LiarsDice)
+      bundle.module shouldBe LiarsDiceModule
+      bundle.actor shouldBe LiarsDiceActor
+    }
+  }
+}

--- a/game-service-actor/src/test/scala/com/andy327/actor/liarsdice/LiarsDiceActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/liarsdice/LiarsDiceActorSpec.scala
@@ -1,0 +1,84 @@
+package com.andy327.actor.liarsdice
+
+import java.util.UUID
+
+import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
+import org.apache.pekko.actor.typed.ActorRef
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import com.andy327.actor.core.{GameManager, TurnBasedGameActor}
+import com.andy327.actor.events.NoOpEventPublisher
+import com.andy327.actor.game.GameState
+import com.andy327.actor.persistence.PersistenceProtocol
+import com.andy327.model.core.{GameError, PlayerId}
+import com.andy327.model.liarsdice.{Bid, Challenge, MakeBid}
+
+/** Drives the shared turn-based actor with Liar's Dice moves to lock in the move-log encoder — in particular that a
+  * challenge never records its server-rolled dice pool (the history endpoint is public) and that a wild "ones" bid
+  * records a null face. State projection and rules are covered by `LiarsDiceStateSpec` and `LiarsDiceSpec`.
+  */
+class LiarsDiceActorSpec extends AnyWordSpecLike with Matchers {
+  private val testKit = ActorTestKit()
+  import testKit._
+
+  val alice: PlayerId = UUID.randomUUID()
+  val bob: PlayerId = UUID.randomUUID()
+
+  private val dummyGameManager: ActorRef[GameManager.Command] = createTestProbe[GameManager.Command]().ref
+
+  private def newActor(): (ActorRef[LiarsDiceActor.Command], TestProbe[PersistenceProtocol.Command]) = {
+    val persistProbe = createTestProbe[PersistenceProtocol.Command]()
+    val (_, behavior) =
+      LiarsDiceActor.create(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        Seq(alice, bob),
+        persistProbe.ref,
+        dummyGameManager,
+        NoOpEventPublisher
+      )
+    (spawn(behavior), persistProbe)
+  }
+
+  /** Applies a move and returns the JSON the actor appended to the move-log for it. */
+  private def loggedMove(
+      actor: ActorRef[LiarsDiceActor.Command],
+      persistProbe: TestProbe[PersistenceProtocol.Command],
+      player: PlayerId,
+      move: com.andy327.model.liarsdice.LiarsDiceMove
+  ): io.circe.Json = {
+    val replyProbe = createTestProbe[Either[GameError, GameState]]()
+    actor ! TurnBasedGameActor.MakeMove(player, move, replyProbe.ref)
+    replyProbe.receiveMessage()
+    persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+    persistProbe.expectMessageType[PersistenceProtocol.AppendMove].move
+  }
+
+  "LiarsDiceActor's move-log encoder" should {
+    "record a numbered bid's quantity and face" in {
+      val (actor, persistProbe) = newActor()
+      val json = loggedMove(actor, persistProbe, alice, MakeBid(Bid(2, Some(4))))
+      json.hcursor.get[String]("action") shouldBe Right("bid")
+      json.hcursor.get[Int]("quantity") shouldBe Right(2)
+      json.hcursor.get[Int]("face") shouldBe Right(4)
+    }
+
+    "record a wild ones bid with a null face" in {
+      val (actor, persistProbe) = newActor()
+      loggedMove(actor, persistProbe, alice, MakeBid(Bid(2, Some(4))))
+      // "2 ones" is the next clockwise ones space after "2 fours", so this is a legal raise
+      val json = loggedMove(actor, persistProbe, bob, MakeBid(Bid(2, None)))
+      json.hcursor.get[Int]("quantity") shouldBe Right(2)
+      json.hcursor.downField("face").focus.flatMap(_.asNull) shouldBe Some(())
+    }
+
+    "record only the action for a challenge, never the dice pool" in {
+      val (actor, persistProbe) = newActor()
+      loggedMove(actor, persistProbe, alice, MakeBid(Bid(2, Some(4))))
+      val json = loggedMove(actor, persistProbe, bob, Challenge(List.fill(30)(3)))
+      json.hcursor.get[String]("action") shouldBe Right("challenge")
+      json.asObject.map(_.keys.toList) shouldBe Some(List("action")) // no dice/pool leaked to the public history log
+    }
+  }
+}

--- a/game-service-model/src/main/scala/com/andy327/model/core/GameType.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/core/GameType.scala
@@ -41,6 +41,11 @@ object GameType {
     val (minPlayers, maxPlayers) = (2, 2)
   }
 
+  /** A 2–6 player dice-bluffing game: players bid on the dice hidden under every cup until someone calls "Liar". */
+  case object LiarsDice extends GameType {
+    val (minPlayers, maxPlayers) = (2, 6)
+  }
+
   /** Parses a string into a GameType instance.
     *
     * @param s the name of the game type (case-insensitive)
@@ -52,6 +57,7 @@ object GameType {
     case "battleship"  => Some(Battleship)
     case "pig"         => Some(Pig)
     case "mastermind"  => Some(Mastermind)
+    case "liarsdice"   => Some(LiarsDice)
     case _             => None
   }
 }

--- a/game-service-model/src/main/scala/com/andy327/model/core/GameTypeTag.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/core/GameTypeTag.scala
@@ -2,6 +2,7 @@ package com.andy327.model.core
 
 import com.andy327.model.battleship.Battleship
 import com.andy327.model.connectfour.ConnectFour
+import com.andy327.model.liarsdice.LiarsDice
 import com.andy327.model.mastermind.Mastermind
 import com.andy327.model.pig.Pig
 import com.andy327.model.tictactoe.TicTacToe
@@ -41,5 +42,9 @@ object GameTypeTag {
 
   implicit val mastermindTag: GameTypeTag[Mastermind] = new GameTypeTag[Mastermind] {
     override val value: GameType = GameType.Mastermind
+  }
+
+  implicit val liarsDiceTag: GameTypeTag[LiarsDice] = new GameTypeTag[LiarsDice] {
+    override val value: GameType = GameType.LiarsDice
   }
 }

--- a/game-service-model/src/main/scala/com/andy327/model/liarsdice/GameError.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/liarsdice/GameError.scala
@@ -1,0 +1,21 @@
+package com.andy327.model.liarsdice
+
+import com.andy327.model.core.GameError
+
+// Liar's Dice-specific game errors. Errors shared by every turn-based game (InvalidPlayer, InvalidTurn, GameOver,
+// Unknown) are defined once in core.GameError.
+
+/** A bid was malformed — a non-positive quantity, or a numbered face outside 2–6. */
+case object InvalidBid extends GameError {
+  val message: String = "A bid must name a positive quantity and a face of 2–6, or a number of wild ones."
+}
+
+/** A bid did not legally raise the standing bid on the bidding track. */
+case object IllegalRaise extends GameError {
+  val message: String = "That bid does not raise the current bid."
+}
+
+/** A challenge was made with no standing bid to challenge — the opening move of a round must be a bid. */
+case object NoBidToChallenge extends GameError {
+  val message: String = "There is no bid to challenge yet."
+}

--- a/game-service-model/src/main/scala/com/andy327/model/liarsdice/LiarsDice.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/liarsdice/LiarsDice.scala
@@ -1,0 +1,199 @@
+package com.andy327.model.liarsdice
+
+import com.andy327.model.core.GameError.{GameOver, InvalidTurn}
+import com.andy327.model.core.{Game, GameError, GameStatus, InProgress, PlayerId, Won}
+
+object LiarsDice {
+
+  /** Dice each player starts with. */
+  val DicePerPlayer: Int = 5
+
+  /** Maximum number of players (mirrors `GameType.LiarsDice.maxPlayers`). */
+  val MaxPlayers: Int = 6
+
+  /** Upper bound on the number of dice on the table, and hence the size of a fresh-dice pool a challenge must carry. */
+  val MaxTotalDice: Int = MaxPlayers * DicePerPlayer
+
+  /** Human-readable seat label for a zero-based seat index. */
+  def seatLabel(seat: Int): String = s"P${seat + 1}"
+
+  /** Deals a flat pool of freshly rolled dice into per-seat hands of the given sizes, in seat order.
+    *
+    * Each seat takes a prefix of what remains of `pool`; a size of 0 (an eliminated seat) yields an empty hand. The
+    * pool must hold at least `sizes.sum` dice. This is the single path by which server-rolled dice enter the pure
+    * model: the actor/module rolls the pool, the model deals it — so `play` never calls a random source.
+    */
+  def deal(pool: List[Int], sizes: Seq[Int]): Vector[Vector[Int]] =
+    sizes
+      .foldLeft((Vector.empty[Vector[Int]], pool)) { case ((hands, remaining), n) =>
+        (hands :+ remaining.take(n).toVector, remaining.drop(n))
+      }
+      ._1
+
+  /** The number of dice counting toward `bid` across `allDice`: its face plus every wild 1, or — for a wild "ones"
+    * bid — simply the number of 1s.
+    */
+  def countToward(bid: Bid, allDice: Vector[Vector[Int]]): Int = {
+    val flat = allDice.flatten
+    bid.face match {
+      case None    => flat.count(_ == 1)
+      case Some(f) => flat.count(d => d == f || d == 1)
+    }
+  }
+
+  /** Creates a fresh game: every player holds [[DicePerPlayer]] dice dealt from `pool`, seat 0 opens the bidding.
+    *
+    * `pool` is rolled server-side (in the actor layer) and must contain at least `players.size * DicePerPlayer` dice.
+    */
+  def newGame(playerIds: Seq[PlayerId], pool: List[Int]): LiarsDice =
+    LiarsDice(
+      playerIds = playerIds.toVector,
+      dice = deal(pool, Vector.fill(playerIds.size)(DicePerPlayer)),
+      currentSeat = 0,
+      standing = None,
+      lastReveal = None,
+      winner = None,
+      moveCount = 0
+    )
+}
+
+/** An instance of a Liar's Dice game (the "Wild Ones" house rules).
+  *
+  * Each round every remaining player has hidden dice; on their turn a player either raises the bid ([[MakeBid]]) or
+  * calls "Liar" ([[Challenge]]). A bid names a quantity and a face over all dice on the table, with 1s wild, and must
+  * advance along the bidding track (see [[Bid.canRaiseTo]]). A challenge reveals every die: if the true count meets or
+  * beats the bid the challenger loses a die for each die the count overshoots by (none on an exact meet), otherwise the
+  * bidder loses a single die. The round's loser starts the next round; a player is eliminated at zero dice and the last
+  * player holding dice wins.
+  *
+  * The model is pure: dice are rolled server-side and supplied to it — the initial hands via [[LiarsDice.newGame]], and
+  * each round's re-roll via the [[Challenge]] move's dice pool, which the model deals to the survivors.
+  *
+  * @param playerIds ordered list of participating players; the seat index into this vector is the game's player token
+  * @param dice each seat's hidden dice, indexed in the same order as `playerIds`; an empty hand means eliminated
+  * @param currentSeat zero-based index of the player whose turn it is
+  * @param standing the current standing bid and who made it, or None at the start of a round
+  * @param lastReveal the most recently resolved challenge, or None before any challenge
+  * @param winner the winning seat index once the game is over, otherwise None
+  * @param moveCount total bids and challenges applied so far; survives serialization for the history log
+  */
+final case class LiarsDice(
+    playerIds: Vector[PlayerId],
+    dice: Vector[Vector[Int]],
+    currentSeat: Int,
+    standing: Option[StandingBid],
+    lastReveal: Option[Reveal],
+    winner: Option[Int],
+    moveCount: Int
+) extends Game[LiarsDiceMove, LiarsDice, Int, GameStatus[Int], GameError] {
+
+  import LiarsDice._
+
+  def currentState: LiarsDice = this
+  def currentPlayer: Int = currentSeat
+  def gameStatus: GameStatus[Int] = winner.map(Won(_)).getOrElse(InProgress)
+  def players: List[PlayerId] = playerIds.toList
+
+  /** Resolves a platform player ID to the zero-based seat index, or `None` if not a participant. */
+  def playerFor(playerId: PlayerId): Option[Int] = {
+    val i = playerIds.indexOf(playerId)
+    if (i >= 0) Some(i) else None
+  }
+
+  /** Number of dice seat `seat` still holds; a seat with none has been eliminated. */
+  def diceCount(seat: Int): Int = dice(seat).size
+
+  /** Next seat clockwise from `seat` that still holds dice. Only called while at least one other seat is active (during
+    * a round, or when advancing past an eliminated loser), so the search always terminates.
+    */
+  private def nextActiveSeat(seat: Int): Int = {
+    val n = playerIds.size
+    Iterator.iterate((seat + 1) % n)(s => (s + 1) % n).find(diceCount(_) > 0).get
+  }
+
+  /** Applies a player action.
+    *
+    * Validates turn order, then either raises the bid or resolves a challenge. See [[MakeBid]]/[[Challenge]] and the
+    * class comment for the rules each enforces.
+    */
+  def play(player: Int, move: LiarsDiceMove): Either[GameError, LiarsDice] =
+    if (gameStatus != InProgress) Left(GameOver)
+    else if (player != currentSeat) Left(InvalidTurn)
+    else
+      move match {
+        case MakeBid(bid)         => makeBid(bid)
+        case Challenge(freshDice) => challenge(freshDice)
+      }
+
+  /** Opens or raises the bidding. The opening bid of a round may be any well-formed bid; a later bid must legally raise
+    * the standing bid. On success the bid becomes the new standing bid and the turn passes to the next active seat.
+    */
+  private def makeBid(bid: Bid): Either[GameError, LiarsDice] =
+    if (!bid.isWellFormed) Left(InvalidBid)
+    else
+      standing match {
+        case Some(StandingBid(current, _)) if !current.canRaiseTo(bid) => Left(IllegalRaise)
+        case _                                                         =>
+          Right(
+            copy(
+              standing = Some(StandingBid(bid, currentSeat)),
+              currentSeat = nextActiveSeat(currentSeat),
+              moveCount = moveCount + 1
+            )
+          )
+      }
+
+  /** Resolves a challenge against the standing bid, then deals the next round's dice from `freshDice`.
+    *
+    * The true count is compared to the bid: `count >= quantity` means the challenger was wrong and loses the overshoot
+    * (zero dice on an exact meet), otherwise the bidder loses a single die. The loser starts the next round, or — if
+    * they were eliminated — the next active seat does. When only one seat is left holding dice, that seat wins.
+    */
+  private def challenge(freshDice: List[Int]): Either[GameError, LiarsDice] =
+    standing match {
+      case None                               => Left(NoBidToChallenge)
+      case Some(StandingBid(bid, bidderSeat)) =>
+        val challengerSeat = currentSeat
+        val count = countToward(bid, dice)
+        val (loserSeat, rawLoss) =
+          if (count >= bid.quantity) (challengerSeat, count - bid.quantity)
+          else (bidderSeat, 1)
+        val diceLost = math.min(rawLoss, diceCount(loserSeat))
+
+        val newSizes =
+          playerIds.indices.toVector.map(s => if (s == loserSeat) diceCount(s) - diceLost else diceCount(s))
+        val reveal = Reveal(bid, count, dice, challengerSeat, bidderSeat, loserSeat, diceLost)
+        val base =
+          copy(dice = deal(freshDice, newSizes), standing = None, lastReveal = Some(reveal), moveCount = moveCount + 1)
+
+        val survivors = newSizes.indices.filter(newSizes(_) > 0)
+        if (survivors.size == 1)
+          Right(base.copy(winner = Some(survivors.head)))
+        else {
+          val starter = if (newSizes(loserSeat) > 0) loserSeat else base.nextActiveSeat(loserSeat)
+          Right(base.copy(currentSeat = starter))
+        }
+    }
+
+  /** The leaver forfeits: their dice are set aside. If only one player remains they win; otherwise the round resets —
+    * the standing bid is cleared and the turn moves to the next active seat if the leaver was on the clock.
+    *
+    * No dice are re-rolled: a leave carries no fresh dice, and the surviving hands are unaffected. Rejects with
+    * [[core.GameError.InvalidPlayer]] for a non-participant or [[core.GameError.GameOver]] once the game has ended.
+    */
+  override def playerLeft(playerId: PlayerId): Either[GameError, LiarsDice] =
+    playerFor(playerId) match {
+      case None                                => Left(GameError.InvalidPlayer(playerId))
+      case Some(_) if gameStatus != InProgress => Left(GameOver)
+      case Some(leaverSeat)                    =>
+        val newDice = dice.updated(leaverSeat, Vector.empty[Int])
+        val base = copy(dice = newDice, standing = None)
+        val survivors = newDice.indices.filter(newDice(_).nonEmpty)
+        if (survivors.size == 1)
+          Right(base.copy(winner = Some(survivors.head)))
+        else
+          Right(
+            base.copy(currentSeat = if (currentSeat == leaverSeat) base.nextActiveSeat(leaverSeat) else currentSeat)
+          )
+    }
+}

--- a/game-service-model/src/main/scala/com/andy327/model/liarsdice/package.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/liarsdice/package.scala
@@ -1,0 +1,81 @@
+package com.andy327.model
+
+package object liarsdice {
+
+  /** A standing or proposed bid over all dice on the table.
+    *
+    * A numbered bid (`face = Some(2..6)`) claims at least `quantity` dice show that face, counting wild 1s; a wild
+    * "ones" bid (`face = None`) claims at least `quantity` ones. Ordering follows the printed bidding track — see
+    * [[Bid.canRaiseTo]].
+    *
+    * @param quantity the number of dice claimed (for a "ones" bid, the number of ones)
+    * @param face the numbered face 2–6, or `None` for a wild "ones" bid
+    */
+  final case class Bid(quantity: Int, face: Option[Int]) {
+
+    /** True for a wild "ones" bid (no numbered face). */
+    def isOnes: Boolean = face.isEmpty
+
+    /** The bid's clockwise position on the track. A numbered space `q` sits at `2q`; a "k ones" space sits at `4k - 1`,
+      * between odd quantity `2k - 1` and even quantity `2k`, so the two kinds of space interleave in track order.
+      */
+    def spaceRank: Int = if (isOnes) 4 * quantity - 1 else 2 * quantity
+
+    /** A well-formed bid names a positive quantity and, if numbered, a face of 2–6. */
+    def isWellFormed: Boolean = quantity >= 1 && face.forall(f => f >= 2 && f <= 6)
+
+    /** Whether raising from this bid to `next` is a legal move on the track:
+      *   - numbered → numbered: the same quantity needs a strictly higher face; a higher quantity may keep or raise the
+      *     face but never lower it
+      *   - numbered → ones, or ones → ones: any clockwise-later space (a "ones" space is always reachable, face-free)
+      *   - ones → numbered: any face, provided the quantity reaches the number printed after the ones space
+      *     (`quantity >= 2k`, which `spaceRank` encodes)
+      */
+    def canRaiseTo(next: Bid): Boolean = (face, next.face) match {
+      case (Some(f), Some(nf)) =>
+        if (next.quantity == quantity) nf > f
+        else if (next.quantity > quantity) nf >= f
+        else false
+      case (Some(_), None) => next.spaceRank > spaceRank
+      case (None, Some(_)) => next.spaceRank > spaceRank
+      case (None, None)    => next.quantity > quantity
+    }
+  }
+
+  /** The current standing bid together with the seat that made it — the seat a losing challenge would penalize. */
+  final case class StandingBid(bid: Bid, bidderSeat: Int)
+
+  /** A snapshot of the most recently resolved challenge — the one moment every die is public.
+    *
+    * Retained in the game state so all viewers (and reconnecting clients) can see how the last round ended, even after
+    * the dice have been re-rolled for the next round.
+    *
+    * @param bid the bid that was challenged
+    * @param count the true number of dice counting toward `bid` (its face plus wild ones)
+    * @param allDice every seat's dice as revealed at the challenge, in seat order
+    * @param challengerSeat the seat that called "Liar"
+    * @param bidderSeat the seat whose bid was challenged
+    * @param loserSeat the seat that lost dice this round
+    * @param diceLost how many dice `loserSeat` lost (0 when a challenger meets the bid exactly)
+    */
+  final case class Reveal(
+      bid: Bid,
+      count: Int,
+      allDice: Vector[Vector[Int]],
+      challengerSeat: Int,
+      bidderSeat: Int,
+      loserSeat: Int,
+      diceLost: Int
+  )
+
+  /** A player action on their turn: raise the bid or call "Liar." */
+  sealed trait LiarsDiceMove
+
+  /** Raise (or open) the bidding with `bid`. */
+  final case class MakeBid(bid: Bid) extends LiarsDiceMove
+
+  /** Challenge the standing bid. `freshDice` is a flat pool of server-rolled dice the model deals out to the surviving
+    * hands for the next round, keeping the roll server-side so the model stays pure.
+    */
+  final case class Challenge(freshDice: List[Int]) extends LiarsDiceMove
+}

--- a/game-service-model/src/test/scala/com/andy327/model/liarsdice/LiarsDiceSpec.scala
+++ b/game-service-model/src/test/scala/com/andy327/model/liarsdice/LiarsDiceSpec.scala
@@ -1,0 +1,286 @@
+package com.andy327.model.liarsdice
+
+import java.util.UUID
+
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import com.andy327.model.core.GameError.{GameOver, InvalidTurn}
+import com.andy327.model.core.{InProgress, PlayerId, Won}
+
+class LiarsDiceSpec extends AnyWordSpec with Matchers with OptionValues {
+  val alice: PlayerId = UUID.randomUUID()
+  val bob: PlayerId = UUID.randomUUID()
+  val carol: PlayerId = UUID.randomUUID()
+
+  // A pool large enough to deal any hand; only the dealt prefixes ever matter, so exact values are set per test.
+  private val pool: List[Int] = List.fill(LiarsDice.MaxTotalDice)(2)
+
+  /** Builds a two-player game with explicit dice for each seat and no standing bid, seat 0 to act. */
+  private def game(seat0: Vector[Int], seat1: Vector[Int]): LiarsDice =
+    LiarsDice(Vector(alice, bob), Vector(seat0, seat1), 0, None, None, None, 0)
+
+  "A LiarsDice game" should {
+
+    "resolve participants to their seat indices with playerFor" in {
+      val g = game(Vector(2, 3), Vector(4, 5))
+      g.playerFor(alice) shouldBe Some(0)
+      g.playerFor(bob) shouldBe Some(1)
+      g.playerFor(UUID.randomUUID()) shouldBe None
+    }
+
+    "list its roster in seat order with players" in {
+      game(Vector(2, 3), Vector(4, 5)).players shouldBe List(alice, bob)
+    }
+
+    "start with a full hand, no standing bid, and the first player to move" in {
+      val g = LiarsDice.newGame(Seq(alice, bob), pool)
+      g.currentSeat shouldBe 0
+      g.currentPlayer shouldBe 0
+      g.standing shouldBe None
+      g.lastReveal shouldBe None
+      g.moveCount shouldBe 0
+      g.gameStatus shouldBe InProgress
+    }
+
+    "accept any well-formed opening bid and pass the turn" in {
+      val Right(next) = game(Vector(2, 3), Vector(4, 5)).play(0, MakeBid(Bid(2, Some(4))))
+      next.standing shouldBe Some(StandingBid(Bid(2, Some(4)), 0))
+      next.currentSeat shouldBe 1
+      next.moveCount shouldBe 1
+    }
+
+    "reject a malformed bid" in {
+      game(Vector(2), Vector(3)).play(0, MakeBid(Bid(0, Some(4)))) shouldBe Left(InvalidBid)
+      game(Vector(2), Vector(3)).play(0, MakeBid(Bid(2, Some(7)))) shouldBe Left(InvalidBid)
+    }
+
+    "reject a challenge when there is no standing bid" in {
+      game(Vector(2), Vector(3)).play(0, Challenge(pool)) shouldBe Left(NoBidToChallenge)
+    }
+
+    "reject a move made out of turn" in {
+      game(Vector(2), Vector(3)).play(1, MakeBid(Bid(1, Some(2)))) shouldBe Left(InvalidTurn)
+    }
+
+    "accept a legal raise and reject an illegal one" in {
+      val g = game(Vector(2, 3), Vector(4, 5)).copy(standing = Some(StandingBid(Bid(2, Some(4)), 0)), currentSeat = 1)
+      g.play(1, MakeBid(Bid(2, Some(5)))).map(_.standing) shouldBe Right(Some(StandingBid(Bid(2, Some(5)), 1)))
+      g.play(1, MakeBid(Bid(2, Some(3)))) shouldBe Left(IllegalRaise)
+    }
+
+    "penalise the challenger by the overshoot when the bid is good" in {
+      // bid "3 fours"; dice hold four 4s and one 1 => count 5, overshoot 2, so the challenger (seat 1) loses 2 dice
+      val g = game(Vector(4, 4, 4), Vector(4, 1))
+        .copy(standing = Some(StandingBid(Bid(3, Some(4)), 0)), currentSeat = 1)
+      val Right(next) = g.play(1, Challenge(pool))
+      val reveal = next.lastReveal.value
+      reveal.count shouldBe 5
+      reveal.loserSeat shouldBe 1
+      reveal.diceLost shouldBe 2
+      next.diceCount(0) shouldBe 3
+      next.diceCount(1) shouldBe 0 // eliminated (had 2, lost 2)
+      next.gameStatus shouldBe Won(0)
+    }
+
+    "penalise the bidder a single die when the bid is too high" in {
+      // bid "4 sixes"; only one 6 and no wild 1s => count 1 < 4, so the bidder (seat 0) loses one die
+      val g = game(Vector(6, 2, 3), Vector(2, 2, 3))
+        .copy(standing = Some(StandingBid(Bid(4, Some(6)), 0)), currentSeat = 1)
+      val Right(next) = g.play(1, Challenge(List.fill(LiarsDice.MaxTotalDice)(2)))
+      next.lastReveal.value.loserSeat shouldBe 0
+      next.lastReveal.value.diceLost shouldBe 1
+      next.diceCount(0) shouldBe 2
+      next.diceCount(1) shouldBe 3
+      next.currentSeat shouldBe 0 // the loser starts the next round
+      next.standing shouldBe None
+      next.gameStatus shouldBe InProgress
+    }
+
+    "cost the challenger no dice when the count meets the bid exactly" in {
+      // bid "2 fours"; exactly two 4s => count 2 == quantity, so the challenger loses zero dice but still loses the round
+      val g = game(Vector(4, 2, 3), Vector(4, 5, 6))
+        .copy(standing = Some(StandingBid(Bid(2, Some(4)), 0)), currentSeat = 1)
+      val Right(next) = g.play(1, Challenge(pool))
+      next.lastReveal.value.diceLost shouldBe 0
+      next.lastReveal.value.loserSeat shouldBe 1
+      next.diceCount(1) shouldBe 3
+      next.currentSeat shouldBe 1 // the losing challenger starts the next round
+      next.gameStatus shouldBe InProgress
+    }
+
+    "re-roll every surviving hand from the supplied pool" in {
+      val g = game(Vector(6, 2), Vector(2, 3))
+        .copy(standing = Some(StandingBid(Bid(4, Some(6)), 0)), currentSeat = 1)
+      val Right(next) = g.play(1, Challenge(List.fill(LiarsDice.MaxTotalDice)(5)))
+      next.dice.flatten.forall(_ == 5) shouldBe true // fresh dice replaced the old hands
+      next.diceCount(0) shouldBe 1 // bidder lost one die
+      next.diceCount(1) shouldBe 2
+    }
+
+    "start the next round from the next active seat when the loser is eliminated" in {
+      // three players; the challenger (seat 2) is wrong and is eliminated, so seat 0 (clockwise from 2) starts
+      val g = LiarsDice(
+        Vector(alice, bob, carol),
+        Vector(Vector(4, 4, 4), Vector(4, 4, 4), Vector(2)),
+        2,
+        Some(StandingBid(Bid(4, Some(4)), 0)),
+        None,
+        None,
+        0
+      )
+      val Right(next) = g.play(2, Challenge(pool))
+      next.diceCount(2) shouldBe 0
+      next.currentSeat shouldBe 0
+      next.gameStatus shouldBe InProgress // two players remain
+    }
+
+    "skip an already-eliminated seat when advancing the turn, wrapping around the table" in {
+      // three players with seat 2 already out; seat 1 bids, so the turn skips the empty seat 2 and wraps to seat 0
+      val g =
+        LiarsDice(Vector(alice, bob, carol), Vector(Vector(2, 3), Vector(4, 5), Vector.empty), 1, None, None, None, 0)
+      val Right(next) = g.play(1, MakeBid(Bid(1, Some(2))))
+      next.currentSeat shouldBe 0
+    }
+
+    "reject any move once the game is over" in {
+      val finished = game(Vector(2), Vector(3)).copy(winner = Some(0))
+      finished.play(0, MakeBid(Bid(1, Some(2)))) shouldBe Left(GameOver)
+      finished.play(0, Challenge(pool)) shouldBe Left(GameOver)
+    }
+  }
+
+  "A LiarsDice Bid" should {
+
+    "allow a higher face on the same quantity" in {
+      Bid(3, Some(4)).canRaiseTo(Bid(3, Some(5))) shouldBe true
+      Bid(3, Some(4)).canRaiseTo(Bid(3, Some(6))) shouldBe true
+    }
+
+    "reject the same or a lower face on the same quantity" in {
+      Bid(3, Some(4)).canRaiseTo(Bid(3, Some(4))) shouldBe false
+      Bid(3, Some(4)).canRaiseTo(Bid(3, Some(3))) shouldBe false
+    }
+
+    "allow a higher quantity only if the face is not lowered" in {
+      Bid(3, Some(4)).canRaiseTo(Bid(4, Some(4))) shouldBe true
+      Bid(3, Some(4)).canRaiseTo(Bid(4, Some(5))) shouldBe true
+      Bid(3, Some(4)).canRaiseTo(Bid(4, Some(3))) shouldBe false // higher quantity, lower face
+    }
+
+    "reject a lower quantity (counter-clockwise)" in {
+      Bid(4, Some(4)).canRaiseTo(Bid(3, Some(6))) shouldBe false
+    }
+
+    "allow advancing to any clockwise-later ones space, but not an earlier one" in {
+      // "3 fours" sits at rank 6; "2 ones" sits at rank 7 (clockwise-later); "1 one" sits at rank 3 (earlier)
+      Bid(3, Some(4)).canRaiseTo(Bid(2, None)) shouldBe true
+      Bid(3, Some(4)).canRaiseTo(Bid(1, None)) shouldBe false
+    }
+
+    "allow leaving a ones bid to any face once the quantity reaches the following number" in {
+      // out of "1 one" the smallest numbered bid is 2 of any face
+      Bid(1, None).canRaiseTo(Bid(2, Some(2))) shouldBe true
+      Bid(1, None).canRaiseTo(Bid(2, Some(6))) shouldBe true
+      Bid(1, None).canRaiseTo(Bid(1, Some(6))) shouldBe false // quantity 1 is before the ones space
+    }
+
+    "order ones bids by their count" in {
+      Bid(1, None).canRaiseTo(Bid(2, None)) shouldBe true
+      Bid(2, None).canRaiseTo(Bid(1, None)) shouldBe false
+    }
+
+    "match the worked example from the rules (3 fours)" in {
+      val from = Bid(3, Some(4))
+      val legal = Seq(Bid(3, Some(5)), Bid(3, Some(6)), Bid(2, None), Bid(4, Some(4)), Bid(4, Some(5)), Bid(4, Some(6)))
+      legal.foreach(b => withClue(b)(from.canRaiseTo(b) shouldBe true))
+      from.canRaiseTo(Bid(4, Some(3))) shouldBe false // "4 threes" is explicitly illegal
+    }
+  }
+
+  "A leaving player" should {
+
+    "award the win to the last remaining player" in {
+      game(Vector(2, 3), Vector(4, 5)).playerLeft(alice).map(_.gameStatus) shouldBe Right(Won(1))
+      game(Vector(2, 3), Vector(4, 5)).playerLeft(bob).map(_.gameStatus) shouldBe Right(Won(0))
+    }
+
+    "keep a multiplayer game going, clearing the bid and advancing off a leaver who was on the clock" in {
+      val g = LiarsDice(
+        Vector(alice, bob, carol),
+        Vector(Vector(2, 3), Vector(4, 5), Vector(6, 1)),
+        0,
+        Some(StandingBid(Bid(1, Some(2)), 2)),
+        None,
+        None,
+        3
+      )
+      val Right(next) = g.playerLeft(alice)
+      next.diceCount(0) shouldBe 0
+      next.standing shouldBe None
+      next.currentSeat shouldBe 1 // advanced off the leaving seat
+      next.gameStatus shouldBe InProgress
+    }
+
+    "leave the turn unchanged when the leaver was not on the clock" in {
+      // seat 1 is to act; seat 2 leaves, so the turn stays on seat 1 (only the leaver's dice are set aside)
+      val g = LiarsDice(
+        Vector(alice, bob, carol),
+        Vector(Vector(2, 3), Vector(4, 5), Vector(6, 1)),
+        1,
+        Some(StandingBid(Bid(1, Some(2)), 0)),
+        None,
+        None,
+        3
+      )
+      val Right(next) = g.playerLeft(carol)
+      next.diceCount(2) shouldBe 0
+      next.currentSeat shouldBe 1 // unchanged — the leaver was not the current player
+      next.gameStatus shouldBe InProgress
+    }
+
+    "be rejected for a non-participant" in {
+      game(Vector(2), Vector(3)).playerLeft(UUID.randomUUID()) shouldBe a[Left[_, _]]
+    }
+
+    "be rejected once the game is over" in {
+      game(Vector(2), Vector(3)).copy(winner = Some(0)).playerLeft(bob) shouldBe Left(GameOver)
+    }
+  }
+
+  "LiarsDice.newGame" should {
+
+    "deal every player five dice and seat player one to open" in {
+      val g = LiarsDice.newGame(Seq(alice, bob, carol), List.fill(LiarsDice.MaxTotalDice)(3))
+      g.dice.map(_.size) shouldBe Vector(5, 5, 5)
+      g.dice.flatten.forall(_ == 3) shouldBe true
+      g.currentSeat shouldBe 0
+    }
+
+    "seat players in the order provided" in {
+      val g = LiarsDice.newGame(Seq(alice, bob, carol), pool)
+      g.playerFor(alice) shouldBe Some(0)
+      g.playerFor(bob) shouldBe Some(1)
+      g.playerFor(carol) shouldBe Some(2)
+    }
+
+    "support up to six players" in {
+      val players = Seq.fill(6)(UUID.randomUUID())
+      val g = LiarsDice.newGame(players, pool)
+      g.playerIds.size shouldBe 6
+      g.dice.map(_.size) shouldBe Vector.fill(6)(LiarsDice.DicePerPlayer)
+    }
+  }
+
+  "LiarsDice.countToward" should {
+
+    "count the named face plus wild ones for a numbered bid" in {
+      LiarsDice.countToward(Bid(1, Some(4)), Vector(Vector(4, 1, 2), Vector(4, 1, 6))) shouldBe 4 // two 4s, two 1s
+    }
+
+    "count only the ones for a wild ones bid" in {
+      LiarsDice.countToward(Bid(1, None), Vector(Vector(4, 1, 2), Vector(1, 1, 6))) shouldBe 3
+    }
+  }
+}

--- a/game-service-persistence/src/main/scala/com/andy327/persistence/db/schema/GameTypeCodecs.scala
+++ b/game-service-persistence/src/main/scala/com/andy327/persistence/db/schema/GameTypeCodecs.scala
@@ -8,6 +8,7 @@ import io.circe.{Codec, Decoder, Encoder}
 import com.andy327.model.battleship.{Battleship, Coord, Player1, Player2, PlayerBoard, Seat, Ship}
 import com.andy327.model.connectfour.{ConnectFour, Mark => ConnectFourMark, Red, Yellow}
 import com.andy327.model.core.{Game, GameType}
+import com.andy327.model.liarsdice.{Bid, LiarsDice, Reveal, StandingBid}
 import com.andy327.model.mastermind.{Attempt, Codebreaker, Codemaker, Feedback, Mastermind, Peg, Role}
 import com.andy327.model.pig.Pig
 import com.andy327.model.tictactoe.{Mark, O, TicTacToe, X}
@@ -27,6 +28,7 @@ object GameTypeCodecs {
       case "Battleship"  => Right(GameType.Battleship)
       case "Pig"         => Right(GameType.Pig)
       case "Mastermind"  => Right(GameType.Mastermind)
+      case "LiarsDice"   => Right(GameType.LiarsDice)
       case other         => Left(s"Unknown GameType: $other")
     },
     Encoder.encodeString.contramap[GameType] {
@@ -35,6 +37,7 @@ object GameTypeCodecs {
       case GameType.Battleship  => "Battleship"
       case GameType.Pig         => "Pig"
       case GameType.Mastermind  => "Mastermind"
+      case GameType.LiarsDice   => "LiarsDice"
     }
   )
 
@@ -95,6 +98,13 @@ object GameTypeCodecs {
   implicit val attemptCodec: Codec[Attempt] = deriveCodec[Attempt]
   implicit val mastermindCodec: Codec[Mastermind] = deriveCodec[Mastermind]
 
+  // Declared in dependency order so each is in scope for the deriveCodec that needs it. A Bid's optional `face`
+  // (absent for a wild "ones" bid) round-trips as a nullable JSON field.
+  implicit val bidCodec: Codec[Bid] = deriveCodec[Bid]
+  implicit val standingBidCodec: Codec[StandingBid] = deriveCodec[StandingBid]
+  implicit val revealCodec: Codec[Reveal] = deriveCodec[Reveal]
+  implicit val liarsDiceCodec: Codec[LiarsDice] = deriveCodec[LiarsDice]
+
   /** Serializes a game instance to a JSON string using the codec for the given GameType. */
   def serializeGame(gameType: GameType, game: Game[_, _, _, _, _]): String = gameType match {
     case GameType.TicTacToe   => game.asInstanceOf[TicTacToe].asJson.noSpaces
@@ -102,6 +112,7 @@ object GameTypeCodecs {
     case GameType.Battleship  => game.asInstanceOf[Battleship].asJson.noSpaces
     case GameType.Pig         => game.asInstanceOf[Pig].asJson.noSpaces
     case GameType.Mastermind  => game.asInstanceOf[Mastermind].asJson.noSpaces
+    case GameType.LiarsDice   => game.asInstanceOf[LiarsDice].asJson.noSpaces
   }
 
   /** Deserializes a game state JSON string into a Game instance based on the provided GameType. */
@@ -112,5 +123,6 @@ object GameTypeCodecs {
       case GameType.Battleship  => decode[Battleship](json).left.map(err => new Exception(err))
       case GameType.Pig         => decode[Pig](json).left.map(err => new Exception(err))
       case GameType.Mastermind  => decode[Mastermind](json).left.map(err => new Exception(err))
+      case GameType.LiarsDice   => decode[LiarsDice](json).left.map(err => new Exception(err))
     }
 }

--- a/game-service-persistence/src/test/scala/com/andy327/persistence/db/schema/GameTypeCodecsSpec.scala
+++ b/game-service-persistence/src/test/scala/com/andy327/persistence/db/schema/GameTypeCodecsSpec.scala
@@ -12,6 +12,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import com.andy327.model.battleship.{Battleship, Coord, Fire, Player1, Player2, PlayerBoard, Ship}
 import com.andy327.model.connectfour.{ConnectFour, Drop, Red}
 import com.andy327.model.core.{GameType, PlayerId}
+import com.andy327.model.liarsdice.{Bid, Challenge, LiarsDice, MakeBid, StandingBid}
 import com.andy327.model.mastermind.Peg.{Blue, Green, Red => MmRed, Yellow}
 import com.andy327.model.mastermind.{Codebreaker, Codemaker, Guess, Mastermind, SetCode}
 import com.andy327.model.pig.Pig
@@ -228,6 +229,42 @@ class GameTypeCodecsSpec extends AnyWordSpec with Matchers {
 
     "return Left if Mastermind game JSON is invalid" in {
       deserializeGame(GameType.Mastermind, """{ "not": "valid" }""").isLeft shouldBe true
+    }
+
+    "resolve liarsdice via GameType.fromString" in {
+      GameType.fromString("liarsdice") shouldBe Some(GameType.LiarsDice)
+    }
+
+    "correctly encode and decode GameType.LiarsDice" in {
+      val t: GameType = GameType.LiarsDice
+      val json = t.asJson.noSpaces
+      json shouldBe "\"LiarsDice\""
+      decode[GameType](json) shouldBe Right(GameType.LiarsDice)
+    }
+
+    "round-trip a Liar's Dice game through serializeGame and deserializeGame" in {
+      // open with a numbered bid, then a wild "ones" bid, then a challenge, so the round-trip exercises the Bid
+      // (with and without a face), StandingBid, and Reveal codecs
+      val game = LiarsDice
+        .newGame(Seq(alice, bob), List.fill(LiarsDice.MaxTotalDice)(4))
+        .play(0, MakeBid(Bid(2, Some(4))))
+        .flatMap(_.play(1, MakeBid(Bid(2, None)))) // "2 ones" is the next clockwise ones space after "2 fours"
+        .flatMap(_.play(0, Challenge(List.fill(LiarsDice.MaxTotalDice)(3))))
+        .toOption
+        .get
+      val json = serializeGame(GameType.LiarsDice, game)
+      deserializeGame(GameType.LiarsDice, json) shouldBe Right(game)
+    }
+
+    "round-trip a finished Liar's Dice game with a standing bid still present" in {
+      val game = LiarsDice.newGame(Seq(alice, bob), List.fill(LiarsDice.MaxTotalDice)(6))
+        .copy(standing = Some(StandingBid(Bid(3, Some(5)), 0)), winner = Some(1))
+      val json = serializeGame(GameType.LiarsDice, game)
+      deserializeGame(GameType.LiarsDice, json) shouldBe Right(game)
+    }
+
+    "return Left if Liar's Dice game JSON is invalid" in {
+      deserializeGame(GameType.LiarsDice, """{ "not": "valid" }""").isLeft shouldBe true
     }
   }
 }

--- a/game-service-server/src/main/resources/web/app.js
+++ b/game-service-server/src/main/resources/web/app.js
@@ -26,7 +26,8 @@ const GAMES = {
   connectfour: { label: "Connect Four", maxPlayers: 2, move: (row, col) => ({ col }), columns: true },
   battleship:  { label: "Battleship",   maxPlayers: 2, move: (row, col) => ({ row, col }) },
   pig:         { label: "Pig",          maxPlayers: 8, pig: true },
-  mastermind:  { label: "Mastermind",   maxPlayers: 2, mastermind: true }
+  mastermind:  { label: "Mastermind",   maxPlayers: 2, mastermind: true },
+  liarsdice:   { label: "Liar's Dice",  maxPlayers: 6, liarsdice: true }
 };
 
 const $ = (id) => document.getElementById(id);
@@ -723,6 +724,7 @@ function renderBoard(state) {
   $("post-game-bar").classList.add("hidden");
   $("rematch-btn").classList.add("hidden");
   setError("game-error", "");
+  $("board").classList.remove("ld-active"); // cleared here so switching away from Liar's Dice restores the board grid
 
   if (state.board1 !== undefined) {
     renderBattleshipBoard(state);
@@ -736,6 +738,11 @@ function renderBoard(state) {
 
   if (state.guessesRemaining !== undefined) {
     renderMastermindBoard(state);
+    return;
+  }
+
+  if (state.diceCounts !== undefined) {
+    renderLiarsDiceBoard(state);
     return;
   }
 
@@ -1009,6 +1016,244 @@ function makeMmInput(action) {
   actions.appendChild(clear);
 
   wrap.appendChild(actions);
+  return wrap;
+}
+
+// Liar's Dice: each player hides five dice; on your turn you either raise the bid (a quantity + face over all dice on
+// the table, with 1s wild) or call "Liar". `state.dice` is only your own hand — other seats show just a count — until a
+// challenge reveals every die in `state.lastReveal`, the one public moment.
+// A die drawn as CSS pips — clearer and larger than a unicode glyph. `face` is 1–6; `opts.red` draws the bid marker
+// (white pips on red), `opts.small` a compact die for the reveal rows and the track marker.
+const LD_PIPS = { 1: [4], 2: [0, 8], 3: [0, 4, 8], 4: [0, 2, 6, 8], 5: [0, 2, 4, 6, 8], 6: [0, 2, 3, 5, 6, 8] };
+
+function makeLdDie(face, opts = {}) {
+  const die = document.createElement("span");
+  die.className = "ld-die" + (opts.red ? " ld-die-red" : "") + (opts.small ? " ld-die-sm" : "");
+  const pips = new Set(LD_PIPS[face] || []);
+  for (let i = 0; i < 9; i++) {
+    const cell = document.createElement("span");
+    cell.className = "ld-pipcell";
+    if (pips.has(i)) {
+      const dot = document.createElement("span");
+      dot.className = "ld-pip";
+      cell.appendChild(dot);
+    }
+    die.appendChild(cell);
+  }
+  return die;
+}
+
+// The bidding track in clockwise order: quantities 1–20 with a wild "k ones" space after each odd quantity 2k−1,
+// exactly where the physical mat prints them, so the ones spaces are visible in relation to the numbered ones.
+function ldTrackSpaces() {
+  const spaces = [];
+  for (let q = 1; q <= 20; q++) {
+    spaces.push({ kind: "num", quantity: q });
+    if (q % 2 === 1) spaces.push({ kind: "ones", quantity: (q + 1) / 2 });
+  }
+  return spaces; // 20 numbered + 10 ones = 30
+}
+
+// Perimeter cell positions for a 10×7 grid, clockwise from the top-left — 30 cells, one per track space, leaving the
+// interior free for the current-bid summary.
+function ldRingPositions() {
+  const W = 10, H = 7, pos = [];
+  for (let c = 1; c <= W; c++) pos.push({ r: 1, c }); // top, left → right
+  for (let r = 2; r <= H; r++) pos.push({ r, c: W }); // right, top → bottom
+  for (let c = W - 1; c >= 1; c--) pos.push({ r: H, c }); // bottom, right → left
+  for (let r = H - 1; r >= 2; r--) pos.push({ r, c: 1 }); // left, bottom → top
+  return pos;
+}
+
+// The track-space index the current bid sits on, or -1 when there is no standing bid.
+function ldCurrentSpaceIndex(spaces, bid) {
+  if (!bid) return -1;
+  const kind = bid.face == null ? "ones" : "num";
+  return spaces.findIndex((s) => s.kind === kind && s.quantity === bid.quantity);
+}
+
+// The Monopoly-style bidding-track ring, marking the current bid with a red die (its face for a numbered bid, a single
+// pip for a wild ones bid); the ring's centre carries the current-bid summary.
+function renderLdTrack(state) {
+  const spaces = ldTrackSpaces();
+  const positions = ldRingPositions();
+  const currentIndex = ldCurrentSpaceIndex(spaces, state.currentBid);
+
+  const track = document.createElement("div");
+  track.className = "ld-track";
+
+  spaces.forEach((space, i) => {
+    const cell = document.createElement("div");
+    cell.className = space.kind === "ones" ? "ld-space ld-space-ones" : "ld-space ld-space-num";
+    cell.style.gridColumn = String(positions[i].c);
+    cell.style.gridRow = String(positions[i].r);
+
+    const label = document.createElement("span");
+    label.className = "ld-space-label";
+    label.textContent = String(space.quantity);
+    cell.appendChild(label);
+    if (space.kind === "ones") {
+      const pip = document.createElement("span");
+      pip.className = "ld-onepip"; // marks a wild "ones" space
+      cell.appendChild(pip);
+    }
+
+    if (i === currentIndex) {
+      cell.classList.add("ld-space-current");
+      const face = state.currentBid.face == null ? 1 : state.currentBid.face;
+      const marker = makeLdDie(face, { red: true, small: true });
+      marker.classList.add("ld-marker");
+      cell.appendChild(marker);
+    }
+    track.appendChild(cell);
+  });
+
+  const center = document.createElement("div");
+  center.className = "ld-track-center";
+  center.textContent = state.currentBid ? `Current bid: ${formatLdBid(state.currentBid)}` : "No bid yet this round";
+  track.appendChild(center);
+
+  return track;
+}
+
+// "3 × 4s" for a numbered bid, "2 × ones" for a wild ones bid, or a dash when there is no bid.
+function formatLdBid(bid) {
+  if (!bid) return "—";
+  return bid.face == null ? `${bid.quantity} × ones` : `${bid.quantity} × ${bid.face}s`;
+}
+
+async function submitLiarsDiceMove(body) {
+  const game = session.game;
+  if (!game) return;
+  setError("game-error", "");
+  const res = await api(`/${game.gameType}/${game.roomId}/move`, { method: "POST", body });
+  if (!res.ok) flashError("game-error", res.data?.error || res.data || "Move rejected");
+}
+
+function renderLiarsDiceBoard(state) {
+  const board = $("board");
+  board.classList.remove("bs-active");
+  board.classList.add("ld-active"); // the bidding-track ring is wider than the default board grid; let it size freely
+  board.innerHTML = "";
+  $("column-controls").innerHTML = "";
+
+  const over = Boolean(state.winner);
+  const spectating = Boolean(session.game && session.game.isSpectator) || state.viewerSeat == null;
+  const myTurn = !over && !spectating && state.currentPlayer === state.viewerSeat;
+
+  if (over) setStatus(state.winner === state.viewerSeat ? "You win!" : `${state.winner} wins!`);
+  else if (spectating) setStatus(`Spectating — ${state.currentPlayer} to bid`);
+  else setStatus(myTurn ? "Your turn — raise or call Liar!" : `${state.currentPlayer}'s turn…`);
+
+  // The bidding-track ring, with a red die on the current bid's space.
+  board.appendChild(renderLdTrack(state));
+
+  // Last challenge reveal: the one moment every cup comes up — show the bid, the true count, who lost, and all hands.
+  if (state.lastReveal) {
+    const r = state.lastReveal;
+    const box = document.createElement("div");
+    box.className = "ld-reveal";
+    const summary = document.createElement("p");
+    summary.className = "ld-reveal-summary";
+    const lost = r.diceLost === 0 ? "no dice" : `${r.diceLost} ${r.diceLost === 1 ? "die" : "dice"}`;
+    summary.textContent =
+      `${r.challenger} called Liar on ${r.bidder}'s ${formatLdBid(r.bid)} — ` +
+      `count was ${r.count}. ${r.loser} lost ${lost}.`;
+    box.appendChild(summary);
+    Object.keys(r.dice).sort().forEach((seat) => {
+      const row = document.createElement("div");
+      row.className = "ld-row";
+      const label = document.createElement("span");
+      label.className = "ld-seat";
+      label.textContent = seat;
+      row.appendChild(label);
+      r.dice[seat].forEach((d) => row.appendChild(makeLdDie(d)));
+      box.appendChild(row);
+    });
+    board.appendChild(box);
+  }
+
+  // Dice remaining per seat, highlighting whose turn it is.
+  const table = document.createElement("table");
+  table.className = "ld-counts";
+  const header = table.insertRow();
+  header.innerHTML = "<th>Player</th><th>Dice</th>";
+  Object.keys(state.diceCounts).sort().forEach((seat) => {
+    const row = table.insertRow();
+    row.className = seat === state.currentPlayer && !over ? "ld-current" : "";
+    const you = seat === state.viewerSeat ? " (you)" : "";
+    const out = state.diceCounts[seat] === 0 ? " — out" : "";
+    row.innerHTML = `<td>${seat}${you}${out}</td><td>${state.diceCounts[seat]}</td>`;
+  });
+  board.appendChild(table);
+
+  // The viewer's own hidden hand.
+  if (state.dice) {
+    const hand = document.createElement("div");
+    hand.className = "ld-row ld-hand";
+    const label = document.createElement("span");
+    label.className = "ld-seat";
+    label.textContent = "Your dice:";
+    hand.appendChild(label);
+    state.dice.forEach((d) => hand.appendChild(makeLdDie(d)));
+    board.appendChild(hand);
+  }
+
+  if (myTurn) board.appendChild(makeLdControls(state));
+}
+
+// The free-form bid input: a quantity, a face (2–6 or wild ones), a Bid button, and a Call Liar button. The server
+// validates each raise against the bidding track and rejects an illegal one, surfaced as an error.
+function makeLdControls(state) {
+  const wrap = document.createElement("div");
+  wrap.className = "ld-controls";
+
+  const bidRow = document.createElement("div");
+  bidRow.className = "row ld-bid-row";
+
+  const qty = document.createElement("input");
+  qty.type = "number";
+  qty.min = "1";
+  qty.value = state.currentBid ? String(state.currentBid.quantity) : "1";
+  qty.className = "ld-qty";
+  bidRow.appendChild(qty);
+
+  const face = document.createElement("select");
+  face.className = "ld-face";
+  [2, 3, 4, 5, 6].forEach((f) => {
+    const opt = document.createElement("option");
+    opt.value = String(f);
+    opt.textContent = `${f}s`;
+    face.appendChild(opt);
+  });
+  const onesOpt = document.createElement("option");
+  onesOpt.value = "ones";
+  onesOpt.textContent = "ones (wild)";
+  face.appendChild(onesOpt);
+  if (state.currentBid && state.currentBid.face != null) face.value = String(state.currentBid.face);
+  bidRow.appendChild(face);
+
+  const bidBtn = document.createElement("button");
+  bidBtn.textContent = "Bid";
+  bidBtn.onclick = () => {
+    const quantity = parseInt(qty.value, 10);
+    if (!Number.isInteger(quantity) || quantity < 1) {
+      flashError("game-error", "Enter a valid quantity.");
+      return;
+    }
+    const f = face.value === "ones" ? null : parseInt(face.value, 10);
+    submitLiarsDiceMove({ action: "bid", quantity, face: f });
+  };
+  bidRow.appendChild(bidBtn);
+  wrap.appendChild(bidRow);
+
+  const challenge = document.createElement("button");
+  challenge.className = "ld-challenge";
+  challenge.textContent = "Call Liar!";
+  challenge.disabled = !state.currentBid; // the opening move of a round must be a bid
+  challenge.onclick = () => submitLiarsDiceMove({ action: "challenge" });
+  wrap.appendChild(challenge);
+
   return wrap;
 }
 

--- a/game-service-server/src/main/resources/web/index.html
+++ b/game-service-server/src/main/resources/web/index.html
@@ -56,6 +56,7 @@
       <button data-gametype="battleship">Battleship</button>
       <button data-gametype="pig">Pig</button>
       <button data-gametype="mastermind">Mastermind</button>
+      <button data-gametype="liarsdice">Liar's Dice</button>
     </div>
 
     <h3>Your games &amp; lobbies</h3>
@@ -72,6 +73,7 @@
         <option value="battleship">Battleship</option>
         <option value="pig">Pig</option>
         <option value="mastermind">Mastermind</option>
+        <option value="liarsdice">Liar's Dice</option>
       </select>
     </div>
     <ul id="lobby-list"></ul>

--- a/game-service-server/src/main/resources/web/style.css
+++ b/game-service-server/src/main/resources/web/style.css
@@ -318,3 +318,89 @@ button:disabled { opacity: 0.5; cursor: default; }
 .mm-input { margin-top: 0.75rem; }
 .mm-palette { gap: 0.4rem; }
 .mm-actions { margin-top: 0.5rem; }
+
+/* Liar's Dice: a bidding-track ring, a per-seat dice-count table, the viewer's own hand, and the challenge reveal. */
+.ld-row { display: flex; align-items: center; gap: 0.4rem; margin: 0.3rem 0; }
+.ld-seat { color: var(--muted); font-size: 0.9rem; min-width: 4.5rem; }
+
+/* Dice drawn as CSS pips: a 3×3 grid with dots at the face's positions. */
+.ld-die {
+  display: inline-grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  width: 2.2rem;
+  height: 2.2rem;
+  padding: 3px;
+  box-sizing: border-box;
+  background: #f5f7fa;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  vertical-align: middle;
+}
+.ld-die-sm { width: 1.5rem; height: 1.5rem; padding: 2px; border-radius: 4px; }
+.ld-pipcell { display: flex; align-items: center; justify-content: center; }
+.ld-pip { width: 42%; height: 42%; border-radius: 50%; background: #14171c; }
+.ld-die-red { background: #c0272d; border-color: #7f1a1e; }
+.ld-die-red .ld-pip { background: #ffffff; }
+
+/* Liar's Dice content (the track ring especially) is wider than the default 360px board grid, so free the board up. */
+#board.ld-active { display: block; max-width: none; }
+
+/* The Monopoly-style bidding-track ring: 30 spaces around a 10×7 grid, with the current bid marked by a red die. */
+.ld-track {
+  display: grid;
+  grid-template-columns: repeat(10, 2.2rem);
+  grid-template-rows: repeat(7, 2.2rem);
+  gap: 3px;
+  width: max-content;
+  margin: 0 auto 1rem;
+}
+.ld-space {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  font-weight: 700;
+  font-size: 0.85rem;
+}
+.ld-space-num { background: var(--panel); color: var(--text); }
+.ld-space-ones { background: #14171c; color: #f5f7fa; border-color: #4a5568; }
+.ld-onepip { width: 0.28rem; height: 0.28rem; border-radius: 50%; background: #f5f7fa; margin-top: 2px; }
+.ld-space-current { outline: 2px solid var(--accent); z-index: 1; }
+.ld-marker { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); }
+.ld-track-center {
+  grid-column: 2 / 10;
+  grid-row: 2 / 7;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 0.5rem;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.ld-counts { border-collapse: collapse; margin: 0.5rem 0; }
+.ld-counts th, .ld-counts td { padding: 0.25rem 0.9rem; text-align: left; border-bottom: 1px solid var(--line); }
+.ld-counts th { color: var(--muted); font-weight: 600; }
+.ld-current { background: var(--accent-dim); }
+
+.ld-hand { margin-top: 0.5rem; }
+
+.ld-reveal {
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.75rem;
+}
+.ld-reveal-summary { margin: 0 0 0.4rem; font-size: 0.9rem; }
+
+.ld-controls { margin-top: 0.75rem; }
+.ld-bid-row { gap: 0.5rem; align-items: center; }
+.ld-qty { width: 4rem; }
+.ld-challenge { margin-top: 0.5rem; background: #8b1a1a; border-color: #a52020; }
+.ld-challenge:hover:not(:disabled) { background: #a52020; }

--- a/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
@@ -146,6 +146,7 @@ object GameServer {
       new GameRoutes(GameType.Battleship, system).routes,
       new GameRoutes(GameType.Pig, system).routes,
       new GameRoutes(GameType.Mastermind, system).routes,
+      new GameRoutes(GameType.LiarsDice, system).routes,
       new WebSocketRoutes(system).routes,
       new TraceRoutes(system).routes,
       new MetricsRoutes(metricsRegistry).routes,

--- a/game-service-server/src/main/scala/com/andy327/server/analytics/GameMetrics.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/analytics/GameMetrics.scala
@@ -71,5 +71,6 @@ class GameMetrics(registry: CollectorRegistry) {
     case GameType.Battleship  => "battleship"
     case GameType.Pig         => "pig"
     case GameType.Mastermind  => "mastermind"
+    case GameType.LiarsDice   => "liarsdice"
   }
 }

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -22,7 +22,17 @@ import com.andy327.actor.core.GameManager.{
 }
 import com.andy327.actor.core.LobbyManager.LobbySummary
 import com.andy327.actor.core.PlayerEvent
-import com.andy327.actor.game.{BattleshipState, GameState, GridGameState, GuessResult, MastermindState, PigState}
+import com.andy327.actor.game.{
+  BattleshipState,
+  BidView,
+  GameState,
+  GridGameState,
+  GuessResult,
+  LiarsDiceState,
+  MastermindState,
+  PigState,
+  RevealView
+}
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyCodecs, LobbyMetadata, Player}
 import com.andy327.actor.tracing.TraceEvent
 import com.andy327.persistence.db.MoveRecord
@@ -118,14 +128,22 @@ object JsonProtocol extends CirceSupport {
 
   implicit val mastermindStateCodec: Codec[MastermindState] = deriveCodec[MastermindState]
 
-  /** Encoder for the polymorphic `GameState` hierarchy (grid games share `GridGameState`;
-    * Battleship has its own per-viewer `BattleshipState`; Pig has `PigState`; Mastermind has `MastermindState`).
+  implicit val bidViewCodec: Codec[BidView] = deriveCodec[BidView]
+
+  implicit val revealViewCodec: Codec[RevealView] = deriveCodec[RevealView]
+
+  implicit val liarsDiceStateCodec: Codec[LiarsDiceState] = deriveCodec[LiarsDiceState]
+
+  /** Encoder for the polymorphic `GameState` hierarchy (grid games share `GridGameState`; Battleship has its own
+    * per-viewer `BattleshipState`; Pig has `PigState`; Mastermind has `MastermindState`; Liar's Dice has
+    * `LiarsDiceState`).
     */
   implicit val gameStateEncoder: Encoder[GameState] = Encoder.instance {
     case s: GridGameState   => s.asJson
     case s: BattleshipState => s.asJson
     case s: PigState        => s.asJson
     case s: MastermindState => s.asJson
+    case s: LiarsDiceState  => s.asJson
   }
 
   // Entity unmarshallers, declared per-type so they don't shadow the predefined `String` unmarshaller (see

--- a/game-service-server/src/test/scala/com/andy327/server/analytics/GameMetricsSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/analytics/GameMetricsSpec.scala
@@ -79,6 +79,13 @@ class GameMetricsSpec extends AnyWordSpec with Matchers {
       sample(registry, "games_started_total", Array("game_type"), Array("mastermind")) shouldBe Some(1.0)
     }
 
+    "label Liar's Dice events with the liarsdice game type" in {
+      val (registry, metrics) = fixture
+      metrics.record(GameStarted(UUID.randomUUID(), GameType.LiarsDice, 4))
+
+      sample(registry, "games_started_total", Array("game_type"), Array("liarsdice")) shouldBe Some(1.0)
+    }
+
     "label lobby chat as lobby and in-game chat by game type" in {
       val (registry, metrics) = fixture
       metrics.record(ChatSent(UUID.randomUUID(), Some(GameType.Battleship)))

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -21,10 +21,12 @@ import com.andy327.actor.core.GameManager.{
 import com.andy327.actor.core.PlayerEvent
 import com.andy327.actor.game.{
   BattleshipState,
+  BidView,
   GameState,
   GameStateConverters,
   GridGameState,
   GuessResult,
+  LiarsDiceState,
   MastermindState,
   PigState
 }
@@ -161,6 +163,22 @@ class SerializationSpec extends AnyWordSpec with Matchers {
       val json = state.asJson
       json.hcursor.downField("guesses").focus should be(defined)
       json.hcursor.get[String]("currentPlayer") shouldBe Right("codebreaker")
+    }
+
+    "encode a LiarsDiceState branch, keeping the viewer's dice and a wild-ones bid's absent face" in {
+      val state: GameState = LiarsDiceState(
+        dice = Some(List(2, 3, 4, 5, 6)),
+        diceCounts = Map("P1" -> 5, "P2" -> 5),
+        currentBid = Some(BidView(2, None)), // a wild "ones" bid: face is absent
+        currentPlayer = "P1",
+        winner = None,
+        viewerSeat = Some("P1"),
+        lastReveal = None
+      )
+      val json = state.asJson
+      json.hcursor.get[List[Int]]("dice") shouldBe Right(List(2, 3, 4, 5, 6))
+      json.hcursor.get[String]("currentPlayer") shouldBe Right("P1")
+      json.hcursor.downField("currentBid").get[Option[Int]]("face") shouldBe Right(None)
     }
   }
 


### PR DESCRIPTION
Adds Liar's Dice — the "Wild Ones" house ruleset — as the sixth game type. It's the first game that is multiplayer *and* hidden-information with per-round elimination, exercising Pig's server-rolled-dice/pure-model path and Battleship/Mastermind's per-viewer projection at once, and it's a deliberate bridge toward Hold 'Em's turn structure.

### Rules
- 2–6 players, five dice each; last player holding dice wins. Lose a round, lose a die; out at zero.
- A bid names a quantity and a face over all dice on the table, with **1s wild**. Raises follow the printed bidding track: same quantity needs a higher face, a higher quantity may not lower the face, and the wild "ones" spaces (a "k ones" space after odd quantity `2k−1`) are the only way to reset the face.
- On your turn you either raise or call "Liar". A challenge reveals every die: if the true count meets or beats the bid the challenger loses one die per die of overshoot (none on an exact meet); otherwise the bidder loses one die. The round's loser opens the next round.

### Design
- **Pure model, server-rolled dice.** The model never calls a random source: the opening hands are rolled in `LiarsDiceActor`'s factory, and each round's re-roll rides in the `Challenge` move as a flat pool the model deals to the survivors.
- **Per-viewer projection.** `LiarsDiceState` shows the viewer only their own dice plus every seat's count; the `lastReveal` snapshot carries all hands from the last challenge — the one public moment — and survives into the next round for reconnects and spectators.
- **Public move log stays honest.** The move-log encoder records a bid's quantity and face but never a challenge's dice pool.

### Scope
Per the house rules as agreed: no "exact/spot-on" call (only Bid / Challenge), and the two-players-one-die-each combined-total endgame is intentionally omitted — common-hand bidding continues to the end.

### Touch points
model `liarsdice/` + `GameType`/`GameTypeTag`; persistence `GameTypeCodecs`; actor `MovePayload`/`GameState`/`LiarsDiceActor`/`LiarsDiceModule`/`GameRegistry`; server `JsonProtocol`/`GameServer`/`GameMetrics`; web UI + README.

### Testing
`scalafmtCheckAll`, `scalafixAll --check`, full `test`, and `doc` all clean. New specs cover the model rules and bidding track, the codecs, the module and per-viewer projection, the move-log encoder (including that a challenge omits its dice pool), and the JSON/metrics wiring.

Closes #24.