### PR TITLE
Add Texas Hold 'Em game

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Although it runs as a single instance today, the system is **designed for horizo
 - 🔐 Credentialed accounts — register, log in, and change password (Argon2-hashed), issuing expiring JWTs for player actions
 - 🏛️ Full lobby lifecycle — create, join, leave, list, and start matches
 - 🔁 Post-game rooms — a finished match keeps its room alive for chat, and the host can start a same-roster rematch; idle/empty rooms are evicted automatically
-- 🎲 Multiple game types — Tic-Tac-Toe, Connect Four, Battleship, Pig, Mastermind, and Liar's Dice
+- 🎲 Multiple game types — Tic-Tac-Toe, Connect Four, Battleship, Pig, Mastermind, Liar's Dice, and Texas Hold 'Em
 - ✅ Server-side move validation (turn order and legality enforced by the game model)
 - ⚡ Real-time state delivery to all participants over WebSockets
 - 🌫️ Per-viewer / fog-of-war state projection for hidden-information games and spectators
@@ -162,7 +162,7 @@ The response is the updated board, and every connected participant is pushed the
 
 ## API reference
 
-All gameplay endpoints require a `Authorization: Bearer <jwt>` header; obtain a token from `/auth/register` or `/auth/token`. Paths with a `{gameType}` segment accept `tictactoe`, `connectfour`, or `battleship`.
+All gameplay endpoints require a `Authorization: Bearer <jwt>` header; obtain a token from `/auth/register` or `/auth/token`. Paths with a `{gameType}` segment accept `tictactoe`, `connectfour`, `battleship`, `pig`, `mastermind`, `liarsdice`, or `texasholdem`.
 
 ### Auth
 
@@ -280,7 +280,7 @@ On startup `GameManager` doesn't accept traffic blindly — it kicks off an asyn
 
 ### Per-viewer projection (fog of war)
 
-A game actor never ships its raw internal state to anyone. When it needs to send state out — as a move reply or a push — it renders a **view** for a specific viewer through a `GameStateView` type class: `serialize(game, Some(playerId))` for that player's own view, `serialize(game, None)` for a public/spectator view. Full-information games (Tic-Tac-Toe, Connect Four, Pig) ignore the viewer and show everyone the same board. For Battleship the projection is where fog of war is enforced: your own ships are visible to you, your opponent's are hidden, and a spectator sees both boards fogged. Mastermind works the same way — the codemaker's secret code is hidden from the codebreaker (and spectators) until the game ends. Liar's Dice is the same idea across many hands: each player sees only their own dice (everyone else's is a count), until a challenge turns every cup over and the reveal becomes public. No code path can leak hidden state, because the unredacted model never leaves the actor.
+A game actor never ships its raw internal state to anyone. When it needs to send state out — as a move reply or a push — it renders a **view** for a specific viewer through a `GameStateView` type class: `serialize(game, Some(playerId))` for that player's own view, `serialize(game, None)` for a public/spectator view. Full-information games (Tic-Tac-Toe, Connect Four, Pig) ignore the viewer and show everyone the same board. For Battleship the projection is where fog of war is enforced: your own ships are visible to you, your opponent's are hidden, and a spectator sees both boards fogged. Mastermind works the same way — the codemaker's secret code is hidden from the codebreaker (and spectators) until the game ends. Liar's Dice is the same idea across many hands: each player sees only their own dice (everyone else's is a count), until a challenge turns every cup over and the reveal becomes public. Texas Hold 'Em follows suit — you see only your own hole cards, the community cards are public, and a contested hand's showdown is the moment the remaining players' cards are revealed. No code path can leak hidden state, because the unredacted model never leaves the actor.
 
 ### Real-time delivery
 
@@ -347,7 +347,7 @@ Planned work, in rough priority order:
 - **Horizontal scaling (Pekko Cluster Sharding)** — today the service is single-instance (lobbies, game actors, and player sessions live in one JVM). The target is to shard game and lobby entities across a Pekko cluster so play is location-transparent across nodes. Cluster messaging would carry cross-instance delivery between game actors and player sessions directly, while the analytics event stream survives unchanged. Kept deliberately out of the main architecture diagram above so it reflects what's actually deployed.
 - **Authentication hardening** — the credentialed auth in place covers registration, login, and password change, with Argon2id hashing, short-lived tokens, and login timing-equalization to blunt email enumeration. Considered and deliberately deferred: **token revocation** — JWTs are stateless, so a password change or "log out" doesn't invalidate already-issued tokens before they expire; closing that needs a per-account token version baked into the claim (or a `jti` denylist in Redis) checked at validation time. **Password reset** (forgot-password) — needs an out-of-band channel (email) and a single-use, TTL'd reset-token store (a natural fit for Redis), so it's gated on an email integration. **Rate limiting / lockout** on the auth endpoints to slow credential stuffing, and **email-address verification** at registration, are likewise out of scope for now. The short token TTL keeps the revocation gap small in the meantime.
 - **OAuth / social login** — a second `IdentityProvider` (e.g. Google/GitHub) plus a callback route, resolving an external identity to the same `Account` and reusing token issuance and the account store unchanged. The `IdentityProvider` seam exists precisely so this is additive; the open design questions are account-linking policy (same email via password and OAuth) and how non-browser clients complete the redirect.
-- **More game types** — additional turn-based games beyond the current six (e.g. Texas Hold 'Em).
+- **More game types** — additional turn-based games beyond the current seven.
 - **AI opponent** — a bot player for single-player matches and testing.
 - **Load testing** — throughput/latency benchmarking, plus retention policies for snapshots and move logs.
 

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/GameRegistry.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/GameRegistry.scala
@@ -10,11 +10,13 @@ import com.andy327.actor.game.modules.{
   LiarsDiceModule,
   MastermindModule,
   PigModule,
+  TexasHoldEmModule,
   TicTacToeModule
 }
 import com.andy327.actor.liarsdice.LiarsDiceActor
 import com.andy327.actor.mastermind.MastermindActor
 import com.andy327.actor.pig.PigActor
+import com.andy327.actor.texasholdem.TexasHoldEmActor
 import com.andy327.actor.tictactoe.TicTacToeActor
 import com.andy327.model.core.{Game, GameType, PlayerId}
 
@@ -58,5 +60,6 @@ object GameRegistry {
     case GameType.Pig         => GameModuleBundle(PigModule, PigActor)
     case GameType.Mastermind  => GameModuleBundle(MastermindModule, MastermindActor)
     case GameType.LiarsDice   => GameModuleBundle(LiarsDiceModule, LiarsDiceActor)
+    case GameType.TexasHoldEm => GameModuleBundle(TexasHoldEmModule, TexasHoldEmActor)
   }
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
@@ -3,6 +3,7 @@ package com.andy327.actor.game
 import com.andy327.model.battleship.{Battleship, Coord, Player1, Player2, PlayerBoard, Seat}
 import com.andy327.model.connectfour.ConnectFour
 import com.andy327.model.core.{Draw, Game, GameStatus, Mark, PlayerId, Won}
+import com.andy327.model.holdem.TexasHoldEm
 import com.andy327.model.liarsdice.{Bid, LiarsDice}
 import com.andy327.model.mastermind.{Codemaker, Mastermind, Role}
 import com.andy327.model.pig.Pig
@@ -227,6 +228,95 @@ object LiarsDiceState {
   }
 }
 
+/** One seat's public state in a Texas Hold 'Em view: its chips, what it has committed this hand and this street, and
+  * whether it has folded or is all-in. Hole cards are never here — a viewer sees only their own, in [[HoldEmState]].
+  */
+case class HoldEmSeat(seat: String, stack: Int, committed: Int, bet: Int, folded: Boolean, allIn: Boolean)
+
+/** One pot awarded in a Texas Hold 'Em showdown view: chips, the winning seat labels, and the hand description (absent
+  * when the pot was taken uncontested).
+  */
+case class HoldEmPotAward(amount: Int, winners: List[String], description: Option[String])
+
+/** The public reveal of the most recently finished Texas Hold 'Em hand.
+  *
+  * Every seat that reached the showdown exposes its hole cards here (keyed by seat label); folded hands stay hidden.
+  * Safe to show everyone and retained into the next hand for reconnecting clients, mirroring Liar's Dice's reveal.
+  *
+  * @param board the community cards that were face-up when the hand ended
+  * @param shownHands the hole cards shown at the showdown, keyed by seat label ("P1", "P2", …)
+  * @param awards the pots awarded, main pot first
+  */
+case class HoldEmHandResult(board: List[String], shownHands: Map[String, List[String]], awards: List[HoldEmPotAward])
+
+/** Serializable, per-viewer view of a Texas Hold 'Em game.
+  *
+  * The viewer sees their own hole cards and every seat's public chips/bets, but never another seat's hole cards until a
+  * showdown, which surfaces through `handResult`. `board` holds only the community cards revealed on the current street.
+  * Cards are rendered as their compact text form ("As", "Td"); `street` is the street name.
+  *
+  * @param seats every seat's public state, in seat order
+  * @param holeCards the viewer's own two hole cards, or `None` for a spectator
+  * @param board the community cards revealed so far
+  * @param button the seat label holding the dealer button
+  * @param currentPlayer the seat label whose turn it is
+  * @param currentBet the amount to match on the current street
+  * @param minRaise the smallest total a bet or raise may commit this street
+  * @param pot the total chips committed to the pot this hand
+  * @param toCall the chips the viewer must put in to call, or 0 for a spectator
+  * @param street the current street ("PreFlop", "Flop", "Turn", "River")
+  * @param winner the winning seat label once the sit-and-go is over, otherwise `None`
+  * @param viewerSeat the viewer's seat label, or `None` for a spectator
+  * @param handResult the most recently finished hand's public reveal, or `None` before any hand ends
+  */
+case class HoldEmState(
+    seats: List[HoldEmSeat],
+    holeCards: Option[List[String]],
+    board: List[String],
+    button: String,
+    currentPlayer: String,
+    currentBet: Int,
+    minRaise: Int,
+    pot: Int,
+    toCall: Int,
+    street: String,
+    winner: Option[String],
+    viewerSeat: Option[String],
+    handResult: Option[HoldEmHandResult]
+) extends GameState
+
+object HoldEmState {
+
+  /** Builds the view of `game` for the given viewer seat (`None` = spectator, who sees no hole cards). */
+  def of(game: TexasHoldEm, viewerSeat: Option[Int]): HoldEmState = {
+    def label(seat: Int): String = TexasHoldEm.seatLabel(seat)
+    val minRaise = if (game.currentBet == 0) TexasHoldEm.BigBlind else game.currentBet + game.lastRaiseSize
+    HoldEmState(
+      seats = game.playerIds.indices.toList.map { i =>
+        HoldEmSeat(label(i), game.stacks(i), game.committed(i), game.streetContrib(i), game.folded(i), game.allIn(i))
+      },
+      holeCards = viewerSeat.map(seat => game.holeCards(seat).map(_.toString)),
+      board = game.board.take(game.street.revealed).map(_.toString),
+      button = label(game.button),
+      currentPlayer = label(game.toAct),
+      currentBet = game.currentBet,
+      minRaise = minRaise,
+      pot = game.pot,
+      toCall = viewerSeat.map(game.toCall).getOrElse(0),
+      street = game.street.toString,
+      winner = game.winner.map(label),
+      viewerSeat = viewerSeat.map(label),
+      handResult = game.handResult.map { r =>
+        HoldEmHandResult(
+          board = r.board.map(_.toString),
+          shownHands = r.shownHands.map { case (seat, cs) => label(seat) -> cs.map(_.toString) },
+          awards = r.awards.map(a => HoldEmPotAward(a.amount, a.winners.map(label), a.description))
+        )
+      }
+    )
+  }
+}
+
 /** Type class for converting an internal game model into a serializable GameState.
   *
   * Instances live in the companion object, which is always in implicit scope for `GameStateView[G, S]` searches, so
@@ -265,6 +355,10 @@ object GameStateView {
   /** Type class instance for serializing a Liar's Dice game, projected per viewer (only the viewer's own dice show). */
   implicit val liarsDiceView: GameStateView[LiarsDice, LiarsDiceState] =
     (game, viewer) => LiarsDiceState.of(game, viewer.flatMap(game.playerFor))
+
+  /** Type class instance for serializing a Texas Hold 'Em game, projected per viewer (only the viewer's hole cards). */
+  implicit val texasHoldEmView: GameStateView[TexasHoldEm, HoldEmState] =
+    (game, viewer) => HoldEmState.of(game, viewer.flatMap(game.playerFor))
 }
 
 /** Utility for converting internal game models to HTTP-serializable GameState representations using the GameStateView

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/MovePayload.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/MovePayload.scala
@@ -52,4 +52,15 @@ object MovePayload {
     * @param face the bid's numbered face 2–6, or `None` for a wild "ones" bid
     */
   final case class LiarsDiceAction(action: String, quantity: Option[Int], face: Option[Int]) extends MovePayload
+
+  /** A move for Texas Hold 'Em: `fold`, `check`, `call`, `bet`, or `raise`.
+    *
+    * `amount` is the total chip target for a `bet` or `raise` (the seat's street contribution after the action) and is
+    * absent for `fold`, `check`, and `call`. The deck a hand-starting action shuffles is supplied server-side, never by
+    * the client.
+    *
+    * @param action `fold`, `check`, `call`, `bet`, or `raise`
+    * @param amount the total to bet or raise to, for a `bet` or `raise` action
+    */
+  final case class HoldEmAction(action: String, amount: Option[Int]) extends MovePayload
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/modules/TexasHoldEmModule.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/modules/TexasHoldEmModule.scala
@@ -1,0 +1,65 @@
+package com.andy327.actor.game.modules
+
+import scala.util.Random
+
+import cats.syntax.functor._
+
+import io.circe.Decoder
+import io.circe.generic.auto._
+import org.apache.pekko.actor.typed.ActorRef
+
+import com.andy327.actor.core.{GameActor, TurnBasedGameActor}
+import com.andy327.actor.game.MovePayload.HoldEmAction
+import com.andy327.actor.game.{GameOperation, GameState, GameStateConverters, MovePayload}
+import com.andy327.model.core.{GameError, PlayerId}
+import com.andy327.model.holdem.Action.{Bet, Call, Check, Fold, Raise}
+import com.andy327.model.holdem.{Action, Card, HoldEmMove, TexasHoldEm}
+
+/** [[GameModule]] implementation for Texas Hold 'Em.
+  *
+  * Provides move decoding, operation-to-command mapping, and per-viewer serialization. Every action carries a freshly
+  * shuffled deck produced here — server-side — because any action can end a hand and start the next one; the pure model
+  * deals the next hand from it and ignores it otherwise, so `TexasHoldEm.play` stays a pure function. Bet and raise
+  * sizing is validated by the model, which rejects an illegal amount with its own errors.
+  */
+object TexasHoldEmModule extends GameModule[TexasHoldEm] {
+
+  override val moveDecoder: Decoder[MovePayload] = Decoder[HoldEmAction].widen
+
+  /** A freshly shuffled 52-card deck. Used for the opening deal and carried on every move for the next hand. */
+  def shuffledDeck(): List[Card] = Random.shuffle(Card.deck)
+
+  override def toGameCommand(
+      op: GameOperation,
+      replyTo: ActorRef[Either[GameError, GameState]]
+  ): Either[GameError, GameActor.GameCommand] = op match {
+    case GameOperation.MakeMove(playerId, HoldEmAction(action, amount)) =>
+      def command(a: Action): Either[GameError, GameActor.GameCommand] =
+        Right(TurnBasedGameActor.MakeMove(playerId, HoldEmMove(a, shuffledDeck()), replyTo))
+
+      def sized(make: Int => Action): Either[GameError, GameActor.GameCommand] =
+        amount match {
+          case Some(a) => command(make(a))
+          case None    => Left(GameError.Unknown(s"A Texas Hold 'Em $action requires an amount."))
+        }
+
+      action.toLowerCase match {
+        case "fold"  => command(Fold)
+        case "check" => command(Check)
+        case "call"  => command(Call)
+        case "bet"   => sized(Bet(_))
+        case "raise" => sized(Raise(_))
+        case other   => Left(GameError.Unknown(s"Unknown Texas Hold 'Em action: $other"))
+      }
+
+    case GameOperation.MakeMove(_, otherMove) =>
+      val name = Option(otherMove).map(_.getClass.getSimpleName).getOrElse("null")
+      Left(GameError.Unknown(s"Unsupported move type for Texas Hold 'Em: $name"))
+
+    case GameOperation.GetState =>
+      Right(TurnBasedGameActor.GetState(replyTo))
+  }
+
+  override def serialize(game: TexasHoldEm, viewer: Option[PlayerId]): GameState =
+    GameStateConverters.serializeGame(game, viewer)
+}

--- a/game-service-actor/src/main/scala/com/andy327/actor/texasholdem/TexasHoldEmActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/texasholdem/TexasHoldEmActor.scala
@@ -1,0 +1,34 @@
+package com.andy327.actor.texasholdem
+
+import io.circe.syntax._
+import io.circe.{Encoder, Json}
+
+import com.andy327.actor.core.TurnBasedGameActor
+import com.andy327.actor.game.HoldEmState
+import com.andy327.actor.game.modules.TexasHoldEmModule
+import com.andy327.model.holdem.Action.{Bet, Call, Check, Fold, Raise}
+import com.andy327.model.holdem.{HoldEmMove, TexasHoldEm}
+
+/** [[core.GameActor]] binding for Texas Hold 'Em.
+  *
+  * All behavior lives in [[core.TurnBasedGameActor]]; the rules (betting, streets, side pots, sit-and-go win) live in
+  * `model.holdem.TexasHoldEm`, and the per-viewer projection that hides each player's hole cards lives in
+  * `GameStateView[TexasHoldEm, HoldEmState]`. The opening deal is shuffled here — server-side — and dealt by the pure
+  * model.
+  *
+  * The move-log encoder records a bet's or raise's amount but omits the deck each move carries: that deck is internal
+  * server randomness for the next hand, not meaningful public history.
+  */
+object TexasHoldEmActor
+    extends TurnBasedGameActor[TexasHoldEm, HoldEmMove, Int, HoldEmState](
+      players => TexasHoldEm.newGame(players, TexasHoldEmModule.shuffledDeck()),
+      Encoder.instance[HoldEmMove] { move =>
+        move.action match {
+          case Fold     => Json.obj("action" -> "fold".asJson)
+          case Check    => Json.obj("action" -> "check".asJson)
+          case Call     => Json.obj("action" -> "call".asJson)
+          case Bet(a)   => Json.obj("action" -> "bet".asJson, "amount" -> a.asJson)
+          case Raise(a) => Json.obj("action" -> "raise".asJson, "amount" -> a.asJson)
+        }
+      }
+    )

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/TexasHoldEmStateSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/TexasHoldEmStateSpec.scala
@@ -1,0 +1,107 @@
+package com.andy327.actor.game
+
+import java.util.UUID
+
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import com.andy327.model.core.PlayerId
+import com.andy327.model.holdem.{Card, HandResult, PotAward, Street, TexasHoldEm}
+
+class TexasHoldEmStateSpec extends AnyWordSpec with Matchers with OptionValues {
+  private val alice: PlayerId = UUID.randomUUID() // seat 0
+  private val bob: PlayerId = UUID.randomUUID() // seat 1
+  private val carol: PlayerId = UUID.randomUUID() // seat 2
+
+  private def cards(text: String*): List[Card] = text.map(Card(_)).toList
+
+  private def game: TexasHoldEm =
+    TexasHoldEm(
+      playerIds = Vector(alice, bob, carol),
+      stacks = Vector(900, 800, 1000),
+      button = 0,
+      holeCards = Vector(cards("AS", "AH"), cards("KS", "KH"), cards("QS", "QH")),
+      board = cards("2C", "7D", "9S", "JD", "4H"),
+      deck = Nil,
+      street = Street.Flop, // only the first three community cards are revealed
+      toAct = 1,
+      streetContrib = Vector(0, 50, 0),
+      committed = Vector(100, 150, 100),
+      currentBet = 50,
+      lastRaiseSize = 50,
+      hasActed = Vector(true, true, false),
+      folded = Vector(false, false, false),
+      allIn = Vector(false, false, false),
+      handResult = None,
+      winner = None,
+      moveCount = 5
+    )
+
+  "HoldEmState.of for a seated player" should {
+    "reveal only that player's own hole cards, plus every seat's public state" in {
+      val p1 = HoldEmState.of(game, Some(0))
+      p1.viewerSeat shouldBe Some("P1")
+      p1.holeCards shouldBe Some(List("AS", "AH"))
+      p1.seats shouldBe List(
+        HoldEmSeat("P1", 900, 100, 0, folded = false, allIn = false),
+        HoldEmSeat("P2", 800, 150, 50, folded = false, allIn = false),
+        HoldEmSeat("P3", 1000, 100, 0, folded = false, allIn = false)
+      )
+
+      val p2 = HoldEmState.of(game, Some(1))
+      p2.holeCards shouldBe Some(List("KS", "KH")) // its own hand, not seat 0's
+    }
+
+    "reveal only the community cards dealt on the current street" in {
+      HoldEmState.of(game, Some(0)).board shouldBe List("2C", "7D", "9S") // the flop, not the turn or river
+      HoldEmState.of(game.copy(street = Street.PreFlop), Some(0)).board shouldBe Nil
+      HoldEmState.of(game.copy(street = Street.River), Some(0)).board shouldBe
+        List("2C", "7D", "9S", "JD", "4H")
+    }
+
+    "expose the betting state and each player's amount to call" in {
+      val p1 = HoldEmState.of(game, Some(0))
+      p1.button shouldBe "P1"
+      p1.currentPlayer shouldBe "P2"
+      p1.currentBet shouldBe 50
+      p1.minRaise shouldBe 100 // current bet plus the last raise size
+      p1.pot shouldBe 350
+      p1.toCall shouldBe 50 // seat 0 has nothing in this street yet
+
+      HoldEmState.of(game, Some(1)).toCall shouldBe 0 // seat 1 has already matched the bet
+    }
+
+    "report the minimum raise as the big blind when there is no bet yet on the street" in {
+      val noBet = game.copy(currentBet = 0, streetContrib = Vector(0, 0, 0))
+      HoldEmState.of(noBet, Some(0)).minRaise shouldBe TexasHoldEm.BigBlind
+    }
+  }
+
+  "HoldEmState.of for a spectator" should {
+    "hide every hole card while still reporting the public state" in {
+      val view = HoldEmState.of(game, None)
+      view.viewerSeat shouldBe None
+      view.holeCards shouldBe None
+      view.toCall shouldBe 0
+      view.seats.map(_.stack) shouldBe List(900, 800, 1000)
+    }
+  }
+
+  "HoldEmState.of with a finished hand" should {
+    "expose the showdown reveal — hole cards of the seats that reached it" in {
+      val result = HandResult(
+        board = cards("2C", "7D", "9S", "JD", "4H"),
+        shownHands = Map(0 -> cards("AS", "AH"), 2 -> cards("QS", "QH")),
+        awards = List(PotAward(350, List(0), Some("one pair, As")))
+      )
+      val ended = game.copy(handResult = Some(result), winner = Some(0), street = Street.River)
+      val shown = HoldEmState.of(ended, Some(1)).handResult.value
+
+      shown.board shouldBe List("2C", "7D", "9S", "JD", "4H")
+      shown.shownHands shouldBe Map("P1" -> List("AS", "AH"), "P3" -> List("QS", "QH"))
+      shown.awards shouldBe List(HoldEmPotAward(350, List("P1"), Some("one pair, As")))
+      HoldEmState.of(ended, Some(1)).winner shouldBe Some("P1")
+    }
+  }
+}

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/TexasHoldEmModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/TexasHoldEmModuleSpec.scala
@@ -1,0 +1,145 @@
+package com.andy327.actor.game.modules
+
+import java.util.UUID
+
+import io.circe.parser.decode
+import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import com.andy327.actor.core.{PlayerActor, TurnBasedGameActor}
+import com.andy327.actor.game.{GameOperation, GameRegistry, GameState, HoldEmState, MovePayload}
+import com.andy327.actor.lobby.Player
+import com.andy327.actor.texasholdem.TexasHoldEmActor
+import com.andy327.model.core.{GameError, GameType}
+import com.andy327.model.holdem.Action.{Bet, Call, Check, Fold, Raise}
+import com.andy327.model.holdem.{Action, Card, HoldEmMove, TexasHoldEm}
+
+class TexasHoldEmModuleSpec extends AnyWordSpecLike with Matchers {
+  private val testKit = ActorTestKit()
+  import testKit._
+
+  "TexasHoldEmModule" should {
+    "decode a fold action JSON" in {
+      decode[MovePayload]("""{"action":"fold"}""")(TexasHoldEmModule.moveDecoder) shouldBe
+        Right(MovePayload.HoldEmAction("fold", None))
+    }
+
+    "decode a bet action JSON with an amount" in {
+      decode[MovePayload]("""{"action":"bet","amount":50}""")(TexasHoldEmModule.moveDecoder) shouldBe
+        Right(MovePayload.HoldEmAction("bet", Some(50)))
+    }
+
+    "fail to decode an invalid Texas Hold 'Em move JSON" in {
+      decode[MovePayload]("""{"bad":"data"}""")(TexasHoldEmModule.moveDecoder).isLeft shouldBe true
+    }
+
+    "convert a fold MakeMove to a Fold GameCommand carrying a full shuffled deck" in {
+      val alice = Player("alice")
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+
+      TexasHoldEmModule.toGameCommand(
+        GameOperation.MakeMove(alice.id, MovePayload.HoldEmAction("fold", None)),
+        replyProbe.ref
+      ) match {
+        case Right(TurnBasedGameActor.MakeMove(playerId, HoldEmMove(action, deck), reply)) =>
+          playerId shouldBe alice.id
+          action shouldBe Fold
+          deck.size shouldBe 52
+          deck.toSet.size shouldBe 52 // a real, distinct shuffle
+          reply shouldBe replyProbe.ref
+        case other => fail(s"Unexpected result: $other")
+      }
+    }
+
+    "convert a bet MakeMove to a Bet GameCommand with the amount" in {
+      val alice = Player("alice")
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+
+      TexasHoldEmModule.toGameCommand(
+        GameOperation.MakeMove(alice.id, MovePayload.HoldEmAction("bet", Some(75))),
+        replyProbe.ref
+      ) match {
+        case Right(TurnBasedGameActor.MakeMove(_, HoldEmMove(action, _), _)) => action shouldBe Bet(75)
+        case other                                                           => fail(s"Unexpected result: $other")
+      }
+    }
+
+    "convert check, call, and raise actions to their moves" in {
+      val alice = Player("alice")
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      def action(payload: MovePayload.HoldEmAction): Action =
+        TexasHoldEmModule.toGameCommand(GameOperation.MakeMove(alice.id, payload), replyProbe.ref) match {
+          case Right(TurnBasedGameActor.MakeMove(_, HoldEmMove(a, _), _)) => a
+          case other                                                      => fail(s"Unexpected result: $other")
+        }
+      action(MovePayload.HoldEmAction("check", None)) shouldBe Check
+      action(MovePayload.HoldEmAction("call", None)) shouldBe Call
+      action(MovePayload.HoldEmAction("raise", Some(40))) shouldBe Raise(40)
+    }
+
+    "reject a bet with no amount" in {
+      val alice = Player("alice")
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+
+      val Left(err) = TexasHoldEmModule.toGameCommand(
+        GameOperation.MakeMove(alice.id, MovePayload.HoldEmAction("bet", None)),
+        replyProbe.ref
+      )
+      err.message should include("requires an amount")
+    }
+
+    "return an error for an unknown action string" in {
+      val alice = Player("alice")
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+
+      val Left(err) = TexasHoldEmModule.toGameCommand(
+        GameOperation.MakeMove(alice.id, MovePayload.HoldEmAction("bad", None)),
+        replyProbe.ref
+      )
+      err.message should include("Unknown Texas Hold 'Em action: bad")
+    }
+
+    "return error when passing an unsupported MovePayload to toGameCommand" in {
+      val alice = Player("alice")
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+
+      val Left(err) = TexasHoldEmModule.toGameCommand(
+        GameOperation.MakeMove(alice.id, null.asInstanceOf[MovePayload]),
+        replyProbe.ref
+      )
+      err.message should include("Unsupported move type for Texas Hold 'Em")
+    }
+
+    "convert GetState to a GetState GameCommand" in {
+      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      TexasHoldEmModule.toGameCommand(GameOperation.GetState, replyProbe.ref) shouldBe
+        Right(TurnBasedGameActor.GetState(replyProbe.ref))
+    }
+
+    "produce a Subscribe command for a given PlayerActor ref" in {
+      val playerProbe = TestProbe[PlayerActor.Command]()
+      val playerId = UUID.randomUUID()
+      TexasHoldEmActor.subscribeCommand(playerProbe.ref, playerId) shouldBe
+        TurnBasedGameActor.Subscribe(playerProbe.ref, playerId)
+    }
+
+    "serialize a Texas Hold 'Em game to a HoldEmState for the requesting player" in {
+      val alice = Player("alice")
+      val bob = Player("bob")
+      val game = TexasHoldEm.newGame(Seq(alice.id, bob.id), Card.deck)
+      val state = TexasHoldEmModule.serialize(game, Some(alice.id)).asInstanceOf[HoldEmState]
+      state.viewerSeat shouldBe Some("P1")
+      state.holeCards.map(_.size) shouldBe Some(2)
+      state.seats.map(_.seat) shouldBe List("P1", "P2")
+      state.currentPlayer shouldBe "P1"
+      state.pot shouldBe 15
+    }
+
+    "expose the Texas Hold 'Em bundle through the GameRegistry" in {
+      val bundle = GameRegistry.forType(GameType.TexasHoldEm)
+      bundle.module shouldBe TexasHoldEmModule
+      bundle.actor shouldBe TexasHoldEmActor
+    }
+  }
+}

--- a/game-service-actor/src/test/scala/com/andy327/actor/texasholdem/TexasHoldEmActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/texasholdem/TexasHoldEmActorSpec.scala
@@ -1,0 +1,78 @@
+package com.andy327.actor.texasholdem
+
+import java.util.UUID
+
+import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
+import org.apache.pekko.actor.typed.ActorRef
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import com.andy327.actor.core.{GameManager, TurnBasedGameActor}
+import com.andy327.actor.events.NoOpEventPublisher
+import com.andy327.actor.game.GameState
+import com.andy327.actor.persistence.PersistenceProtocol
+import com.andy327.model.core.{GameError, PlayerId}
+import com.andy327.model.holdem.Action.{Call, Raise}
+import com.andy327.model.holdem.{Card, HoldEmMove}
+
+/** Drives the shared turn-based actor with Texas Hold 'Em moves to lock in the move-log encoder — in particular that
+  * the deck each move carries never reaches the public history log, and that a raise records its amount. State
+  * projection and rules are covered by `TexasHoldEmStateSpec` and `TexasHoldEmSpec`.
+  */
+class TexasHoldEmActorSpec extends AnyWordSpecLike with Matchers {
+  private val testKit = ActorTestKit()
+  import testKit._
+
+  val alice: PlayerId = UUID.randomUUID()
+  val bob: PlayerId = UUID.randomUUID()
+
+  private val deck: List[Card] = Card.deck // any full deck; the encoder must never log it
+
+  private val dummyGameManager: ActorRef[GameManager.Command] = createTestProbe[GameManager.Command]().ref
+
+  private def newActor(): (ActorRef[TexasHoldEmActor.Command], TestProbe[PersistenceProtocol.Command]) = {
+    val persistProbe = createTestProbe[PersistenceProtocol.Command]()
+    val (_, behavior) =
+      TexasHoldEmActor.create(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        Seq(alice, bob),
+        persistProbe.ref,
+        dummyGameManager,
+        NoOpEventPublisher
+      )
+    (spawn(behavior), persistProbe)
+  }
+
+  /** Applies a move and returns the JSON the actor appended to the move-log for it. */
+  private def loggedMove(
+      actor: ActorRef[TexasHoldEmActor.Command],
+      persistProbe: TestProbe[PersistenceProtocol.Command],
+      player: PlayerId,
+      move: HoldEmMove
+  ): io.circe.Json = {
+    val replyProbe = createTestProbe[Either[GameError, GameState]]()
+    actor ! TurnBasedGameActor.MakeMove(player, move, replyProbe.ref)
+    replyProbe.receiveMessage()
+    persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+    persistProbe.expectMessageType[PersistenceProtocol.AppendMove].move
+  }
+
+  "TexasHoldEmActor's move-log encoder" should {
+    "record a raise's amount but never the deck it carries" in {
+      val (actor, persistProbe) = newActor()
+      // heads-up, seat 0 (button/SB) is first to act pre-flop and raises to 40
+      val json = loggedMove(actor, persistProbe, alice, HoldEmMove(Raise(40), deck))
+      json.hcursor.get[String]("action") shouldBe Right("raise")
+      json.hcursor.get[Int]("amount") shouldBe Right(40)
+      json.asObject.map(_.keys.toList) shouldBe Some(List("action", "amount")) // no deck leaked to the history log
+    }
+
+    "record only the action for a call, never the deck" in {
+      val (actor, persistProbe) = newActor()
+      val json = loggedMove(actor, persistProbe, alice, HoldEmMove(Call, deck))
+      json.hcursor.get[String]("action") shouldBe Right("call")
+      json.asObject.map(_.keys.toList) shouldBe Some(List("action"))
+    }
+  }
+}

--- a/game-service-model/src/main/scala/com/andy327/model/core/GameType.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/core/GameType.scala
@@ -46,6 +46,11 @@ object GameType {
     val (minPlayers, maxPlayers) = (2, 6)
   }
 
+  /** A 2–6 player No-Limit Texas Hold 'Em sit-and-go: play hands until one player has all the chips. */
+  case object TexasHoldEm extends GameType {
+    val (minPlayers, maxPlayers) = (2, 6)
+  }
+
   /** Parses a string into a GameType instance.
     *
     * @param s the name of the game type (case-insensitive)
@@ -58,6 +63,7 @@ object GameType {
     case "pig"         => Some(Pig)
     case "mastermind"  => Some(Mastermind)
     case "liarsdice"   => Some(LiarsDice)
+    case "texasholdem" => Some(TexasHoldEm)
     case _             => None
   }
 }

--- a/game-service-model/src/main/scala/com/andy327/model/core/GameTypeTag.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/core/GameTypeTag.scala
@@ -2,6 +2,7 @@ package com.andy327.model.core
 
 import com.andy327.model.battleship.Battleship
 import com.andy327.model.connectfour.ConnectFour
+import com.andy327.model.holdem.TexasHoldEm
 import com.andy327.model.liarsdice.LiarsDice
 import com.andy327.model.mastermind.Mastermind
 import com.andy327.model.pig.Pig
@@ -46,5 +47,9 @@ object GameTypeTag {
 
   implicit val liarsDiceTag: GameTypeTag[LiarsDice] = new GameTypeTag[LiarsDice] {
     override val value: GameType = GameType.LiarsDice
+  }
+
+  implicit val texasHoldEmTag: GameTypeTag[TexasHoldEm] = new GameTypeTag[TexasHoldEm] {
+    override val value: GameType = GameType.TexasHoldEm
   }
 }

--- a/game-service-model/src/main/scala/com/andy327/model/holdem/Card.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/holdem/Card.scala
@@ -1,0 +1,47 @@
+package com.andy327.model.holdem
+
+object Card {
+
+  /** Renders a rank as its display symbol: `A`, `K`, `Q`, `J`, `T`, or the number itself for 2–9. */
+  def rankToString(rank: Rank): String = rank match {
+    case 14 => "A"
+    case 13 => "K"
+    case 12 => "Q"
+    case 11 => "J"
+    case 10 => "T"
+    case n  => n.toString
+  }
+
+  /** Parses a card from its text form — a rank symbol followed by a suit letter — e.g. `"AS"`, `"TD"`, `"9H"`. */
+  def apply(text: String): Card = {
+    val rank: Rank = text.dropRight(1) match {
+      case "A" => 14
+      case "K" => 13
+      case "Q" => 12
+      case "J" => 11
+      case "T" => 10
+      case n   => n.toInt
+    }
+    Card(rank, Suit(text.takeRight(1)))
+  }
+
+  /** A standard 52-card deck in a fixed order (rank-major, then suit). Shuffling happens server-side in the actor
+    * layer, never here, so the model stays pure.
+    */
+  val deck: List[Card] =
+    (for {
+      rank <- 2 to 14
+      suit <- Suit.all
+    } yield Card(rank, suit)).toList
+}
+
+/** A single playing card.
+  *
+  * @param rank the rank, 2–14 (Jack = 11, Queen = 12, King = 13, Ace = 14)
+  * @param suit the suit
+  */
+final case class Card(rank: Rank, suit: Suit) {
+  require(rank >= 2 && rank <= 14, s"Rank must be between 2 and 14 (Ace), got $rank")
+
+  override def toString: String = s"${Card.rankToString(rank)}$suit"
+}

--- a/game-service-model/src/main/scala/com/andy327/model/holdem/GameError.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/holdem/GameError.scala
@@ -1,0 +1,36 @@
+package com.andy327.model.holdem
+
+import com.andy327.model.core.GameError
+
+// Texas Hold 'Em-specific game errors. Errors shared by every turn-based game (InvalidPlayer, InvalidTurn, GameOver,
+// Unknown) are defined once in core.GameError.
+
+/** A bet was attempted while there was already a bet to match — the player must call or raise instead. */
+case object BetNotAllowed extends GameError {
+  val message: String = "There is already a bet; call or raise instead."
+}
+
+/** A raise was attempted with no bet outstanding — the player must bet to open the action. */
+case object RaiseNotAllowed extends GameError {
+  val message: String = "There is no bet to raise; bet to open the action."
+}
+
+/** A check was attempted while facing a bet — the player must call, raise, or fold. */
+case object CannotCheck extends GameError {
+  val message: String = "You cannot check while facing a bet."
+}
+
+/** An opening bet was smaller than the big blind (and not an all-in for the player's whole stack). */
+case object BetTooSmall extends GameError {
+  val message: String = "A bet must be at least the big blind."
+}
+
+/** A raise was smaller than the minimum legal raise (and not an all-in for the player's whole stack). */
+case object RaiseTooSmall extends GameError {
+  val message: String = "A raise must be at least the size of the previous bet or raise."
+}
+
+/** An action would commit more chips than the player has. */
+case object InsufficientChips extends GameError {
+  val message: String = "You do not have enough chips for that action."
+}

--- a/game-service-model/src/main/scala/com/andy327/model/holdem/Hand.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/holdem/Hand.scala
@@ -1,0 +1,116 @@
+package com.andy327.model.holdem
+
+object Hand {
+  import scala.math.Ordering.Implicits._
+
+  /** Orders hands by category first, then by the ranks of the cards making up the hand with kickers appended, so a
+    * stronger category always beats a weaker one and ties within a category break on high card. Two hands compare equal
+    * exactly when they tie at a showdown (a split pot), since suits never affect a poker hand's strength.
+    */
+  val handOrdering: Ordering[Hand] = Ordering.by((hand: Hand) => (hand.handType, hand.cardRanks))
+
+  /** Builds a hand from up to five distinct cards. */
+  def apply(cards: Card*): Hand = {
+    val cardSet: Set[Card] = cards.toSet
+    require(cards.size == cardSet.size, s"No duplicate cards allowed: ${cards.mkString(", ")}")
+    Hand(cardSet)
+  }
+
+  /** The best five-card hand formable from the given cards — typically the seven a player holds at a Hold 'Em showdown
+    * (two hole cards plus five community cards). Evaluates all 5-card combinations and keeps the strongest.
+    */
+  def bestHand(cards: Set[Card]): Hand =
+    cards.toSeq.combinations(5).map(five => Hand(five.toSet)).max(handOrdering)
+}
+
+/** A poker hand of up to five cards, categorized and ranked so hands can be compared directly.
+  *
+  * Beyond the raw cards it derives the hand [[handType]], which cards form the hand versus which are kickers, and the
+  * rank sequence [[cardRanks]] used to break ties. It implements `scala.math.Ordered` via [[Hand.handOrdering]], so
+  * `>`, `<`, and `compare` all reflect poker hand strength and `compare == 0` marks a tie (a split pot).
+  *
+  * @param cards the up-to-five cards making up the hand
+  */
+final case class Hand(cards: Set[Card]) extends Ordered[Hand] {
+  import HandType._
+
+  require(cards.size <= 5, "A hand has at most five cards")
+
+  val ranks: Set[Rank] = cards.map(_.rank)
+  val suits: Set[Suit] = cards.map(_.suit)
+
+  val cardsByRank: Map[Rank, Set[Card]] = cards.groupBy(_.rank)
+  val cardsByFrequency: Map[Int, Set[Card]] = cards.groupBy(card => cardsByRank(card.rank).size)
+
+  val quads: Set[Card] = cardsByFrequency.getOrElse(4, Set.empty)
+  val triples: Set[Card] = cardsByFrequency.getOrElse(3, Set.empty)
+  val pairs: Set[Card] = cardsByFrequency.getOrElse(2, Set.empty)
+  val singles: Set[Card] = cardsByFrequency.getOrElse(1, Set.empty)
+
+  val isFlush: Boolean = suits.size == 1 && cards.size == 5
+  val isRoyal: Boolean = ranks == Set(14, 13, 12, 11, 10)
+  val isWheel: Boolean = ranks == Set(5, 4, 3, 2, 14) // ace-low straight, the lowest-ranked straight
+  val isStraight: Boolean = isWheel || (ranks.size == 5 && ranks.max - ranks.min == 4)
+
+  val handType: HandType.Value =
+    if (isRoyal && isFlush) RoyalFlush
+    else if (isStraight && isFlush) StraightFlush
+    else if (quads.nonEmpty) FourOfAKind
+    else if (triples.nonEmpty && pairs.nonEmpty) FullHouse
+    else if (isFlush) Flush
+    else if (isStraight) Straight
+    else if (triples.nonEmpty) ThreeOfAKind
+    else if (pairs.size == 4) TwoPair
+    else if (pairs.nonEmpty) OnePair
+    else HighCard
+
+  private val (usedCards, unusedCards): (Set[Card], Set[Card]) = handType match {
+    case RoyalFlush | StraightFlush | FullHouse | Flush | Straight => (cards, Set.empty)
+    case FourOfAKind                                               => (quads, singles)
+    case ThreeOfAKind                                              => (triples, singles)
+    case TwoPair | OnePair                                         => (pairs, singles)
+    case HighCard                                                  => (Set.empty, cards)
+  }
+
+  /** The cards forming the hand, ordered for tie-breaking. Normally this is descending rank, but two categories need
+    * special handling: a full house ranks by its trips before its pair (so "queens full of aces" ranks below "kings
+    * full of fives", never above it), and the wheel drops its ace to the bottom so it ranks as a five-high straight.
+    */
+  val rankedCards: Seq[Card] =
+    if (handType == FullHouse)
+      triples.toSeq.sortBy(_.rank).reverse ++ pairs.toSeq.sortBy(_.rank).reverse
+    else {
+      val sorted = usedCards.toSeq.sortBy(_.rank).reverse
+      if (isWheel) sorted.tail :+ sorted.head // A,5,4,3,2 -> 5,4,3,2,A so the ace ranks low
+      else sorted
+    }
+
+  /** The leftover cards not part of the hand, ordered by descending rank; they break ties between equal categories. */
+  val kickers: Seq[Card] = unusedCards.toSeq.sortBy(_.rank).reverse
+
+  /** The ranks of every card, hand cards first then kickers — the tie-break key used by [[Hand.handOrdering]]. */
+  val cardRanks: Seq[Rank] = (rankedCards ++ kickers).map(_.rank)
+
+  /** A human-readable summary of the hand, e.g. "full house, Ks over 5s" or "ace-high straight" (used at showdown). */
+  val description: String = handType match {
+    case RoyalFlush    => "royal flush"
+    case StraightFlush => s"${Card.rankToString(rankedCards.head.rank)}-high straight flush"
+    case FourOfAKind   => s"four of a kind, ${Card.rankToString(quads.head.rank)}s"
+    case FullHouse     =>
+      val trip = Card.rankToString(triples.head.rank)
+      val pair = Card.rankToString(pairs.head.rank)
+      s"full house, ${trip}s over ${pair}s"
+    case Flush        => s"${Card.rankToString(rankedCards.head.rank)}-high flush"
+    case Straight     => s"${Card.rankToString(rankedCards.head.rank)}-high straight"
+    case ThreeOfAKind => s"three of a kind, ${Card.rankToString(triples.head.rank)}s"
+    case TwoPair      =>
+      val pairRanks = pairs.map(_.rank).toSeq.sorted
+      s"two pair, ${Card.rankToString(pairRanks(1))}s and ${Card.rankToString(pairRanks(0))}s"
+    case OnePair  => s"one pair, ${Card.rankToString(pairs.head.rank)}s"
+    case HighCard => s"${Card.rankToString(kickers.head.rank)} high"
+  }
+
+  def compare(that: Hand): Int = Hand.handOrdering.compare(this, that)
+
+  override def toString: String = (rankedCards ++ kickers).mkString("[", " ", "]")
+}

--- a/game-service-model/src/main/scala/com/andy327/model/holdem/TexasHoldEm.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/holdem/TexasHoldEm.scala
@@ -1,0 +1,406 @@
+package com.andy327.model.holdem
+
+import com.andy327.model.core.GameError.{GameOver, InvalidPlayer, InvalidTurn}
+import com.andy327.model.core.{Game, GameError, GameStatus, InProgress, PlayerId, Won}
+
+/** A betting street. `revealed` is the number of community cards that are face-up on that street. */
+sealed trait Street {
+  def revealed: Int
+}
+
+object Street {
+  case object PreFlop extends Street { val revealed: Int = 0 }
+  case object Flop extends Street { val revealed: Int = 3 }
+  case object Turn extends Street { val revealed: Int = 4 }
+  case object River extends Street { val revealed: Int = 5 }
+
+  /** The street that follows `street`, or `None` after the river (the last betting street). */
+  def next(street: Street): Option[Street] = street match {
+    case PreFlop => Some(Flop)
+    case Flop    => Some(Turn)
+    case Turn    => Some(River)
+    case River   => None
+  }
+}
+
+/** A player action on their turn. `Bet`/`Raise` carry the chip target as a total street contribution, not a delta. */
+sealed trait Action
+object Action {
+  case object Fold extends Action
+  case object Check extends Action
+  case object Call extends Action
+
+  /** Open the betting for `amount` chips (only legal when there is no bet yet on the street). */
+  final case class Bet(amount: Int) extends Action
+
+  /** Raise so the acting player's total contribution this street becomes `toAmount`. */
+  final case class Raise(toAmount: Int) extends Action
+}
+
+/** A Hold 'Em move: a player [[Action]] plus a freshly shuffled deck the pure model deals from only if this action
+  * starts the next hand. The deck rides along on every action because any action can end a hand (a fold down to one
+  * player, or a call that closes the river); it is kept server-side (rolled in the actor layer) so the model stays
+  * pure, mirroring how Liar's Dice injects its re-roll pool. The move-log encoder records only `action`, never `deck`.
+  */
+final case class HoldEmMove(action: Action, deck: List[Card])
+
+/** One pot awarded at the end of a hand: `amount` chips split among `winners`, with the winning `description` at a
+  * showdown (or `None` when everyone else folded and the pot was taken uncontested).
+  */
+final case class PotAward(amount: Int, winners: List[Int], description: Option[String])
+
+/** The public record of the hand that just finished — the one moment hole cards may come up.
+  *
+  * Retained in the game state so all viewers, including reconnecting clients, can see how the last hand ended even
+  * after the next hand has been dealt.
+  *
+  * @param board the community cards that were face-up when the hand ended (all five at a showdown)
+  * @param shownHands the hole cards of each seat that reached the showdown, keyed by seat; empty for an uncontested win
+  * @param awards the pots awarded, main pot first
+  */
+final case class HandResult(board: List[Card], shownHands: Map[Int, List[Card]], awards: List[PotAward])
+
+object TexasHoldEm {
+
+  /** Chips each player starts a sit-and-go with. */
+  val StartingStack: Int = 1000
+
+  /** The small blind, posted by the seat to the left of the button (the button itself when heads-up). */
+  val SmallBlind: Int = 5
+
+  /** The big blind, posted by the next seat along; also the minimum opening bet. */
+  val BigBlind: Int = 10
+
+  /** Hole cards dealt to each seat still in the sit-and-go. */
+  val HoleCards: Int = 2
+
+  /** Creates a fresh sit-and-go: equal starting stacks, the button just before seat 0 (so the first hand's button is
+    * seat 0), and the first hand dealt and blinded from `deck`. `deck` is a full 52-card shuffle produced server-side.
+    */
+  def newGame(playerIds: Seq[PlayerId], deck: List[Card]): TexasHoldEm = {
+    val n = playerIds.size
+    val base = TexasHoldEm(
+      playerIds = playerIds.toVector,
+      stacks = Vector.fill(n)(StartingStack),
+      button = n - 1,
+      holeCards = Vector.fill(n)(Nil),
+      board = Nil,
+      deck = Nil,
+      street = Street.PreFlop,
+      toAct = 0,
+      streetContrib = Vector.fill(n)(0),
+      committed = Vector.fill(n)(0),
+      currentBet = 0,
+      lastRaiseSize = BigBlind,
+      hasActed = Vector.fill(n)(false),
+      folded = Vector.fill(n)(false),
+      allIn = Vector.fill(n)(false),
+      handResult = None,
+      winner = None,
+      moveCount = 0
+    )
+    base.startHand(deck)
+  }
+}
+
+/** A No-Limit Texas Hold 'Em sit-and-go for 2–6 players.
+  *
+  * A "game" runs many hands until one seat holds all the chips — that seat is the single `Won` winner, so the game
+  * fits `GameStatus[Int]` with no draw and no multi-winner status. Individual hands are internal rounds: chips move
+  * between seats (including split and side pots) but only the last-player-standing outcome ever surfaces as the game's
+  * status. This mirrors Liar's Dice, whose game is a sequence of rounds ending when one player remains.
+  *
+  * The model is pure: cards are shuffled server-side and supplied to it — the first hand via [[TexasHoldEm.newGame]],
+  * each later hand via the [[HoldEmMove]] deck that the action starting it carries. Community cards are dealt up front
+  * and hidden at the view edge (only [[Street.revealed]]-many are shown); opponents' hole cards are revealed only
+  * through [[handResult]] at a showdown.
+  *
+  * @param playerIds seat order; the seat index into this vector is the game's player token
+  * @param stacks chips held by each seat; a seat at zero has been eliminated from the sit-and-go
+  * @param button the dealer-button seat for the current hand
+  * @param holeCards each seat's two hole cards for the current hand (empty for an eliminated seat)
+  * @param board the current hand's five community cards, dealt up front and revealed a street at a time
+  * @param deck the current hand's undealt cards; a leave that must start a new hand deals from this unseen remainder
+  * @param street the current betting street
+  * @param toAct the seat whose turn it is to act
+  * @param streetContrib chips each seat has put in on the current street (reset each street)
+  * @param committed chips each seat has put in over the whole hand (drives pot and side-pot construction)
+  * @param currentBet the highest street contribution — the amount a seat must match to stay in
+  * @param lastRaiseSize the size of the last bet or raise, the minimum a further raise must add
+  * @param hasActed whether each seat has acted on the current street (reset each street)
+  * @param folded whether each seat has folded (or been eliminated) for the current hand
+  * @param allIn whether each seat is all-in for the current hand
+  * @param handResult the public record of the most recently finished hand, or None before any hand ends
+  * @param winner the winning seat once one player holds all the chips, otherwise None
+  * @param moveCount total player actions applied so far; survives serialization for the history log
+  */
+final case class TexasHoldEm(
+    playerIds: Vector[PlayerId],
+    stacks: Vector[Int],
+    button: Int,
+    holeCards: Vector[List[Card]],
+    board: List[Card],
+    deck: List[Card],
+    street: Street,
+    toAct: Int,
+    streetContrib: Vector[Int],
+    committed: Vector[Int],
+    currentBet: Int,
+    lastRaiseSize: Int,
+    hasActed: Vector[Boolean],
+    folded: Vector[Boolean],
+    allIn: Vector[Boolean],
+    handResult: Option[HandResult],
+    winner: Option[Int],
+    moveCount: Int
+) extends Game[HoldEmMove, TexasHoldEm, Int, GameStatus[Int], GameError] {
+
+  import Action._
+  import TexasHoldEm.{BigBlind, HoleCards, SmallBlind}
+
+  private val n: Int = playerIds.size
+
+  def currentState: TexasHoldEm = this
+  def currentPlayer: Int = toAct
+  def gameStatus: GameStatus[Int] = winner.map(Won(_)).getOrElse(InProgress)
+  def players: List[PlayerId] = playerIds.toList
+
+  /** Resolves a platform player ID to its zero-based seat index, or `None` if not a participant. */
+  def playerFor(playerId: PlayerId): Option[Int] = {
+    val i = playerIds.indexOf(playerId)
+    if (i >= 0) Some(i) else None
+  }
+
+  /** Chips in the pot (and side pots) for the current hand — the sum of every seat's committed chips. */
+  def pot: Int = committed.sum
+
+  /** The amount `seat` must put in to call the current bet. */
+  def toCall(seat: Int): Int = math.max(0, currentBet - streetContrib(seat))
+
+  // --- seat predicates -------------------------------------------------------------------------------------------
+
+  private def inHand(seat: Int): Boolean = !folded(seat)
+  private def contestable(seat: Int): Boolean = inHand(seat) && !allIn(seat)
+  private def contestableCount: Int = (0 until n).count(contestable)
+
+  /** A seat still owes an action this street if it can act and has either not acted or not yet matched the bet. */
+  private def needsAction(seat: Int): Boolean =
+    contestable(seat) && (!hasActed(seat) || streetContrib(seat) < currentBet)
+
+  private def roundComplete: Boolean = !(0 until n).exists(needsAction)
+
+  /** All seats in clockwise order strictly after `from` (the n-1 other seats). */
+  private def seatsAfter(from: Int): Seq[Int] = (1 until n).map(i => (from + i) % n)
+
+  /** All n seats in clockwise order starting just after `from` and ending at `from`. */
+  private def orderFrom(from: Int): Seq[Int] = (1 to n).map(i => (from + i) % n)
+
+  private def nextSeat(from: Int)(pred: Int => Boolean): Option[Int] = seatsAfter(from).find(pred)
+
+  // --- applying a move -------------------------------------------------------------------------------------------
+
+  /** Applies a player action, then settles the table: advances the turn, opens the next street, runs a showdown, and
+    * deals the next hand as needed, all in one step. Rejects an out-of-turn player or a finished game.
+    */
+  def play(player: Int, move: HoldEmMove): Either[GameError, TexasHoldEm] =
+    if (winner.isDefined) Left(GameOver)
+    else if (player != toAct) Left(InvalidTurn)
+    else applyAction(player, move.action).map(_.copy(moveCount = moveCount + 1).settle(move.deck))
+
+  /** Validates and applies a single action for `seat`, updating that seat's chips and the street's betting state. */
+  private def applyAction(seat: Int, action: Action): Either[GameError, TexasHoldEm] = action match {
+    case Fold =>
+      Right(copy(folded = folded.updated(seat, true), hasActed = hasActed.updated(seat, true)))
+
+    case Check =>
+      if (streetContrib(seat) < currentBet) Left(CannotCheck)
+      else Right(markActed(seat))
+
+    case Call =>
+      val pay = math.min(toCall(seat), stacks(seat))
+      Right(putIn(seat, pay).markActed(seat))
+
+    case Bet(amount) =>
+      if (currentBet > 0) Left(BetNotAllowed)
+      else if (amount > stacks(seat)) Left(InsufficientChips)
+      else if (amount < BigBlind && amount < stacks(seat)) Left(BetTooSmall)
+      else Right(putIn(seat, amount).copy(currentBet = amount, lastRaiseSize = amount).markActed(seat))
+
+    case Raise(toAmount) =>
+      val additional = toAmount - streetContrib(seat)
+      val increment = toAmount - currentBet
+      if (currentBet == 0) Left(RaiseNotAllowed)
+      else if (increment <= 0) Left(RaiseTooSmall)
+      else if (additional > stacks(seat)) Left(InsufficientChips)
+      else if (increment < lastRaiseSize && additional < stacks(seat)) Left(RaiseTooSmall)
+      else {
+        val newLastRaise = if (increment >= lastRaiseSize) increment else lastRaiseSize
+        Right(putIn(seat, additional).copy(currentBet = toAmount, lastRaiseSize = newLastRaise).markActed(seat))
+      }
+  }
+
+  /** Moves `amount` chips from `seat`'s stack into the pot, flagging the seat all-in if it empties their stack. */
+  private def putIn(seat: Int, amount: Int): TexasHoldEm = {
+    val remaining = stacks(seat) - amount
+    copy(
+      stacks = stacks.updated(seat, remaining),
+      streetContrib = streetContrib.updated(seat, streetContrib(seat) + amount),
+      committed = committed.updated(seat, committed(seat) + amount),
+      allIn = if (remaining == 0) allIn.updated(seat, true) else allIn
+    )
+  }
+
+  private def markActed(seat: Int): TexasHoldEm = copy(hasActed = hasActed.updated(seat, true))
+
+  /** Advances the table after an action or a leave: continues the street, opens the next one, or ends the hand.
+    *
+    * `handDeck` supplies the cards for the next hand should this step start one — the injected shuffle for a normal
+    * move, or the current hand's unseen remainder for a leave.
+    */
+  private def settle(handDeck: List[Card]): TexasHoldEm =
+    if ((0 until n).count(inHand) == 1) concludeHand(showdown = false, handDeck)
+    else if (roundComplete)
+      if (street == Street.River || contestableCount <= 1) concludeHand(showdown = true, handDeck)
+      else advanceStreet
+    else {
+      // the actor (or leaver) has acted; pass the turn to the next seat that still owes an action, unless the current
+      // seat still does (a leave by a player who was not on the clock leaves the turn where it was)
+      val next = if (needsAction(toAct)) toAct else nextSeat(toAct)(needsAction).get
+      copy(toAct = next)
+    }
+
+  /** Opens the next street: reveals its community cards (via the view), clears the street's betting, and gives the turn
+    * to the first seat left of the button that can still act.
+    */
+  private def advanceStreet: TexasHoldEm = {
+    val fresh = copy(
+      street = Street.next(street).get,
+      streetContrib = Vector.fill(n)(0),
+      currentBet = 0,
+      lastRaiseSize = BigBlind,
+      hasActed = Vector.fill(n)(false)
+    )
+    fresh.copy(toAct = orderFrom(button).find(fresh.contestable).get)
+  }
+
+  // --- ending a hand ---------------------------------------------------------------------------------------------
+
+  /** Awards the pot(s), records the [[HandResult]], then either ends the sit-and-go or deals the next hand. */
+  private def concludeHand(showdown: Boolean, handDeck: List[Card]): TexasHoldEm = {
+    val (awards, newStacks) = computeAwards(showdown)
+    val shown =
+      if (showdown) (0 until n).filter(inHand).map(s => s -> holeCards(s)).toMap else Map.empty[Int, List[Card]]
+    val revealed = if (showdown) board else board.take(street.revealed)
+    val ended = copy(stacks = newStacks, handResult = Some(HandResult(revealed, shown, awards)))
+    ended.beginNextHandOrEnd(handDeck)
+  }
+
+  /** Splits the committed chips into a main pot and side pots and awards each to the best eligible hand.
+    *
+    * Pots are built from the distinct contribution levels across every seat (folded seats' chips are dead money in the
+    * pot but win nothing). Each level's pot is contested only by the non-folded seats that reached it; at a showdown it
+    * goes to the best five-card hand among them, split on a tie with any odd chip going to the first winner left of the
+    * button. The seat that committed the most is always non-folded (a fold never leaves you the top contributor), so
+    * every pot has at least one eligible winner and no chips are stranded — including an uncalled final bet, which
+    * returns to its lone eligible contributor.
+    *
+    * @return the pot awards and the resulting stacks
+    */
+  private def computeAwards(showdown: Boolean): (List[PotAward], Vector[Int]) =
+    if (!showdown) {
+      // everyone else folded: the lone remaining player takes the whole pot (their own uncalled chips included)
+      val winner = (0 until n).find(inHand).get
+      (List(PotAward(pot, List(winner), None)), stacks.updated(winner, stacks(winner) + pot))
+    } else {
+      val levels: Seq[Int] = committed.filter(_ > 0).distinct.sorted
+      val pots: Seq[(Int, Seq[Int])] = (0 +: levels).zip(levels).map { case (prev, level) =>
+        val atLevel = (0 until n).filter(committed(_) >= level)
+        ((level - prev) * atLevel.size, atLevel.filter(inHand))
+      }
+      val bestHands: Map[Int, Hand] =
+        (0 until n).filter(inHand).map(s => s -> Hand.bestHand((holeCards(s) ++ board).toSet)).toMap
+
+      val deltas = Array.fill(n)(0)
+      val awards = pots.map { case (amount, eligible) =>
+        val best = eligible.map(bestHands).max(Hand.handOrdering)
+        val winners = eligible.filter(s => bestHands(s).compare(best) == 0).toList
+        val share = amount / winners.size
+        winners.foreach(w => deltas(w) += share)
+        // odd chips go one at a time to the winners nearest the button's left
+        val ordered = orderFrom(button).filter(winners.toSet)
+        (0 until amount % winners.size).foreach(i => deltas(ordered(i)) += 1)
+        PotAward(amount, winners, Some(bestHands(winners.head).description))
+      }.toList
+
+      (awards, Vector.tabulate(n)(s => stacks(s) + deltas(s)))
+    }
+
+  /** Ends the sit-and-go if one seat now holds every chip, otherwise deals the next hand from `handDeck`. */
+  private def beginNextHandOrEnd(handDeck: List[Card]): TexasHoldEm = {
+    val survivors = (0 until n).filter(stacks(_) > 0)
+    if (survivors.size == 1) copy(winner = Some(survivors.head))
+    else startHand(handDeck)
+  }
+
+  /** Deals a new hand: rotates the button, deals hole and community cards from `deck`, posts the blinds, and gives the
+    * turn to the first seat to act — or, in the rare case where the blinds put everyone all-in, runs it to showdown.
+    */
+  private def startHand(deck: List[Card]): TexasHoldEm = {
+    val newButton = nextSeat(button)(stacks(_) > 0).get
+    val playing = (0 until n).filter(stacks(_) > 0)
+    val dealt = playing.zipWithIndex.map { case (seat, i) =>
+      seat -> deck.slice(i * HoleCards, i * HoleCards + HoleCards)
+    }.toMap
+    val boardStart = playing.size * HoleCards
+
+    val fresh = copy(
+      button = newButton,
+      holeCards = Vector.tabulate(n)(s => dealt.getOrElse(s, Nil)),
+      board = deck.slice(boardStart, boardStart + 5),
+      deck = deck.drop(boardStart + 5),
+      street = Street.PreFlop,
+      streetContrib = Vector.fill(n)(0),
+      committed = Vector.fill(n)(0),
+      currentBet = 0,
+      lastRaiseSize = BigBlind,
+      hasActed = Vector.fill(n)(false),
+      folded = Vector.tabulate(n)(stacks(_) == 0),
+      allIn = Vector.fill(n)(false)
+    )
+
+    val blinded = fresh.postBlinds()
+    if (blinded.contestableCount == 0) blinded.concludeHand(showdown = true, deck) else blinded
+  }
+
+  /** Posts the small and big blinds for the freshly dealt hand and sets the first seat to act preflop. */
+  private def postBlinds(): TexasHoldEm = {
+    val active = (0 until n).filter(stacks(_) > 0)
+    val smallSeat = if (active.size == 2) button else nextSeat(button)(stacks(_) > 0).get
+    val bigSeat = nextSeat(smallSeat)(stacks(_) > 0).get
+
+    val posted = postBlind(smallSeat, SmallBlind).postBlind(bigSeat, BigBlind)
+    val firstToAct = posted.orderFrom(bigSeat).find(posted.needsAction).getOrElse(bigSeat)
+    posted.copy(currentBet = posted.streetContrib.max, lastRaiseSize = BigBlind, toAct = firstToAct)
+  }
+
+  private def postBlind(seat: Int, amount: Int): TexasHoldEm = putIn(seat, math.min(amount, stacks(seat)))
+
+  /** Applies the effect of `playerId` leaving: they fold the current hand and forfeit their remaining stack (their
+    * already-committed chips stay in the pot). The table then settles like any action, but a leave carries no fresh
+    * cards, so a hand it collapses to a lone winner deals the next hand from this hand's unseen remaining [[deck]].
+    * Ends the sit-and-go if only one seat is left with chips. Rejects a non-participant or an already-finished game.
+    */
+  override def playerLeft(playerId: PlayerId): Either[GameError, TexasHoldEm] =
+    playerFor(playerId) match {
+      case None                        => Left(InvalidPlayer(playerId))
+      case Some(_) if winner.isDefined => Left(GameOver)
+      case Some(seat)                  =>
+        val left = copy(
+          folded = folded.updated(seat, true),
+          allIn = allIn.updated(seat, false),
+          stacks = stacks.updated(seat, 0),
+          hasActed = hasActed.updated(seat, true)
+        )
+        Right(left.settle(deck))
+    }
+}

--- a/game-service-model/src/main/scala/com/andy327/model/holdem/TexasHoldEm.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/holdem/TexasHoldEm.scala
@@ -74,6 +74,9 @@ object TexasHoldEm {
   /** Hole cards dealt to each seat still in the sit-and-go. */
   val HoleCards: Int = 2
 
+  /** Human-readable seat label for a zero-based seat index. */
+  def seatLabel(seat: Int): String = s"P${seat + 1}"
+
   /** Creates a fresh sit-and-go: equal starting stacks, the button just before seat 0 (so the first hand's button is
     * seat 0), and the first hand dealt and blinded from `deck`. `deck` is a full 52-card shuffle produced server-side.
     */

--- a/game-service-model/src/main/scala/com/andy327/model/holdem/package.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/holdem/package.scala
@@ -1,0 +1,43 @@
+package com.andy327.model
+
+/** Card primitives for poker: ranks, suits, and the hand-category enumeration. */
+package object holdem {
+
+  /** A card's rank as an integer from 2 to 14, where Jack = 11, Queen = 12, King = 13, and Ace = 14. */
+  type Rank = Int
+
+  /** One of the four card suits. Suits never affect a poker hand's strength; they matter only for flush detection and
+    * for identifying a specific card.
+    */
+  sealed trait Suit {
+
+    /** The single-letter code used for parsing and serialization (`S`, `H`, `C`, `D`). */
+    def letter: String
+
+    override def toString: String = letter
+  }
+
+  case object Spades extends Suit { val letter: String = "S" }
+  case object Hearts extends Suit { val letter: String = "H" }
+  case object Clubs extends Suit { val letter: String = "C" }
+  case object Diamonds extends Suit { val letter: String = "D" }
+
+  object Suit {
+
+    /** All four suits. */
+    val all: List[Suit] = List(Spades, Hearts, Clubs, Diamonds)
+
+    /** Parses a single-letter suit code (`S`, `H`, `C`, `D`), or fails if it is not one of the four. */
+    def apply(letter: String): Suit =
+      all.find(_.letter == letter).getOrElse(sys.error(s"Invalid Suit representation: $letter"))
+  }
+
+  /** The nine poker hand categories, declared from weakest ([[HandType.HighCard]]) to strongest
+    * ([[HandType.RoyalFlush]]). The enumeration's own ascending value order is what makes hands of different categories
+    * directly comparable in [[Hand.handOrdering]].
+    */
+  object HandType extends Enumeration {
+    val HighCard, OnePair, TwoPair, ThreeOfAKind, Straight, Flush, FullHouse, FourOfAKind, StraightFlush, RoyalFlush =
+      Value
+  }
+}

--- a/game-service-model/src/test/scala/com/andy327/model/holdem/HandSpec.scala
+++ b/game-service-model/src/test/scala/com/andy327/model/holdem/HandSpec.scala
@@ -1,0 +1,194 @@
+package com.andy327.model.holdem
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class HandSpec extends AnyWordSpec with Matchers {
+  import HandType._
+
+  /** Builds a hand from cards written in text form, e.g. `hand("AS", "KS", "QS", "JS", "TS")`. */
+  private def hand(cards: String*): Hand = Hand(cards.map(Card(_)).toSet)
+
+  /** True when `a` outranks `b` (a wins the pot outright). */
+  private def beats(a: Hand, b: Hand): Boolean = a.compare(b) > 0
+
+  /** True when `a` and `b` tie (a split pot). */
+  private def ties(a: Hand, b: Hand): Boolean = a.compare(b) == 0
+
+  "Card" should {
+    "parse rank-and-suit text into a Card" in {
+      Card("AS") shouldBe Card(14, Spades)
+      Card("TD") shouldBe Card(10, Diamonds)
+      Card("9H") shouldBe Card(9, Hearts)
+      Card("2C") shouldBe Card(2, Clubs)
+    }
+
+    "reject a rank outside 2–14" in {
+      an[IllegalArgumentException] should be thrownBy Card(1, Spades)
+      an[IllegalArgumentException] should be thrownBy Card(15, Spades)
+    }
+
+    "expose a full 52-card deck of distinct cards" in {
+      Card.deck.size shouldBe 52
+      Card.deck.toSet.size shouldBe 52
+    }
+
+    "render each rank as its display symbol" in {
+      Card.rankToString(14) shouldBe "A"
+      Card.rankToString(13) shouldBe "K"
+      Card.rankToString(12) shouldBe "Q"
+      Card.rankToString(11) shouldBe "J"
+      Card.rankToString(10) shouldBe "T"
+      Card.rankToString(9) shouldBe "9"
+    }
+
+    "render as its rank symbol followed by its suit letter" in {
+      Card(11, Clubs).toString shouldBe "JC"
+      Card(10, Diamonds).toString shouldBe "TD"
+    }
+  }
+
+  "Suit" should {
+    "render as its single-letter code" in {
+      Spades.toString shouldBe "S"
+      Hearts.toString shouldBe "H"
+      Clubs.toString shouldBe "C"
+      Diamonds.toString shouldBe "D"
+    }
+
+    "parse a single-letter code back into a suit" in {
+      Suit("S") shouldBe Spades
+      Suit("D") shouldBe Diamonds
+    }
+
+    "reject an unknown suit code" in {
+      a[RuntimeException] should be thrownBy Suit("Z")
+    }
+  }
+
+  "Hand construction" should {
+    "accept up to five distinct cards passed individually" in {
+      val h = Hand(Card("AS"), Card("KS"), Card("QS"), Card("JS"), Card("TS"))
+      h.cards should have size 5
+      h.handType shouldBe RoyalFlush
+    }
+
+    "reject duplicate cards" in {
+      an[IllegalArgumentException] should be thrownBy Hand(Card("AS"), Card("AS"))
+    }
+
+    "reject more than five cards" in {
+      val six = Set("AS", "KS", "QS", "JS", "TS", "9S").map(Card(_))
+      an[IllegalArgumentException] should be thrownBy Hand(six)
+    }
+
+    "render its cards from strongest rank to weakest" in {
+      hand("AS", "KH", "QD", "JC", "9S").toString shouldBe "[AS KH QD JC 9S]"
+    }
+  }
+
+  "Hand categorization" should {
+    "detect a royal flush" in {
+      hand("AS", "KS", "QS", "JS", "TS").handType shouldBe RoyalFlush
+    }
+    "detect a straight flush" in {
+      hand("9H", "8H", "7H", "6H", "5H").handType shouldBe StraightFlush
+    }
+    "treat a wheel straight flush as a straight flush" in {
+      hand("5D", "4D", "3D", "2D", "AD").handType shouldBe StraightFlush
+    }
+    "detect four of a kind" in {
+      hand("7S", "7H", "7C", "7D", "KS").handType shouldBe FourOfAKind
+    }
+    "detect a full house" in {
+      hand("KS", "KH", "KD", "5C", "5S").handType shouldBe FullHouse
+    }
+    "detect a flush" in {
+      hand("AH", "JH", "8H", "5H", "2H").handType shouldBe Flush
+    }
+    "detect a straight" in {
+      hand("9S", "8H", "7C", "6D", "5S").handType shouldBe Straight
+    }
+    "treat the wheel as the lowest straight" in {
+      hand("5C", "4D", "3H", "2S", "AS").handType shouldBe Straight
+    }
+    "detect three of a kind" in {
+      hand("QS", "QH", "QD", "9C", "2S").handType shouldBe ThreeOfAKind
+    }
+    "detect two pair" in {
+      hand("KS", "KH", "5D", "5C", "AS").handType shouldBe TwoPair
+    }
+    "detect one pair" in {
+      hand("KS", "KH", "9D", "5C", "2S").handType shouldBe OnePair
+    }
+    "detect high card" in {
+      hand("KS", "JH", "9D", "5C", "2S").handType shouldBe HighCard
+    }
+  }
+
+  "Hand ranking" should {
+    "rank the categories in order" in {
+      val ordered = List(
+        hand("KS", "JH", "9D", "5C", "2S"), // high card
+        hand("KS", "KH", "9D", "5C", "2S"), // one pair
+        hand("KS", "KH", "5D", "5C", "AS"), // two pair
+        hand("QS", "QH", "QD", "9C", "2S"), // three of a kind
+        hand("9S", "8H", "7C", "6D", "5S"), // straight
+        hand("AH", "JH", "8H", "5H", "2H"), // flush
+        hand("KS", "KH", "KD", "5C", "5S"), // full house
+        hand("7S", "7H", "7C", "7D", "KS"), // four of a kind
+        hand("9H", "8H", "7H", "6H", "5H"), // straight flush
+        hand("AS", "KS", "QS", "JS", "TS") // royal flush
+      )
+      ordered.zip(ordered.tail).foreach { case (weaker, stronger) => beats(stronger, weaker) shouldBe true }
+    }
+
+    "break ties on kickers for the same category" in {
+      beats(hand("KS", "KH", "AD", "5C", "2S"), hand("KS", "KH", "QD", "5C", "2S")) shouldBe true
+    }
+
+    "break two-pair ties on the fifth card" in {
+      beats(hand("KS", "KH", "5D", "5C", "AS"), hand("KH", "KD", "5H", "5S", "2C")) shouldBe true
+    }
+
+    "rank the wheel below a six-high straight" in {
+      beats(hand("6S", "5H", "4C", "3D", "2S"), hand("5C", "4D", "3H", "2S", "AS")) shouldBe true
+    }
+
+    "rank a broadway straight above every other straight" in {
+      beats(hand("AS", "KH", "QC", "JD", "TS"), hand("KS", "QH", "JC", "TD", "9S")) shouldBe true
+    }
+
+    "rank full houses by the trips first even when the pair outranks them" in {
+      // kings full of fives beats queens full of aces, though the aces are the highest card present
+      beats(hand("KS", "KH", "KD", "5C", "5S"), hand("QS", "QH", "QD", "AC", "AS")) shouldBe true
+    }
+
+    "rank full houses by the pair only when the trips tie" in {
+      beats(hand("AS", "AH", "AD", "KC", "KS"), hand("AC", "AD", "AH", "QC", "QS")) shouldBe true
+    }
+
+    "treat two flushes with identical ranks as a tie" in {
+      ties(hand("AS", "KS", "QS", "JS", "9S"), hand("AH", "KH", "QH", "JH", "9H")) shouldBe true
+    }
+  }
+
+  "Hand.bestHand" should {
+    "find the best five of seven cards" in {
+      Hand.bestHand(Set("AS", "KS", "QS", "JS", "TS", "2D", "3C").map(Card(_))).handType shouldBe RoyalFlush
+    }
+
+    "prefer a full house over a lower flush draw of seven cards" in {
+      val best = Hand.bestHand(Set("AS", "AH", "AD", "KS", "KH", "2C", "3D").map(Card(_)))
+      best.handType shouldBe FullHouse
+      best.description shouldBe "full house, As over Ks"
+    }
+
+    "pick the highest kicker when the made hand leaves a choice" in {
+      // trip fives with an ace and a king available as kickers -> keep the ace
+      val best = Hand.bestHand(Set("5S", "5H", "5D", "AC", "KD", "2S", "3H").map(Card(_)))
+      best.handType shouldBe ThreeOfAKind
+      best.cardRanks shouldBe Seq(5, 5, 5, 14, 13)
+    }
+  }
+}

--- a/game-service-model/src/test/scala/com/andy327/model/holdem/TexasHoldEmSpec.scala
+++ b/game-service-model/src/test/scala/com/andy327/model/holdem/TexasHoldEmSpec.scala
@@ -1,0 +1,359 @@
+package com.andy327.model.holdem
+
+import java.util.UUID
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{EitherValues, OptionValues}
+
+import com.andy327.model.core.GameError.{GameOver, InvalidPlayer, InvalidTurn}
+import com.andy327.model.core.{InProgress, PlayerId, Won}
+
+class TexasHoldEmSpec extends AnyWordSpec with Matchers with OptionValues with EitherValues {
+  import Action._
+
+  private val alice: PlayerId = UUID.randomUUID()
+  private val bob: PlayerId = UUID.randomUUID()
+  private val carol: PlayerId = UUID.randomUUID()
+
+  /** A full deck; used as each move's next-hand deck since only a hand-starting move ever consumes it. */
+  private val full: List[Card] = Card.deck
+
+  private def cards(text: String*): List[Card] = text.map(Card(_)).toList
+
+  private def move(action: Action, deck: List[Card] = Nil): HoldEmMove = HoldEmMove(action, deck)
+
+  /** A fresh heads-up game, seat 0 to act with the blinds posted. */
+  private def headsUp: TexasHoldEm = TexasHoldEm.newGame(Seq(alice, bob), full)
+
+  /** Applies a sequence of `(seat, action)` moves, each carrying a full next-hand deck, failing on any rejection. */
+  private def playAll(game: TexasHoldEm, moves: (Int, Action)*): TexasHoldEm =
+    moves.foldLeft(game) { case (g, (seat, action)) =>
+      g.play(seat, move(action, full)) match {
+        case Right(next) => next
+        case Left(err)   => fail(s"move ($seat, $action) rejected: $err")
+      }
+    }
+
+  /** Builds a mid-hand table directly, defaulting the bookkeeping so a test need only set what it exercises. */
+  private def table(
+      ids: Vector[PlayerId],
+      stacks: Vector[Int],
+      holeCards: Vector[List[Card]],
+      board: List[Card],
+      toAct: Int = 0,
+      button: Int = 0,
+      currentBet: Int = 0,
+      street: Street = Street.PreFlop,
+      committed: Option[Vector[Int]] = None,
+      folded: Option[Vector[Boolean]] = None,
+      deck: List[Card] = Nil
+  ): TexasHoldEm = {
+    val size = ids.size
+    TexasHoldEm(
+      playerIds = ids,
+      stacks = stacks,
+      button = button,
+      holeCards = holeCards,
+      board = board,
+      deck = deck,
+      street = street,
+      toAct = toAct,
+      streetContrib = Vector.fill(size)(0),
+      committed = committed.getOrElse(Vector.fill(size)(0)),
+      currentBet = currentBet,
+      lastRaiseSize = TexasHoldEm.BigBlind,
+      hasActed = Vector.fill(size)(false),
+      folded = folded.getOrElse(Vector.fill(size)(false)),
+      allIn = Vector.fill(size)(false),
+      handResult = None,
+      winner = None,
+      moveCount = 0
+    )
+  }
+
+  "A TexasHoldEm game" should {
+
+    "resolve participants to their seat indices with playerFor" in {
+      val g = headsUp
+      g.playerFor(alice) shouldBe Some(0)
+      g.playerFor(bob) shouldBe Some(1)
+      g.playerFor(UUID.randomUUID()) shouldBe None
+    }
+
+    "list its roster in seat order with players" in {
+      headsUp.players shouldBe List(alice, bob)
+    }
+
+    "start with blinds posted, cards dealt, and the button to act" in {
+      val g = headsUp
+      g.stacks shouldBe Vector(995, 990) // SB 5, BB 10
+      g.pot shouldBe 15
+      g.currentBet shouldBe 10
+      g.button shouldBe 0
+      g.holeCards(0).size shouldBe 2
+      g.holeCards(1).size shouldBe 2
+      g.board.size shouldBe 5
+      g.toAct shouldBe 0
+      g.currentPlayer shouldBe 0
+      g.gameStatus shouldBe InProgress
+      g.moveCount shouldBe 0
+    }
+
+    "hand the uncontested pot to the last player and deal the next hand on a fold" in {
+      val g = headsUp.play(0, move(Fold, full)).value
+
+      val award = g.handResult.value.awards.head
+      award.amount shouldBe 15
+      award.winners shouldBe List(1)
+      award.description shouldBe None // mucked, no showdown
+
+      g.winner shouldBe None // both still have chips, a new hand is under way
+      g.button shouldBe 1 // button rotated
+      g.stacks shouldBe Vector(985, 1000) // hand 2 blinds already posted (button/SB 1, BB 0)
+    }
+
+    "award the pot to the best five-card hand at showdown" in {
+      val deck = cards("AS", "AH", "KS", "KH", "AD", "7C", "2D", "5S", "9H")
+      val start = TexasHoldEm.newGame(Seq(alice, bob), deck) // seat 0: AsAh, seat 1: KsKh, board Ad 7c 2d 5s 9h
+      val g = playAll(
+        start,
+        (0, Call),
+        (1, Check),
+        (1, Check),
+        (0, Check),
+        (1, Check),
+        (0, Check),
+        (1, Check),
+        (0, Check)
+      )
+      val award = g.handResult.value.awards.head
+      award.amount shouldBe 20
+      award.winners shouldBe List(0)
+      award.description.value should startWith("three of a kind")
+    }
+
+    "reject a move out of turn" in {
+      headsUp.play(1, move(Check)) shouldBe Left(InvalidTurn)
+    }
+
+    "reject checking while facing a bet" in {
+      headsUp.play(0, move(Check)) shouldBe Left(CannotCheck)
+    }
+
+    "reject betting when there is already a bet" in {
+      headsUp.play(0, move(Bet(50))) shouldBe Left(BetNotAllowed)
+    }
+
+    "reject a raise below the minimum" in {
+      headsUp.play(0, move(Raise(15))) shouldBe Left(RaiseTooSmall) // min raise is to 20
+    }
+
+    "reject a raise that does not exceed the current bet" in {
+      headsUp.play(0, move(Raise(10))) shouldBe Left(RaiseTooSmall) // equal to the current bet, not a raise
+    }
+
+    "reject a raise committing more chips than the stack holds" in {
+      headsUp.play(0, move(Raise(5000))) shouldBe Left(InsufficientChips)
+    }
+
+    "reject an opening bet below the big blind on a later street" in {
+      val flop = playAll(headsUp, (0, Call), (1, Check)) // both check to the flop, where the current bet is zero
+      flop.street shouldBe Street.Flop
+      flop.play(flop.toAct, move(Bet(5))) shouldBe Left(BetTooSmall)
+    }
+
+    "reject an opening bet larger than the stack" in {
+      val flop = playAll(headsUp, (0, Call), (1, Check))
+      flop.play(flop.toAct, move(Bet(5000))) shouldBe Left(InsufficientChips)
+    }
+
+    "reject a raise with no bet to raise" in {
+      val flop = playAll(headsUp, (0, Call), (1, Check))
+      flop.play(flop.toAct, move(Raise(20))) shouldBe Left(RaiseNotAllowed)
+    }
+
+    "accept a legal minimum raise" in {
+      val raised = headsUp.play(0, move(Raise(20))).value
+      raised.currentBet shouldBe 20
+      raised.toAct shouldBe 1
+    }
+
+    "allow a short all-in raise and leave the minimum raise unchanged" in {
+      // facing a bet of 10, a 13-chip stack can shove for a 3-chip raise even though the minimum raise is 10
+      val start = table(
+        ids = Vector(alice, bob),
+        stacks = Vector(13, 200),
+        holeCards = Vector(cards("AS", "AD"), cards("KS", "KD")),
+        board = cards("2C", "7D", "9S", "3H", "5C"),
+        toAct = 0,
+        currentBet = 10
+      )
+      val shoved = start.play(0, move(Raise(13))).value
+      shoved.currentBet shouldBe 13
+      shoved.allIn(0) shouldBe true
+      shoved.lastRaiseSize shouldBe 10 // a short all-in does not raise the minimum
+    }
+
+    "split the pot into a main pot and side pots by eligibility" in {
+      // seat 0 all-in for 20, seat 1 all-in for 60, seat 2 covers with chips to spare
+      val start = table(
+        ids = Vector(alice, bob, carol),
+        stacks = Vector(20, 60, 100),
+        holeCards = Vector(cards("AS", "AD"), cards("KS", "KD"), cards("QS", "QD")),
+        board = cards("AH", "2C", "7D", "9S", "3H") // seat 0 trips aces, seat 1 pair kings, seat 2 pair queens
+      )
+      val g = start
+        .play(0, move(Bet(20)))
+        .value
+        .play(1, move(Raise(60)))
+        .value
+        .play(2, move(Call, full))
+        .value
+
+      val awards = g.handResult.value.awards
+      awards.map(_.amount) shouldBe List(60, 80) // main 20*3, side 40*2
+      awards.head.winners shouldBe List(0) // trips aces take the main pot
+      awards(1).winners shouldBe List(1) // kings beat queens for the side pot
+    }
+
+    "split a tied pot evenly and give the odd chip to the first winner left of the button" in {
+      // seats 0 and 1 both play the board straight; seat 2 has folded; the 15-chip pot splits 7/8
+      val start = table(
+        ids = Vector(alice, bob, carol),
+        stacks = Vector(95, 95, 95),
+        holeCards = Vector(cards("KS", "KD"), cards("QS", "QD"), cards("7H", "8H")),
+        board = cards("2S", "3S", "4D", "5C", "6H"),
+        street = Street.River,
+        committed = Some(Vector(5, 5, 5)),
+        folded = Some(Vector(false, false, true))
+      )
+      val g = playAll(start, (0, Check), (1, Check))
+
+      val award = g.handResult.value.awards.head
+      award.amount shouldBe 15
+      award.winners shouldBe List(0, 1)
+      // showdown stacks 102/103/95, then hand 2 blinds (button 1, SB seat 2, BB seat 0): the odd chip sat with seat 1
+      g.stacks shouldBe Vector(92, 103, 90)
+    }
+
+    "end the game when one player wins every chip" in {
+      val start = table(
+        ids = Vector(alice, bob),
+        stacks = Vector(1000, 1000),
+        holeCards = Vector(cards("AS", "AD"), cards("KS", "KD")),
+        board = cards("AH", "2C", "7D", "9S", "3H") // seat 0 makes trips aces
+      )
+      val g = start.play(0, move(Bet(1000))).value.play(1, move(Call, full)).value
+
+      g.winner shouldBe Some(0)
+      g.gameStatus shouldBe Won(0)
+      g.stacks shouldBe Vector(2000, 0)
+    }
+
+    "reject any move once the game is over" in {
+      val start = table(
+        ids = Vector(alice, bob),
+        stacks = Vector(1000, 1000),
+        holeCards = Vector(cards("AS", "AD"), cards("KS", "KD")),
+        board = cards("AH", "2C", "7D", "9S", "3H")
+      )
+      val over = start.play(0, move(Bet(1000))).value.play(1, move(Call, full)).value
+      over.play(0, move(Check)) shouldBe Left(GameOver)
+    }
+
+    "run the next hand to showdown when the blinds put both remaining players all-in" in {
+      // both players are shorter than the blinds, so the next hand is dealt straight to a showdown
+      val nextHand = cards("AS", "AD", "5C", "7D", "AH", "AC", "2S", "3H", "4D") // seat 0 flops quad aces
+      val start = table(
+        ids = Vector(alice, bob),
+        stacks = Vector(5, 3),
+        holeCards = Vector(cards("2H", "3S"), cards("4H", "5D")),
+        board = cards("KS", "KD", "KC", "2D", "2C")
+      )
+      val g = start.play(0, move(Fold, nextHand)).value
+
+      g.winner shouldBe Some(0)
+      g.stacks shouldBe Vector(8, 0)
+    }
+
+    "count only player actions in moveCount" in {
+      val g = playAll(headsUp, (0, Call), (1, Check))
+      g.moveCount shouldBe 2
+    }
+  }
+
+  "A leaving player" should {
+
+    "be rejected for a non-participant" in {
+      val stranger = UUID.randomUUID()
+      headsUp.playerLeft(stranger) shouldBe Left(InvalidPlayer(stranger))
+    }
+
+    "be rejected once the game is already over" in {
+      val over = headsUp.playerLeft(alice).value
+      over.playerLeft(bob) shouldBe Left(GameOver)
+    }
+
+    "hand the win to the last remaining player when only two are left" in {
+      val g = headsUp.playerLeft(alice).value
+      g.winner shouldBe Some(1)
+      g.gameStatus shouldBe Won(1)
+    }
+
+    "continue the hand when players remain and the leaver was not on the clock" in {
+      // seat 1 is the small blind, seat 0 (UTG) is to act
+      val g = TexasHoldEm.newGame(Seq(alice, bob, carol), full).playerLeft(bob).value
+      g.winner shouldBe None
+      g.folded(1) shouldBe true
+      g.stacks(1) shouldBe 0
+      g.toAct shouldBe 0
+    }
+
+    "award the pot and deal the next hand from the unseen deck when the leave ends the hand" in {
+      val start = table(
+        ids = Vector(alice, bob, carol),
+        stacks = Vector(500, 500, 500),
+        holeCards = Vector(cards("2S", "3S"), cards("KS", "KD"), cards("QS", "QD")),
+        board = cards("AH", "2C", "7D", "9S", "3H"),
+        toAct = 1,
+        street = Street.Flop,
+        committed = Some(Vector(10, 20, 20)),
+        folded = Some(Vector(true, false, false)), // seat 0 already folded
+        deck = full
+      )
+      val g = start.playerLeft(carol).value // only seat 1 remains in the hand
+
+      g.winner shouldBe None // seats 0 and 1 still have chips, so the sit-and-go continues
+      g.handResult.value.awards.head.winners shouldBe List(1)
+      g.stacks(2) shouldBe 0 // the leaver is out
+      g.board.size shouldBe 5 // a fresh hand was dealt from the remaining deck
+    }
+  }
+
+  "TexasHoldEm.newGame" should {
+
+    "post the blinds heads-up and have the button act first" in {
+      val g = TexasHoldEm.newGame(Seq(alice, bob), full)
+      g.stacks shouldBe Vector(995, 990) // button/SB 0, BB 1
+      g.currentBet shouldBe 10
+      g.toAct shouldBe 0 // heads-up, the button acts first pre-flop
+    }
+
+    "post blinds left of the button and let the seat after the big blind act first three-handed" in {
+      val g = TexasHoldEm.newGame(Seq(alice, bob, carol), full)
+      g.stacks shouldBe Vector(1000, 995, 990) // button 0, SB 1, BB 2
+      g.currentBet shouldBe 10
+      g.toAct shouldBe 0 // UTG = seat after the big blind
+    }
+  }
+
+  "Street.next" should {
+    "advance through the betting streets and stop after the river" in {
+      Street.next(Street.PreFlop) shouldBe Some(Street.Flop)
+      Street.next(Street.Flop) shouldBe Some(Street.Turn)
+      Street.next(Street.Turn) shouldBe Some(Street.River)
+      Street.next(Street.River) shouldBe None
+    }
+  }
+}

--- a/game-service-persistence/src/main/scala/com/andy327/persistence/db/schema/GameTypeCodecs.scala
+++ b/game-service-persistence/src/main/scala/com/andy327/persistence/db/schema/GameTypeCodecs.scala
@@ -1,5 +1,7 @@
 package com.andy327.persistence.db.schema
 
+import scala.util.Try
+
 import io.circe.generic.semiauto.deriveCodec
 import io.circe.parser.decode
 import io.circe.syntax._
@@ -8,6 +10,7 @@ import io.circe.{Codec, Decoder, Encoder}
 import com.andy327.model.battleship.{Battleship, Coord, Player1, Player2, PlayerBoard, Seat, Ship}
 import com.andy327.model.connectfour.{ConnectFour, Mark => ConnectFourMark, Red, Yellow}
 import com.andy327.model.core.{Game, GameType}
+import com.andy327.model.holdem.{Card, HandResult, PotAward, Street, TexasHoldEm}
 import com.andy327.model.liarsdice.{Bid, LiarsDice, Reveal, StandingBid}
 import com.andy327.model.mastermind.{Attempt, Codebreaker, Codemaker, Feedback, Mastermind, Peg, Role}
 import com.andy327.model.pig.Pig
@@ -29,6 +32,7 @@ object GameTypeCodecs {
       case "Pig"         => Right(GameType.Pig)
       case "Mastermind"  => Right(GameType.Mastermind)
       case "LiarsDice"   => Right(GameType.LiarsDice)
+      case "TexasHoldEm" => Right(GameType.TexasHoldEm)
       case other         => Left(s"Unknown GameType: $other")
     },
     Encoder.encodeString.contramap[GameType] {
@@ -38,6 +42,7 @@ object GameTypeCodecs {
       case GameType.Pig         => "Pig"
       case GameType.Mastermind  => "Mastermind"
       case GameType.LiarsDice   => "LiarsDice"
+      case GameType.TexasHoldEm => "TexasHoldEm"
     }
   )
 
@@ -105,6 +110,34 @@ object GameTypeCodecs {
   implicit val revealCodec: Codec[Reveal] = deriveCodec[Reveal]
   implicit val liarsDiceCodec: Codec[LiarsDice] = deriveCodec[LiarsDice]
 
+  // Texas Hold 'Em. A Card round-trips through its compact text form ("AS", "TD"); a Street through a lowercase name.
+  // Declared in dependency order so each is in scope for the deriveCodec that needs it. Action and HoldEmMove are absent
+  // on purpose: they are moves, not persisted state, and are encoded for the history log in the actor layer.
+  implicit val cardCodec: Codec[Card] = Codec.from(
+    Decoder.decodeString.emap(s => Try(Card(s)).toEither.left.map(_ => s"Invalid Card: $s")),
+    Encoder.encodeString.contramap[Card](_.toString)
+  )
+
+  implicit val streetCodec: Codec[Street] = Codec.from(
+    Decoder.decodeString.emap {
+      case "preflop" => Right(Street.PreFlop)
+      case "flop"    => Right(Street.Flop)
+      case "turn"    => Right(Street.Turn)
+      case "river"   => Right(Street.River)
+      case other     => Left(s"Invalid Street: $other")
+    },
+    Encoder.encodeString.contramap[Street] {
+      case Street.PreFlop => "preflop"
+      case Street.Flop    => "flop"
+      case Street.Turn    => "turn"
+      case Street.River   => "river"
+    }
+  )
+
+  implicit val potAwardCodec: Codec[PotAward] = deriveCodec[PotAward]
+  implicit val handResultCodec: Codec[HandResult] = deriveCodec[HandResult]
+  implicit val texasHoldEmCodec: Codec[TexasHoldEm] = deriveCodec[TexasHoldEm]
+
   /** Serializes a game instance to a JSON string using the codec for the given GameType. */
   def serializeGame(gameType: GameType, game: Game[_, _, _, _, _]): String = gameType match {
     case GameType.TicTacToe   => game.asInstanceOf[TicTacToe].asJson.noSpaces
@@ -113,6 +146,7 @@ object GameTypeCodecs {
     case GameType.Pig         => game.asInstanceOf[Pig].asJson.noSpaces
     case GameType.Mastermind  => game.asInstanceOf[Mastermind].asJson.noSpaces
     case GameType.LiarsDice   => game.asInstanceOf[LiarsDice].asJson.noSpaces
+    case GameType.TexasHoldEm => game.asInstanceOf[TexasHoldEm].asJson.noSpaces
   }
 
   /** Deserializes a game state JSON string into a Game instance based on the provided GameType. */
@@ -124,5 +158,6 @@ object GameTypeCodecs {
       case GameType.Pig         => decode[Pig](json).left.map(err => new Exception(err))
       case GameType.Mastermind  => decode[Mastermind](json).left.map(err => new Exception(err))
       case GameType.LiarsDice   => decode[LiarsDice](json).left.map(err => new Exception(err))
+      case GameType.TexasHoldEm => decode[TexasHoldEm](json).left.map(err => new Exception(err))
     }
 }

--- a/game-service-persistence/src/test/scala/com/andy327/persistence/db/schema/GameTypeCodecsSpec.scala
+++ b/game-service-persistence/src/test/scala/com/andy327/persistence/db/schema/GameTypeCodecsSpec.scala
@@ -12,6 +12,8 @@ import org.scalatest.wordspec.AnyWordSpec
 import com.andy327.model.battleship.{Battleship, Coord, Fire, Player1, Player2, PlayerBoard, Ship}
 import com.andy327.model.connectfour.{ConnectFour, Drop, Red}
 import com.andy327.model.core.{GameType, PlayerId}
+import com.andy327.model.holdem.Action.{Bet, Call, Check, Fold}
+import com.andy327.model.holdem.{Card, HandResult, HoldEmMove, PotAward, Street, TexasHoldEm}
 import com.andy327.model.liarsdice.{Bid, Challenge, LiarsDice, MakeBid, StandingBid}
 import com.andy327.model.mastermind.Peg.{Blue, Green, Red => MmRed, Yellow}
 import com.andy327.model.mastermind.{Codebreaker, Codemaker, Guess, Mastermind, SetCode}
@@ -265,6 +267,79 @@ class GameTypeCodecsSpec extends AnyWordSpec with Matchers {
 
     "return Left if Liar's Dice game JSON is invalid" in {
       deserializeGame(GameType.LiarsDice, """{ "not": "valid" }""").isLeft shouldBe true
+    }
+
+    "resolve texasholdem via GameType.fromString" in {
+      GameType.fromString("texasholdem") shouldBe Some(GameType.TexasHoldEm)
+    }
+
+    "correctly encode and decode GameType.TexasHoldEm" in {
+      val t: GameType = GameType.TexasHoldEm
+      val json = t.asJson.noSpaces
+      json shouldBe "\"TexasHoldEm\""
+      decode[GameType](json) shouldBe Right(GameType.TexasHoldEm)
+    }
+
+    "round-trip a Texas Hold 'Em game through serializeGame and deserializeGame" in {
+      // play a hand to a showdown so the round-trip exercises the Card, Street, PotAward, and HandResult codecs (the
+      // last carrying a shown-hands map and an odd-length board) alongside the full game state
+      val deck = "AS AH KS KH AD 7C 2D 5S 9H".split(" ").map(Card(_)).toList
+      val fullDeck = Card.deck
+      val game = TexasHoldEm
+        .newGame(Seq(alice, bob), deck)
+        .play(0, HoldEmMove(Call, fullDeck))
+        .flatMap(_.play(1, HoldEmMove(Check, fullDeck)))
+        .flatMap(_.play(1, HoldEmMove(Check, fullDeck)))
+        .flatMap(_.play(0, HoldEmMove(Bet(50), fullDeck)))
+        .flatMap(_.play(1, HoldEmMove(Fold, fullDeck)))
+        .toOption
+        .get
+      val json = serializeGame(GameType.TexasHoldEm, game)
+      deserializeGame(GameType.TexasHoldEm, json) shouldBe Right(game)
+    }
+
+    "round-trip a finished Texas Hold 'Em game with a showdown result present" in {
+      val game = TexasHoldEm
+        .newGame(Seq(alice, bob), Card.deck)
+        .copy(
+          handResult = Some(
+            HandResult(
+              board = "AS KD 9C 4H 2S".split(" ").map(Card(_)).toList,
+              shownHands = Map(0 -> List(Card("AH"), Card("AC")), 1 -> List(Card("KS"), Card("KH"))),
+              awards = List(PotAward(200, List(0), Some("three of a kind, As")))
+            )
+          ),
+          winner = Some(0)
+        )
+      val json = serializeGame(GameType.TexasHoldEm, game)
+      deserializeGame(GameType.TexasHoldEm, json) shouldBe Right(game)
+    }
+
+    "round-trip a Texas Hold 'Em game on every street" in {
+      val base = TexasHoldEm.newGame(Seq(alice, bob), Card.deck)
+      Seq(Street.PreFlop, Street.Flop, Street.Turn, Street.River).foreach { street =>
+        val game = base.copy(street = street)
+        val json = serializeGame(GameType.TexasHoldEm, game)
+        deserializeGame(GameType.TexasHoldEm, json) shouldBe Right(game)
+      }
+    }
+
+    "fail to decode an unknown Street in Texas Hold 'Em JSON" in {
+      val json = serializeGame(GameType.TexasHoldEm, TexasHoldEm.newGame(Seq(alice, bob), Card.deck))
+      val corrupted = json.replace("\"street\":\"preflop\"", "\"street\":\"showdown\"")
+      deserializeGame(GameType.TexasHoldEm, corrupted).isLeft shouldBe true
+    }
+
+    "fail to decode an invalid Card in Texas Hold 'Em JSON" in {
+      val game = TexasHoldEm.newGame(Seq(alice, bob), Card.deck)
+      val json = serializeGame(GameType.TexasHoldEm, game)
+      // corrupt a hole card's rank to something outside 2–14
+      val corrupted = json.replaceFirst("\"board\":\\[\"[^\"]+\"", "\"board\":[\"ZZ\"")
+      deserializeGame(GameType.TexasHoldEm, corrupted).isLeft shouldBe true
+    }
+
+    "return Left if Texas Hold 'Em game JSON is invalid" in {
+      deserializeGame(GameType.TexasHoldEm, """{ "not": "valid" }""").isLeft shouldBe true
     }
   }
 }

--- a/game-service-server/src/main/resources/web/app.js
+++ b/game-service-server/src/main/resources/web/app.js
@@ -27,7 +27,8 @@ const GAMES = {
   battleship:  { label: "Battleship",   maxPlayers: 2, move: (row, col) => ({ row, col }) },
   pig:         { label: "Pig",          maxPlayers: 8, pig: true },
   mastermind:  { label: "Mastermind",   maxPlayers: 2, mastermind: true },
-  liarsdice:   { label: "Liar's Dice",  maxPlayers: 6, liarsdice: true }
+  liarsdice:   { label: "Liar's Dice",  maxPlayers: 6, liarsdice: true },
+  texasholdem: { label: "Texas Hold 'Em", maxPlayers: 6, texasholdem: true }
 };
 
 const $ = (id) => document.getElementById(id);
@@ -725,6 +726,7 @@ function renderBoard(state) {
   $("rematch-btn").classList.add("hidden");
   setError("game-error", "");
   $("board").classList.remove("ld-active"); // cleared here so switching away from Liar's Dice restores the board grid
+  $("board").classList.remove("holdem-active"); // likewise for the free-sized Texas Hold 'Em table
 
   if (state.board1 !== undefined) {
     renderBattleshipBoard(state);
@@ -743,6 +745,11 @@ function renderBoard(state) {
 
   if (state.diceCounts !== undefined) {
     renderLiarsDiceBoard(state);
+    return;
+  }
+
+  if (state.seats !== undefined) {
+    renderTexasHoldEmBoard(state);
     return;
   }
 
@@ -1123,6 +1130,183 @@ function formatLdBid(bid) {
 }
 
 async function submitLiarsDiceMove(body) {
+  const game = session.game;
+  if (!game) return;
+  setError("game-error", "");
+  const res = await api(`/${game.gameType}/${game.roomId}/move`, { method: "POST", body });
+  if (!res.ok) flashError("game-error", res.data?.error || res.data || "Move rejected");
+}
+
+// --- Texas Hold 'Em --------------------------------------------------------------------------------------------------
+// The community board, a seat table (stacks, bets, folded/all-in), the viewer's own hole cards, the last hand's
+// showdown reveal, and betting controls. The server validates every bet/raise amount and rejects an illegal one.
+const HOLDEM_SUITS = { S: "♠", H: "♥", C: "♣", D: "♦" };
+
+function renderTexasHoldEmBoard(state) {
+  const board = $("board");
+  board.classList.remove("bs-active");
+  board.classList.add("holdem-active"); // the seat table is wider than the default board grid; let it size freely
+  board.innerHTML = "";
+  $("column-controls").innerHTML = "";
+
+  const over = Boolean(state.winner);
+  const spectating = Boolean(session.game && session.game.isSpectator) || state.viewerSeat == null;
+  const myTurn = !over && !spectating && state.currentPlayer === state.viewerSeat;
+
+  if (over) setStatus(state.winner === state.viewerSeat ? "You win the sit-and-go!" : `${state.winner} wins the sit-and-go!`);
+  else if (spectating) setStatus(`Spectating — ${state.currentPlayer} to act`);
+  else setStatus(myTurn ? "Your turn to act." : `${state.currentPlayer}'s turn…`);
+
+  // The community cards (revealed cards face-up, the rest face-down) and the pot.
+  const cards = document.createElement("div");
+  cards.className = "holdem-board";
+  for (let i = 0; i < 5; i++) cards.appendChild(makeHoldemCard(i < state.board.length ? state.board[i] : null));
+  board.appendChild(cards);
+
+  const pot = document.createElement("div");
+  pot.className = "holdem-pot";
+  pot.textContent = `Pot: ${state.pot}` + (state.currentBet ? ` · Current bet: ${state.currentBet}` : "");
+  board.appendChild(pot);
+
+  // Seats: stack, chips committed this hand, and whose turn it is.
+  const table = document.createElement("table");
+  table.className = "holdem-seats";
+  table.insertRow().innerHTML = "<th>Player</th><th>Stack</th><th>In pot</th><th></th>";
+  state.seats.forEach((s) => {
+    const row = table.insertRow();
+    row.className = s.seat === state.currentPlayer && !over ? "holdem-current" : "";
+    const you = s.seat === state.viewerSeat ? " (you)" : "";
+    const dealer = s.seat === state.button ? " Ⓓ" : ""; // circled D marks the dealer button
+    const status = s.folded ? "folded" : s.allIn ? "all-in" : s.bet > 0 ? `bet ${s.bet}` : "";
+    row.innerHTML = `<td>${s.seat}${you}${dealer}</td><td>${s.stack}</td><td>${s.committed}</td><td>${status}</td>`;
+  });
+  board.appendChild(table);
+
+  // The most recent hand's showdown reveal — the one moment hole cards come up.
+  if (state.handResult) board.appendChild(renderHoldemResult(state.handResult));
+
+  // The viewer's own hole cards.
+  if (state.holeCards && state.holeCards.length) {
+    const hand = document.createElement("div");
+    hand.className = "holdem-hand";
+    const label = document.createElement("span");
+    label.className = "holdem-label";
+    label.textContent = "Your hand:";
+    hand.appendChild(label);
+    state.holeCards.forEach((c) => hand.appendChild(makeHoldemCard(c)));
+    board.appendChild(hand);
+  }
+
+  if (myTurn) board.appendChild(makeHoldemControls(state));
+}
+
+// A single card face from its text form ("AS", "TD"), or a face-down card for a null (unrevealed) slot.
+function makeHoldemCard(card) {
+  const el = document.createElement("span");
+  el.className = "holdem-card";
+  if (!card) {
+    el.classList.add("holdem-card-back");
+    return el;
+  }
+  const suit = card.slice(-1);
+  if (suit === "H" || suit === "D") el.classList.add("holdem-card-red");
+  el.innerHTML =
+    `<span class="holdem-rank">${card.slice(0, -1)}</span>` +
+    `<span class="holdem-suit">${HOLDEM_SUITS[suit] || suit}</span>`;
+  return el;
+}
+
+// The showdown reveal: who won each pot and with what, plus the hole cards of everyone who reached the showdown.
+function renderHoldemResult(result) {
+  const box = document.createElement("div");
+  box.className = "holdem-reveal";
+  result.awards.forEach((a) => {
+    const p = document.createElement("p");
+    p.className = "holdem-reveal-summary";
+    const who = a.winners.join(", ");
+    p.textContent = a.description ? `${who} won ${a.amount} with ${a.description}.` : `${who} won ${a.amount}.`;
+    box.appendChild(p);
+  });
+  Object.keys(result.shownHands).sort().forEach((seat) => {
+    const row = document.createElement("div");
+    row.className = "holdem-hand";
+    const label = document.createElement("span");
+    label.className = "holdem-label";
+    label.textContent = `${seat}:`;
+    row.appendChild(label);
+    result.shownHands[seat].forEach((c) => row.appendChild(makeHoldemCard(c)));
+    box.appendChild(row);
+  });
+  return box;
+}
+
+// Fold, check-or-call, and a bet/raise amount (the total to commit this street) with an all-in shortcut. The bet/raise
+// row is hidden when the viewer cannot raise; a short all-in below the minimum raise is still offered as All-in.
+function makeHoldemControls(state) {
+  const wrap = document.createElement("div");
+  wrap.className = "holdem-controls";
+
+  const me = state.seats.find((s) => s.seat === state.viewerSeat) || { stack: 0, bet: 0 };
+  const maxTo = me.bet + me.stack; // the total this street if the viewer moves all-in
+
+  const row = document.createElement("div");
+  row.className = "row";
+
+  const fold = document.createElement("button");
+  fold.textContent = "Fold";
+  fold.onclick = () => submitTexasHoldEmMove({ action: "fold" });
+  row.appendChild(fold);
+
+  const callBtn = document.createElement("button");
+  if (state.toCall === 0) {
+    callBtn.textContent = "Check";
+    callBtn.onclick = () => submitTexasHoldEmMove({ action: "check" });
+  } else {
+    callBtn.textContent = `Call ${Math.min(state.toCall, me.stack)}`;
+    callBtn.onclick = () => submitTexasHoldEmMove({ action: "call" });
+  }
+  row.appendChild(callBtn);
+  wrap.appendChild(row);
+
+  if (maxTo > state.currentBet) {
+    const opening = state.currentBet === 0;
+    const betRow = document.createElement("div");
+    betRow.className = "row holdem-bet-row";
+
+    if (maxTo >= state.minRaise) {
+      const amount = document.createElement("input");
+      amount.type = "number";
+      amount.className = "holdem-amount";
+      amount.min = String(state.minRaise);
+      amount.max = String(maxTo);
+      amount.value = String(state.minRaise);
+      betRow.appendChild(amount);
+
+      const betBtn = document.createElement("button");
+      betBtn.textContent = opening ? "Bet" : "Raise to";
+      betBtn.onclick = () => {
+        const value = parseInt(amount.value, 10);
+        if (!Number.isInteger(value) || value < 1) {
+          flashError("game-error", "Enter a valid amount.");
+          return;
+        }
+        submitTexasHoldEmMove({ action: opening ? "bet" : "raise", amount: value });
+      };
+      betRow.appendChild(betBtn);
+    }
+
+    const allIn = document.createElement("button");
+    allIn.textContent = `All-in ${maxTo}`;
+    allIn.onclick = () => submitTexasHoldEmMove({ action: opening ? "bet" : "raise", amount: maxTo });
+    betRow.appendChild(allIn);
+
+    wrap.appendChild(betRow);
+  }
+
+  return wrap;
+}
+
+async function submitTexasHoldEmMove(body) {
   const game = session.game;
   if (!game) return;
   setError("game-error", "");

--- a/game-service-server/src/main/resources/web/index.html
+++ b/game-service-server/src/main/resources/web/index.html
@@ -57,6 +57,7 @@
       <button data-gametype="pig">Pig</button>
       <button data-gametype="mastermind">Mastermind</button>
       <button data-gametype="liarsdice">Liar's Dice</button>
+      <button data-gametype="texasholdem">Texas Hold 'Em</button>
     </div>
 
     <h3>Your games &amp; lobbies</h3>
@@ -74,6 +75,7 @@
         <option value="pig">Pig</option>
         <option value="mastermind">Mastermind</option>
         <option value="liarsdice">Liar's Dice</option>
+        <option value="texasholdem">Texas Hold 'Em</option>
       </select>
     </div>
     <ul id="lobby-list"></ul>

--- a/game-service-server/src/main/resources/web/style.css
+++ b/game-service-server/src/main/resources/web/style.css
@@ -404,3 +404,45 @@ button:disabled { opacity: 0.5; cursor: default; }
 .ld-qty { width: 4rem; }
 .ld-challenge { margin-top: 0.5rem; background: #8b1a1a; border-color: #a52020; }
 .ld-challenge:hover:not(:disabled) { background: #a52020; }
+
+/* Texas Hold 'Em: a community board of card faces, a seat table, and betting controls. */
+#board.holdem-active { display: block; max-width: none; }
+.holdem-board { display: flex; gap: 0.4rem; margin: 0.25rem 0; }
+.holdem-card {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 2.6rem;
+  height: 3.6rem;
+  border-radius: 0.35rem;
+  background: #f4f6fb;
+  color: #11151c;
+  border: 1px solid var(--line);
+  font-weight: 700;
+  line-height: 1.1;
+}
+.holdem-card-red { color: #c0392b; }
+.holdem-card-back {
+  background: repeating-linear-gradient(45deg, var(--accent-dim), var(--accent-dim) 4px, var(--panel) 4px, var(--panel) 8px);
+}
+.holdem-rank { font-size: 1.1rem; }
+.holdem-suit { font-size: 1.1rem; }
+.holdem-pot { color: var(--muted); margin: 0.3rem 0 0.6rem; }
+.holdem-seats { border-collapse: collapse; margin: 0.5rem 0; }
+.holdem-seats th, .holdem-seats td { padding: 0.25rem 0.9rem; text-align: left; border-bottom: 1px solid var(--line); }
+.holdem-seats th { color: var(--muted); font-weight: 600; }
+.holdem-current { background: var(--accent-dim); }
+.holdem-hand { display: flex; align-items: center; gap: 0.4rem; margin-top: 0.5rem; }
+.holdem-label { color: var(--muted); font-size: 0.9rem; min-width: 4.5rem; }
+.holdem-reveal {
+  margin-top: 0.75rem;
+  padding: 0.6rem 0.8rem;
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 0.4rem;
+}
+.holdem-reveal-summary { margin: 0 0 0.4rem; font-size: 0.9rem; }
+.holdem-controls { margin-top: 0.75rem; }
+.holdem-bet-row { gap: 0.5rem; align-items: center; margin-top: 0.5rem; }
+.holdem-amount { width: 6rem; }

--- a/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
@@ -147,6 +147,7 @@ object GameServer {
       new GameRoutes(GameType.Pig, system).routes,
       new GameRoutes(GameType.Mastermind, system).routes,
       new GameRoutes(GameType.LiarsDice, system).routes,
+      new GameRoutes(GameType.TexasHoldEm, system).routes,
       new WebSocketRoutes(system).routes,
       new TraceRoutes(system).routes,
       new MetricsRoutes(metricsRegistry).routes,

--- a/game-service-server/src/main/scala/com/andy327/server/analytics/GameMetrics.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/analytics/GameMetrics.scala
@@ -72,5 +72,6 @@ class GameMetrics(registry: CollectorRegistry) {
     case GameType.Pig         => "pig"
     case GameType.Mastermind  => "mastermind"
     case GameType.LiarsDice   => "liarsdice"
+    case GameType.TexasHoldEm => "texasholdem"
   }
 }

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -28,6 +28,10 @@ import com.andy327.actor.game.{
   GameState,
   GridGameState,
   GuessResult,
+  HoldEmHandResult,
+  HoldEmPotAward,
+  HoldEmSeat,
+  HoldEmState,
   LiarsDiceState,
   MastermindState,
   PigState,
@@ -134,9 +138,17 @@ object JsonProtocol extends CirceSupport {
 
   implicit val liarsDiceStateCodec: Codec[LiarsDiceState] = deriveCodec[LiarsDiceState]
 
+  implicit val holdEmSeatCodec: Codec[HoldEmSeat] = deriveCodec[HoldEmSeat]
+
+  implicit val holdEmPotAwardCodec: Codec[HoldEmPotAward] = deriveCodec[HoldEmPotAward]
+
+  implicit val holdEmHandResultCodec: Codec[HoldEmHandResult] = deriveCodec[HoldEmHandResult]
+
+  implicit val holdEmStateCodec: Codec[HoldEmState] = deriveCodec[HoldEmState]
+
   /** Encoder for the polymorphic `GameState` hierarchy (grid games share `GridGameState`; Battleship has its own
     * per-viewer `BattleshipState`; Pig has `PigState`; Mastermind has `MastermindState`; Liar's Dice has
-    * `LiarsDiceState`).
+    * `LiarsDiceState`; Texas Hold 'Em has `HoldEmState`).
     */
   implicit val gameStateEncoder: Encoder[GameState] = Encoder.instance {
     case s: GridGameState   => s.asJson
@@ -144,6 +156,7 @@ object JsonProtocol extends CirceSupport {
     case s: PigState        => s.asJson
     case s: MastermindState => s.asJson
     case s: LiarsDiceState  => s.asJson
+    case s: HoldEmState     => s.asJson
   }
 
   // Entity unmarshallers, declared per-type so they don't shadow the predefined `String` unmarshaller (see

--- a/game-service-server/src/test/scala/com/andy327/server/analytics/GameMetricsSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/analytics/GameMetricsSpec.scala
@@ -86,6 +86,13 @@ class GameMetricsSpec extends AnyWordSpec with Matchers {
       sample(registry, "games_started_total", Array("game_type"), Array("liarsdice")) shouldBe Some(1.0)
     }
 
+    "label Texas Hold 'Em events with the texasholdem game type" in {
+      val (registry, metrics) = fixture
+      metrics.record(GameStarted(UUID.randomUUID(), GameType.TexasHoldEm, 6))
+
+      sample(registry, "games_started_total", Array("game_type"), Array("texasholdem")) shouldBe Some(1.0)
+    }
+
     "label lobby chat as lobby and in-game chat by game type" in {
       val (registry, metrics) = fixture
       metrics.record(ChatSent(UUID.randomUUID(), Some(GameType.Battleship)))

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -26,6 +26,10 @@ import com.andy327.actor.game.{
   GameStateConverters,
   GridGameState,
   GuessResult,
+  HoldEmHandResult,
+  HoldEmPotAward,
+  HoldEmSeat,
+  HoldEmState,
   LiarsDiceState,
   MastermindState,
   PigState
@@ -179,6 +183,40 @@ class SerializationSpec extends AnyWordSpec with Matchers {
       json.hcursor.get[List[Int]]("dice") shouldBe Right(List(2, 3, 4, 5, 6))
       json.hcursor.get[String]("currentPlayer") shouldBe Right("P1")
       json.hcursor.downField("currentBid").get[Option[Int]]("face") shouldBe Right(None)
+    }
+
+    "encode a HoldEmState branch, keeping the viewer's hole cards and the showdown reveal" in {
+      val state: GameState = HoldEmState(
+        seats = List(
+          HoldEmSeat("P1", 990, 10, 10, folded = false, allIn = false),
+          HoldEmSeat("P2", 985, 15, 15, folded = false, allIn = false)
+        ),
+        holeCards = Some(List("AS", "AH")),
+        board = List("2C", "7D", "9S"),
+        button = "P1",
+        currentPlayer = "P2",
+        currentBet = 15,
+        minRaise = 30,
+        pot = 25,
+        toCall = 5,
+        street = "Flop",
+        winner = None,
+        viewerSeat = Some("P1"),
+        handResult = Some(
+          HoldEmHandResult(
+            List("2C"),
+            Map("P1" -> List("AS", "AH")),
+            List(HoldEmPotAward(25, List("P1"), Some("one pair, As")))
+          )
+        )
+      )
+      val json = state.asJson
+      json.hcursor.get[List[String]]("holeCards") shouldBe Right(List("AS", "AH"))
+      json.hcursor.get[String]("currentPlayer") shouldBe Right("P2")
+      json.hcursor.get[Int]("toCall") shouldBe Right(5)
+      json.hcursor.downField("handResult").downField("shownHands").get[List[String]]("P1") shouldBe Right(
+        List("AS", "AH")
+      )
     }
   }
 


### PR DESCRIPTION
### Overview
Adds No-Limit Texas Hold 'Em as a 2–6 player sit-and-go — the service's largest and most complex game. Closes #11.

### The one design decision that avoided a trait change
A "game" is a sit-and-go that runs hands until one seat holds every chip, so the terminal state is a single last-player-standing winner that fits `GameStatus[Int]` unchanged. Individual hands are internal rounds; split pots and side pots move chips between seats but never surface as the game's status. This is what let Hold 'Em ride the existing `Game`/`GameStatus`/`TurnBasedGameActor` abstraction with **no change to any shared type** — the same shape Liar's Dice already proved.

### Model & rules
- `model.holdem` provides the card and hand-ranking types — `Card`/`Suit`/`Hand`/`HandType` — that pick the best five-card hand out of seven with kickers, and a `Hand` comparison of zero doubles as the split-pot tie test since suits never affect a hand's strength.
- Four streets, blinds with heads-up and multi-way button rules, No-Limit betting with min-raise and all-in handling, and full side-pot resolution by contribution level with odd chips going to the first winner left of the button.
- `playerLeft` folds and eliminates the leaver; the sit-and-go ends when one seat is left, otherwise the hand plays on, or the pot is awarded and the next hand deals from the current hand's unseen deck.

### Purity & hidden state
- Cards are shuffled server-side and injected: the opening deal in `TexasHoldEmActor`, and a fresh deck rides on every move for the next hand, so `TexasHoldEm.play` stays pure and tests deal exact cards.
- `HoldEmState` projects per viewer — you see only your own hole cards, the community cards are public per street, and a contested hand's showdown reveals the remaining players' cards through a durable `handResult`. The move-log records each action's amount but never the deck.

### Extension points
`GameType.TexasHoldEm` (2–6) + `GameTypeTag` + `fromString`; `GameTypeCodecs` round-trip (card/street/hand-result codecs, no new table); `HoldEmAction` payload, `HoldEmState` view + projection, `TexasHoldEmModule`, `TexasHoldEmActor`, `GameRegistry`; `JsonProtocol` codecs + encoder branch; `GameMetrics` label; HTTP route; and the web UI.

### Testing
Full suite green across all four modules; scalafix, scalafmt, and scaladoc clean. New specs cover hand evaluation, the betting/side-pot/split/leave rules, persistence round-trips, move decoding and the server-shuffled deck, per-viewer projection, the move-log encoder, and the metrics/serialization extension points.