### PR TITLE
Auth hardening: JWT revocation and rate limiting (#44, #45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Every setting has a working default for local development and can be overridden 
 | `JWT_TTL` | `1h` | Lifetime of an issued access token |
 | `CHAT_MAX_MESSAGES` | `100` | Per-match chat backscroll retained for `GET /chat` |
 | `ARGON2_MEMORY_KIB` / `ARGON2_ITERATIONS` / `ARGON2_PARALLELISM` | `19456` / `2` / `1` | Argon2id password-hashing cost (OWASP baseline) |
+| `AUTH_RATE_LIMIT_ENABLED` | `true` | Master switch for auth throttling/lockout; the window, per-IP limit, and lockout thresholds are further tunable under `auth.rate-limit` |
 
 ### A two-minute walkthrough
 
@@ -170,8 +171,11 @@ All gameplay endpoints require a `Authorization: Bearer <jwt>` header; obtain a 
 |--------|------|-------------|
 | `POST` | `/auth/register` | Create an account (`username`, `email`, `password`) and receive a JWT |
 | `POST` | `/auth/token` | Authenticate with `email` + `password` and receive a JWT |
-| `POST` | `/auth/password` | Change the authenticated account's password (does not revoke existing tokens) |
+| `POST` | `/auth/password` | Change the authenticated account's password (revokes the account's existing tokens) |
+| `POST` | `/auth/logout` | Revoke the account's outstanding tokens ("log out everywhere") |
 | `GET`  | `/auth/whoami` | Return the caller's player `id` and `name` decoded from the token |
+
+The credential endpoints (`/auth/register`, `/auth/token`, `/auth/password`) are rate limited per client IP, and repeated failed logins temporarily lock the account; exceeding a limit returns `429 Too Many Requests` with a `Retry-After` header. Logout and password change revoke the account's already-issued tokens, so they stop being accepted before they expire.
 
 ### Lobbies
 
@@ -345,7 +349,7 @@ $ sbt actor/test    # a single module
 Planned work, in rough priority order:
 
 - **Horizontal scaling (Pekko Cluster Sharding)** — today the service is single-instance (lobbies, game actors, and player sessions live in one JVM). The target is to shard game and lobby entities across a Pekko cluster so play is location-transparent across nodes. Cluster messaging would carry cross-instance delivery between game actors and player sessions directly, while the analytics event stream survives unchanged. Kept deliberately out of the main architecture diagram above so it reflects what's actually deployed.
-- **Authentication hardening** — the credentialed auth in place covers registration, login, and password change, with Argon2id hashing, short-lived tokens, and login timing-equalization to blunt email enumeration. Considered and deliberately deferred: **token revocation** — JWTs are stateless, so a password change or "log out" doesn't invalidate already-issued tokens before they expire; closing that needs a per-account token version baked into the claim (or a `jti` denylist in Redis) checked at validation time. **Password reset** (forgot-password) — needs an out-of-band channel (email) and a single-use, TTL'd reset-token store (a natural fit for Redis), so it's gated on an email integration. **Rate limiting / lockout** on the auth endpoints to slow credential stuffing, and **email-address verification** at registration, are likewise out of scope for now. The short token TTL keeps the revocation gap small in the meantime.
+- **Authentication hardening** — the credentialed auth in place covers registration, login, and password change, with Argon2id hashing, short-lived tokens, and login timing-equalization to blunt email enumeration. **Token revocation** is now implemented: since JWTs are stateless, each account keeps a Redis-backed "revoked-before" cutoff (self-expiring after the token TTL) that logout and password change advance to now, and the authenticator rejects any token issued before it — so those actions invalidate already-issued tokens instead of waiting for expiry. **Rate limiting and lockout** are also in place: a per-IP fixed-window throttle on the auth endpoints plus a per-account lockout after repeated failed logins, both Redis-backed and returning `429` with `Retry-After` (tunable under `auth.rate-limit`). Still deliberately deferred: **password reset** (forgot-password) — needs an out-of-band channel (email) and a single-use, TTL'd reset-token store (a natural fit for Redis), so it's gated on an email integration; and **email-address verification** at registration, which reuses that same email seam.
 - **OAuth / social login** — a second `IdentityProvider` (e.g. Google/GitHub) plus a callback route, resolving an external identity to the same `Account` and reusing token issuance and the account store unchanged. The `IdentityProvider` seam exists precisely so this is additive; the open design questions are account-linking policy (same email via password and OAuth) and how non-browser clients complete the redirect.
 - **More game types** — additional turn-based games beyond the current seven.
 - **AI opponent** — a bot player for single-player matches and testing.

--- a/game-service-server/src/main/resources/application.conf
+++ b/game-service-server/src/main/resources/application.conf
@@ -42,12 +42,39 @@ auth {
   # Stored hashes are self-describing PHC strings, so these may be raised later and old hashes
   # are transparently upgraded on the next successful login.
   argon2 {
-    memory-kib  = 19456   # 19 MiB
-    memory-kib  = ${?ARGON2_MEMORY_KIB}
-    iterations  = 2
-    iterations  = ${?ARGON2_ITERATIONS}
+    memory-kib = 19456 # 19 MiB
+    memory-kib = ${?ARGON2_MEMORY_KIB}
+    iterations = 2
+    iterations = ${?ARGON2_ITERATIONS}
     parallelism = 1
     parallelism = ${?ARGON2_PARALLELISM}
+  }
+
+  # Throttle + lockout on the auth endpoints (register/login/password), backed by Redis so limits
+  # hold across restarts and self-expire (no pruning). All keys are namespaced under "auth-rl:".
+  rate-limit {
+    enabled = true
+    enabled = ${?AUTH_RATE_LIMIT_ENABLED}
+
+    # Per-IP fixed-window throttle: at most `max-attempts` requests to an auth endpoint per `window`,
+    # after which that IP gets 429s with a Retry-After until the window resets.
+    ip {
+      window = 15m
+      window = ${?AUTH_RATE_LIMIT_IP_WINDOW}
+      max-attempts = 20
+      max-attempts = ${?AUTH_RATE_LIMIT_IP_MAX_ATTEMPTS}
+    }
+
+    # Per-account lockout: `threshold` failed logins for the same email within `window` locks that
+    # account for `duration`. Kept short so an attacker can't trivially lock a victim out for long.
+    lockout {
+      threshold = 5
+      threshold = ${?AUTH_RATE_LIMIT_LOCKOUT_THRESHOLD}
+      window = 15m
+      window = ${?AUTH_RATE_LIMIT_LOCKOUT_WINDOW}
+      duration = 15m
+      duration = ${?AUTH_RATE_LIMIT_LOCKOUT_DURATION}
+    }
   }
 }
 

--- a/game-service-server/src/main/resources/application.conf
+++ b/game-service-server/src/main/resources/application.conf
@@ -93,6 +93,10 @@ auth {
 # }
 
 pekko.http.server {
+  # Expose the peer's address to `extractClientIP` so the auth rate limiter can key on it for
+  # direct connections. Behind a proxy (e.g. Render) the real client comes from X-Forwarded-For.
+  remote-address-attribute = on
+
   # Send a WebSocket ping if no data has flowed for this duration, keeping
   # connections alive during long pauses between moves.
   websocket.periodic-keep-alive-max-idle = 30s

--- a/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
@@ -38,7 +38,15 @@ import com.andy327.persistence.db.{
   PlayerHistoryRepository
 }
 import com.andy327.server.analytics.{AnalyticsConsumer, GameMetrics, RedisAnalyticsPublisher}
-import com.andy327.server.auth.{IdentityProvider, PasswordHasher, PasswordIdentityProvider}
+import com.andy327.server.auth.{
+  AuthRateLimiter,
+  IdentityProvider,
+  NoOpAuthRateLimiter,
+  PasswordHasher,
+  PasswordIdentityProvider,
+  RedisAuthRateLimiter
+}
+import com.andy327.server.config.AuthRateLimitConfig
 import com.andy327.server.http.routes.{
   AuthRoutes,
   GameRoutes,
@@ -81,6 +89,11 @@ object GameServer {
       val userRepo = new PostgresUserRepository(xa)
       val identityProvider = new PasswordIdentityProvider(userRepo, PasswordHasher.fromConfig())
 
+      // Auth rate limiting: a Redis-backed throttle/lockout when enabled, otherwise a no-op limiter
+      val rateLimitConfig = AuthRateLimitConfig.fromConfig(config)
+      val authRateLimiter: AuthRateLimiter =
+        if (rateLimitConfig.enabled) new RedisAuthRateLimiter(redis) else NoOpAuthRateLimiter
+
       // Analytics: publisher emits to the game-analytics channel; consumer folds events into the /metrics registry
       val registry = new CollectorRegistry()
       val metrics = new GameMetrics(registry)
@@ -105,7 +118,9 @@ object GameServer {
           playerHistoryRepo,
           identityProvider,
           publisher,
-          registry
+          registry,
+          authRateLimiter,
+          rateLimitConfig
         ).flatMap { case (system, _) =>
           IO.blocking(Await.result(system.whenTerminated, Duration.Inf))
         }
@@ -125,7 +140,9 @@ object GameServer {
       identityProvider: IdentityProvider =
         new PasswordIdentityProvider(new InMemoryUserRepository, PasswordHasher.fromConfig()),
       publisher: EventPublisher = NoOpEventPublisher,
-      metricsRegistry: CollectorRegistry = new CollectorRegistry()
+      metricsRegistry: CollectorRegistry = new CollectorRegistry(),
+      authRateLimiter: AuthRateLimiter = NoOpAuthRateLimiter,
+      authRateLimitConfig: AuthRateLimitConfig = AuthRateLimitConfig.fromConfig()
   )(implicit runtime: IORuntime): IO[(ActorSystem[GameManager.Command], Http.ServerBinding)] = IO.defer {
     val rootBehavior = Behaviors.setup[GameManager.Command] { context =>
       val persistActor = context.spawn(PostgresActor(gameRepo, moveRepo, playerHistoryRepo), "postgres-persistence")
@@ -138,7 +155,7 @@ object GameServer {
 
     // HTTP routes
     val routes = concat(
-      new AuthRoutes(identityProvider).routes,
+      new AuthRoutes(identityProvider, authRateLimiter, authRateLimitConfig).routes,
       new PlayerRoutes(system, playerHistoryRepo).routes,
       new LobbyRoutes(system).routes,
       new GameRoutes(GameType.TicTacToe, system).routes,

--- a/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
@@ -42,9 +42,12 @@ import com.andy327.server.auth.{
   AuthRateLimiter,
   IdentityProvider,
   NoOpAuthRateLimiter,
+  NoOpRevocationStore,
   PasswordHasher,
   PasswordIdentityProvider,
-  RedisAuthRateLimiter
+  RedisAuthRateLimiter,
+  RedisRevocationStore,
+  RevocationStore
 }
 import com.andy327.server.config.AuthRateLimitConfig
 import com.andy327.server.http.auth.JwtAuthenticator
@@ -95,6 +98,10 @@ object GameServer {
       val authRateLimiter: AuthRateLimiter =
         if (rateLimitConfig.enabled) new RedisAuthRateLimiter(redis) else NoOpAuthRateLimiter
 
+      // Token revocation: a Redis-backed cutoff store that logout/password-change write and the authenticator enforces
+      val revocationStore = new RedisRevocationStore(redis)
+      val authenticator = new JwtAuthenticator(revocationStore = revocationStore)
+
       // Analytics: publisher emits to the game-analytics channel; consumer folds events into the /metrics registry
       val registry = new CollectorRegistry()
       val metrics = new GameMetrics(registry)
@@ -121,7 +128,9 @@ object GameServer {
           publisher,
           registry,
           authRateLimiter,
-          rateLimitConfig
+          rateLimitConfig,
+          authenticator,
+          revocationStore
         ).flatMap { case (system, _) =>
           IO.blocking(Await.result(system.whenTerminated, Duration.Inf))
         }
@@ -144,7 +153,8 @@ object GameServer {
       metricsRegistry: CollectorRegistry = new CollectorRegistry(),
       authRateLimiter: AuthRateLimiter = NoOpAuthRateLimiter,
       authRateLimitConfig: AuthRateLimitConfig = AuthRateLimitConfig.fromConfig(),
-      authenticator: JwtAuthenticator = new JwtAuthenticator()
+      authenticator: JwtAuthenticator = new JwtAuthenticator(),
+      revocationStore: RevocationStore = NoOpRevocationStore
   )(implicit runtime: IORuntime): IO[(ActorSystem[GameManager.Command], Http.ServerBinding)] = IO.defer {
     val rootBehavior = Behaviors.setup[GameManager.Command] { context =>
       val persistActor = context.spawn(PostgresActor(gameRepo, moveRepo, playerHistoryRepo), "postgres-persistence")
@@ -157,7 +167,7 @@ object GameServer {
 
     // HTTP routes
     val routes = concat(
-      new AuthRoutes(identityProvider, authRateLimiter, authRateLimitConfig, authenticator).routes,
+      new AuthRoutes(identityProvider, authRateLimiter, authRateLimitConfig, authenticator, revocationStore).routes,
       new PlayerRoutes(system, playerHistoryRepo, authenticator).routes,
       new LobbyRoutes(system, authenticator).routes,
       new GameRoutes(GameType.TicTacToe, system, authenticator).routes,

--- a/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/GameServer.scala
@@ -47,6 +47,7 @@ import com.andy327.server.auth.{
   RedisAuthRateLimiter
 }
 import com.andy327.server.config.AuthRateLimitConfig
+import com.andy327.server.http.auth.JwtAuthenticator
 import com.andy327.server.http.routes.{
   AuthRoutes,
   GameRoutes,
@@ -142,7 +143,8 @@ object GameServer {
       publisher: EventPublisher = NoOpEventPublisher,
       metricsRegistry: CollectorRegistry = new CollectorRegistry(),
       authRateLimiter: AuthRateLimiter = NoOpAuthRateLimiter,
-      authRateLimitConfig: AuthRateLimitConfig = AuthRateLimitConfig.fromConfig()
+      authRateLimitConfig: AuthRateLimitConfig = AuthRateLimitConfig.fromConfig(),
+      authenticator: JwtAuthenticator = new JwtAuthenticator()
   )(implicit runtime: IORuntime): IO[(ActorSystem[GameManager.Command], Http.ServerBinding)] = IO.defer {
     val rootBehavior = Behaviors.setup[GameManager.Command] { context =>
       val persistActor = context.spawn(PostgresActor(gameRepo, moveRepo, playerHistoryRepo), "postgres-persistence")
@@ -155,18 +157,18 @@ object GameServer {
 
     // HTTP routes
     val routes = concat(
-      new AuthRoutes(identityProvider, authRateLimiter, authRateLimitConfig).routes,
-      new PlayerRoutes(system, playerHistoryRepo).routes,
-      new LobbyRoutes(system).routes,
-      new GameRoutes(GameType.TicTacToe, system).routes,
-      new GameRoutes(GameType.ConnectFour, system).routes,
-      new GameRoutes(GameType.Battleship, system).routes,
-      new GameRoutes(GameType.Pig, system).routes,
-      new GameRoutes(GameType.Mastermind, system).routes,
-      new GameRoutes(GameType.LiarsDice, system).routes,
-      new GameRoutes(GameType.TexasHoldEm, system).routes,
-      new WebSocketRoutes(system).routes,
-      new TraceRoutes(system).routes,
+      new AuthRoutes(identityProvider, authRateLimiter, authRateLimitConfig, authenticator).routes,
+      new PlayerRoutes(system, playerHistoryRepo, authenticator).routes,
+      new LobbyRoutes(system, authenticator).routes,
+      new GameRoutes(GameType.TicTacToe, system, authenticator).routes,
+      new GameRoutes(GameType.ConnectFour, system, authenticator).routes,
+      new GameRoutes(GameType.Battleship, system, authenticator).routes,
+      new GameRoutes(GameType.Pig, system, authenticator).routes,
+      new GameRoutes(GameType.Mastermind, system, authenticator).routes,
+      new GameRoutes(GameType.LiarsDice, system, authenticator).routes,
+      new GameRoutes(GameType.TexasHoldEm, system, authenticator).routes,
+      new WebSocketRoutes(system, authenticator).routes,
+      new TraceRoutes(system, authenticator).routes,
       new MetricsRoutes(metricsRegistry).routes,
       new StaticRoutes().routes // Web UI; composed last so its catch-all resource lookup doesn't shadow an API route
     )

--- a/game-service-server/src/main/scala/com/andy327/server/auth/AuthRateLimiter.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/auth/AuthRateLimiter.scala
@@ -63,7 +63,7 @@ object NoOpAuthRateLimiter extends AuthRateLimiter {
 }
 
 /** An in-memory [[AuthRateLimiter]] with the same semantics as the Redis-backed one, used for tests and single-process
-  * runs where no Redis is wired. Expiry is driven by an injectable [[Clock]] so lockout windows can be exercised
+  * runs where no Redis is wired. Expiry is driven by an injectable `Clock` so lockout windows can be exercised
   * deterministically in tests.
   */
 class InMemoryAuthRateLimiter(implicit clock: Clock = Clock.systemUTC()) extends AuthRateLimiter {

--- a/game-service-server/src/main/scala/com/andy327/server/auth/AuthRateLimiter.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/auth/AuthRateLimiter.scala
@@ -1,0 +1,116 @@
+package com.andy327.server.auth
+
+import java.time.{Clock, Instant}
+
+import scala.concurrent.duration.{DurationLong, FiniteDuration}
+
+import cats.effect.IO
+import cats.effect.kernel.Ref
+
+/** The result of counting one request against a throttle. */
+sealed trait RateLimitOutcome
+object RateLimitOutcome {
+
+  /** The request is within the limit and may proceed. */
+  case object Allowed extends RateLimitOutcome
+
+  /** The request is over the limit; the caller should reject it and retry no sooner than `retryAfter`. */
+  final case class Limited(retryAfter: FiniteDuration) extends RateLimitOutcome
+}
+
+/** Server-side throttle and lockout state for the auth endpoints, backed by a self-expiring store.
+  *
+  * Two independent mechanisms share this seam:
+  *   - [[throttle]] is a fixed-window request counter (per client IP), the front-line defense against spraying the
+  *     register/login endpoints.
+  *   - [[recordFailure]]/[[lockStatus]]/[[clearFailures]] implement per-account lockout: repeated failed logins lock an
+  *     account (by email) for a cool-off period, so a single account can't be brute-forced across many source IPs.
+  *
+  * Every key expires on its own (Redis TTLs in production, timestamps in the in-memory implementation), so the store
+  * never needs pruning.
+  */
+trait AuthRateLimiter {
+
+  /** Atomically count one request against a fixed `window` for `key` and report whether it is now within `limit`. The
+    * window starts at the first request and is not extended by later ones, so at most `limit` requests are admitted per
+    * window. When over the limit, the outcome carries the time remaining until the window resets.
+    */
+  def throttle(key: String, limit: Int, window: FiniteDuration): IO[RateLimitOutcome]
+
+  /** How long `key` remains locked out, or `None` if it is not currently locked. */
+  def lockStatus(key: String): IO[Option[FiniteDuration]]
+
+  /** Record a failed attempt for `key`. Failures are counted within a rolling `window`; once they reach `threshold`
+    * the key is locked for `lockout` and the failure count is cleared, so escaping the lock requires the full
+    * threshold of failures again.
+    */
+  def recordFailure(key: String, threshold: Int, window: FiniteDuration, lockout: FiniteDuration): IO[Unit]
+
+  /** Clear the failure count and any active lock for `key`, called after a successful attempt. */
+  def clearFailures(key: String): IO[Unit]
+}
+
+/** An [[AuthRateLimiter]] that never throttles or locks anything — the default when rate limiting is disabled or no
+  * shared store is wired (mirrors the `NoOp` repositories used elsewhere for the same reason).
+  */
+object NoOpAuthRateLimiter extends AuthRateLimiter {
+  override def throttle(key: String, limit: Int, window: FiniteDuration): IO[RateLimitOutcome] =
+    IO.pure(RateLimitOutcome.Allowed)
+  override def lockStatus(key: String): IO[Option[FiniteDuration]] = IO.pure(None)
+  override def recordFailure(key: String, threshold: Int, window: FiniteDuration, lockout: FiniteDuration): IO[Unit] =
+    IO.unit
+  override def clearFailures(key: String): IO[Unit] = IO.unit
+}
+
+/** An in-memory [[AuthRateLimiter]] with the same semantics as the Redis-backed one, used for tests and single-process
+  * runs where no Redis is wired. Expiry is driven by an injectable [[Clock]] so lockout windows can be exercised
+  * deterministically in tests.
+  */
+class InMemoryAuthRateLimiter(implicit clock: Clock = Clock.systemUTC()) extends AuthRateLimiter {
+  import InMemoryAuthRateLimiter._
+
+  private val state: Ref[IO, State] = Ref.unsafe(State(Map.empty, Map.empty))
+
+  override def throttle(key: String, limit: Int, window: FiniteDuration): IO[RateLimitOutcome] =
+    IO(Instant.now(clock)).flatMap { now =>
+      state.modify { s =>
+        val counter = s.counters.get(key).filter(_.expiresAt.isAfter(now)) match {
+          case Some(w) => w.copy(count = w.count + 1)
+          case None    => Counter(1, now.plusMillis(window.toMillis))
+        }
+        val outcome =
+          if (counter.count > limit) RateLimitOutcome.Limited(remaining(now, counter.expiresAt))
+          else RateLimitOutcome.Allowed
+        (s.copy(counters = s.counters.updated(key, counter)), outcome)
+      }
+    }
+
+  override def lockStatus(key: String): IO[Option[FiniteDuration]] =
+    IO(Instant.now(clock)).flatMap(now => state.get.map(_.locks.get(key).filter(_.isAfter(now)).map(remaining(now, _))))
+
+  override def recordFailure(key: String, threshold: Int, window: FiniteDuration, lockout: FiniteDuration): IO[Unit] =
+    IO(Instant.now(clock)).flatMap { now =>
+      state.update { s =>
+        val counter = s.counters.get(key).filter(_.expiresAt.isAfter(now)) match {
+          case Some(w) => w.copy(count = w.count + 1)
+          case None    => Counter(1, now.plusMillis(window.toMillis))
+        }
+        if (counter.count >= threshold)
+          s.copy(counters = s.counters - key, locks = s.locks.updated(key, now.plusMillis(lockout.toMillis)))
+        else
+          s.copy(counters = s.counters.updated(key, counter))
+      }
+    }
+
+  override def clearFailures(key: String): IO[Unit] =
+    state.update(s => s.copy(counters = s.counters - key, locks = s.locks - key))
+}
+
+object InMemoryAuthRateLimiter {
+  final private case class Counter(count: Long, expiresAt: Instant)
+  final private case class State(counters: Map[String, Counter], locks: Map[String, Instant])
+
+  /** The non-negative duration from `now` until `expiresAt`. */
+  private def remaining(now: Instant, expiresAt: Instant): FiniteDuration =
+    math.max(0L, expiresAt.toEpochMilli - now.toEpochMilli).millis
+}

--- a/game-service-server/src/main/scala/com/andy327/server/auth/RedisAuthRateLimiter.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/auth/RedisAuthRateLimiter.scala
@@ -1,0 +1,61 @@
+package com.andy327.server.auth
+
+import scala.concurrent.duration.FiniteDuration
+
+import cats.effect.IO
+
+import dev.profunktor.redis4cats.RedisCommands
+
+/** An [[AuthRateLimiter]] backed by Redis.
+  *
+  * Throttle counters and failure counters are Redis keys incremented with `INCR`, given a TTL equal to their window on
+  * first hit (so the window is fixed, not sliding). Locks are `SETEX` keys whose presence — and remaining TTL — is the
+  * lockout. Because every key carries a TTL, the store self-prunes and survives restarts without cleanup.
+  *
+  * Keys are namespaced under `auth-rl:` so they never collide with the lobby/chat/game keyspaces sharing this Redis.
+  *
+  * @param redis Redis commands handle used for all reads and writes
+  */
+class RedisAuthRateLimiter(redis: RedisCommands[IO, String, String]) extends AuthRateLimiter {
+  import RedisAuthRateLimiter._
+
+  override def throttle(key: String, limit: Int, window: FiniteDuration): IO[RateLimitOutcome] = {
+    val k = countKey(key)
+    redis.incr(k).flatMap { count =>
+      val ensureTtl = if (count == 1L) redis.expire(k, window).void else IO.unit
+      ensureTtl *> {
+        if (count > limit) redis.ttl(k).map(ttl => RateLimitOutcome.Limited(ttl.getOrElse(window)))
+        else IO.pure(RateLimitOutcome.Allowed)
+      }
+    }
+  }
+
+  override def lockStatus(key: String): IO[Option[FiniteDuration]] =
+    redis.ttl(lockKey(key)).map(_.filter(_.length > 0))
+
+  override def recordFailure(
+      key: String,
+      threshold: Int,
+      window: FiniteDuration,
+      lockout: FiniteDuration
+  ): IO[Unit] = {
+    val fk = failKey(key)
+    redis.incr(fk).flatMap { count =>
+      val ensureTtl = if (count == 1L) redis.expire(fk, window).void else IO.unit
+      ensureTtl *> {
+        if (count >= threshold) redis.setEx(lockKey(key), "1", lockout) *> redis.del(fk).void
+        else IO.unit
+      }
+    }
+  }
+
+  override def clearFailures(key: String): IO[Unit] =
+    redis.del(failKey(key), lockKey(key)).void
+}
+
+object RedisAuthRateLimiter {
+  private val Prefix = "auth-rl:"
+  private def countKey(key: String): String = s"${Prefix}count:$key"
+  private def failKey(key: String): String = s"${Prefix}fail:$key"
+  private def lockKey(key: String): String = s"${Prefix}lock:$key"
+}

--- a/game-service-server/src/main/scala/com/andy327/server/auth/RedisRevocationStore.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/auth/RedisRevocationStore.scala
@@ -1,0 +1,32 @@
+package com.andy327.server.auth
+
+import java.time.Instant
+import java.util.UUID
+
+import scala.concurrent.duration.FiniteDuration
+
+import cats.effect.IO
+
+import dev.profunktor.redis4cats.RedisCommands
+
+/** A [[RevocationStore]] backed by Redis.
+  *
+  * Each account's cutoff is a single key holding the cutoff as epoch millis, written with `SETEX` so it expires after
+  * the token lifetime — after which every token predating the cutoff has expired anyway. Keys are namespaced under
+  * `auth:revoked-before:` so they don't collide with the other Redis keyspaces.
+  *
+  * @param redis Redis commands handle used for all reads and writes
+  */
+class RedisRevocationStore(redis: RedisCommands[IO, String, String]) extends RevocationStore {
+  import RedisRevocationStore.key
+
+  override def revokeBefore(accountId: UUID, cutoff: Instant, ttl: FiniteDuration): IO[Unit] =
+    redis.setEx(key(accountId), cutoff.toEpochMilli.toString, ttl)
+
+  override def revokedBefore(accountId: UUID): IO[Option[Instant]] =
+    redis.get(key(accountId)).map(_.flatMap(_.toLongOption).map(Instant.ofEpochMilli))
+}
+
+object RedisRevocationStore {
+  private def key(accountId: UUID): String = s"auth:revoked-before:$accountId"
+}

--- a/game-service-server/src/main/scala/com/andy327/server/auth/RevocationStore.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/auth/RevocationStore.scala
@@ -1,0 +1,59 @@
+package com.andy327.server.auth
+
+import java.time.{Clock, Instant}
+import java.util.UUID
+
+import scala.concurrent.duration.FiniteDuration
+
+import cats.effect.IO
+import cats.effect.kernel.Ref
+
+/** Records per-account token-revocation cutoffs, the state that lets stateless JWTs be invalidated before they expire.
+  *
+  * JWTs carry an `iat` (issued-at) and are otherwise self-contained, so logout and password changes can't reach the
+  * tokens already handed out. Instead, an account records a *cutoff*: every token it issued at or before that instant
+  * is considered revoked. Enforcement compares a presented token's `iat` against the account's cutoff.
+  *
+  * The cutoff is remembered only for the token lifetime (`ttl`): once that elapses, every token predating the cutoff
+  * has expired on its own, so the record can disappear. Backing stores implement this with a native TTL, so the store
+  * self-prunes and never grows unbounded.
+  */
+trait RevocationStore {
+
+  /** Revoke every token for `accountId` issued at or before `cutoff`, remembering it for `ttl`. */
+  def revokeBefore(accountId: UUID, cutoff: Instant, ttl: FiniteDuration): IO[Unit]
+
+  /** The current revocation cutoff for `accountId`, or `None` if nothing is revoked (or the record has expired). */
+  def revokedBefore(accountId: UUID): IO[Option[Instant]]
+}
+
+/** A [[RevocationStore]] that never revokes anything — the default when no shared store is wired (tests, local runs),
+  * mirroring the other `NoOp` collaborators. With this store every validly-signed, unexpired token is accepted.
+  */
+object NoOpRevocationStore extends RevocationStore {
+  override def revokeBefore(accountId: UUID, cutoff: Instant, ttl: FiniteDuration): IO[Unit] = IO.unit
+  override def revokedBefore(accountId: UUID): IO[Option[Instant]] = IO.pure(None)
+}
+
+/** An in-memory [[RevocationStore]] with the same semantics as the Redis-backed one, for tests and single-process runs.
+  * Expiry is driven by an injectable `Clock` so the TTL can be exercised deterministically.
+  */
+class InMemoryRevocationStore(implicit clock: Clock = Clock.systemUTC()) extends RevocationStore {
+  import InMemoryRevocationStore.Entry
+
+  private val cutoffs: Ref[IO, Map[UUID, Entry]] = Ref.unsafe(Map.empty)
+
+  override def revokeBefore(accountId: UUID, cutoff: Instant, ttl: FiniteDuration): IO[Unit] =
+    IO(Instant.now(clock)).flatMap(now =>
+      cutoffs.update(_.updated(accountId, Entry(cutoff, now.plusMillis(ttl.toMillis))))
+    )
+
+  override def revokedBefore(accountId: UUID): IO[Option[Instant]] =
+    IO(Instant.now(clock)).flatMap { now =>
+      cutoffs.get.map(_.get(accountId).filter(_.expiresAt.isAfter(now)).map(_.cutoff))
+    }
+}
+
+object InMemoryRevocationStore {
+  final private case class Entry(cutoff: Instant, expiresAt: Instant)
+}

--- a/game-service-server/src/main/scala/com/andy327/server/config/AuthRateLimitConfig.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/config/AuthRateLimitConfig.scala
@@ -1,0 +1,39 @@
+package com.andy327.server.config
+
+import scala.concurrent.duration.{DurationLong, FiniteDuration}
+
+import com.typesafe.config.{Config, ConfigFactory}
+
+/** Throttle and lockout policy for the auth endpoints, read from the `auth.rate-limit` stanza.
+  *
+  * @param enabled master switch; when `false` the server wires a no-op limiter and none of the values below apply
+  * @param ipWindow fixed window over which per-IP attempts are counted
+  * @param ipMaxAttempts attempts admitted per IP per `ipWindow` before further requests are throttled (429)
+  * @param lockoutThreshold consecutive failed logins (per email) that trigger a lockout
+  * @param lockoutWindow rolling window within which failures must accrue to reach the threshold
+  * @param lockoutDuration how long an account stays locked once the threshold is reached
+  */
+final case class AuthRateLimitConfig(
+    enabled: Boolean,
+    ipWindow: FiniteDuration,
+    ipMaxAttempts: Int,
+    lockoutThreshold: Int,
+    lockoutWindow: FiniteDuration,
+    lockoutDuration: FiniteDuration
+)
+
+object AuthRateLimitConfig {
+  private val Namespace = "auth.rate-limit"
+
+  def fromConfig(config: Config = ConfigFactory.load()): AuthRateLimitConfig = {
+    val rl = config.getConfig(Namespace)
+    AuthRateLimitConfig(
+      enabled = rl.getBoolean("enabled"),
+      ipWindow = rl.getDuration("ip.window").toMillis.millis,
+      ipMaxAttempts = rl.getInt("ip.max-attempts"),
+      lockoutThreshold = rl.getInt("lockout.threshold"),
+      lockoutWindow = rl.getDuration("lockout.window").toMillis.millis,
+      lockoutDuration = rl.getDuration("lockout.duration").toMillis.millis
+    )
+  }
+}

--- a/game-service-server/src/main/scala/com/andy327/server/http/auth/JwtAuthenticator.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/auth/JwtAuthenticator.scala
@@ -4,6 +4,8 @@ import java.util.UUID
 
 import scala.util.{Failure, Success, Try}
 
+import cats.effect.unsafe.IORuntime
+
 import io.circe.parser.decode
 import org.apache.pekko.http.scaladsl.model.StatusCodes
 import org.apache.pekko.http.scaladsl.server.Directive1
@@ -11,18 +13,23 @@ import org.apache.pekko.http.scaladsl.server.Directives._
 import pdi.jwt._
 
 import com.andy327.actor.lobby.Player
-import com.andy327.server.auth.UserContext
+import com.andy327.server.auth.{NoOpRevocationStore, RevocationStore, UserContext}
 import com.andy327.server.config.JwtConfig
 import com.andy327.server.http.json.JsonProtocol._
 
 /** Authenticates players from JWT bearer tokens, as an injectable component.
   *
   * The directive parses the Authorization header, validates the JWT using the configured secret, extracts the
-  * `UserContext` payload, and converts it into a `Player`.
+  * `UserContext` payload, converts it into a `Player`, and rejects the token if the account has revoked everything
+  * issued up to a later cutoff (see [[server.auth.RevocationStore]]).
   *
   * @param secretKey shared secret the tokens are signed with; defaults to the configured `jwt.secret`
+  * @param revocationStore source of per-account revocation cutoffs; defaults to a no-op (nothing is ever revoked)
   */
-class JwtAuthenticator(secretKey: String = JwtConfig.secretKey) {
+class JwtAuthenticator(
+    secretKey: String = JwtConfig.secretKey,
+    revocationStore: RevocationStore = NoOpRevocationStore
+)(implicit runtime: IORuntime = IORuntime.global) {
 
   /** Custom directive that extracts a Player from a valid JWT supplied in the Authorization header.
     *
@@ -69,21 +76,32 @@ class JwtAuthenticator(secretKey: String = JwtConfig.secretKey) {
 
   /** Validates a raw JWT and provides the [[Player]] it identifies, or rejects with an Unauthorized response. */
   private def validateToken(token: String): Directive1[Player] =
-    // Validate the JWT and extract the payload as a JSON object
-    JwtCirce.decodeJson(token, secretKey, Seq(JwtAlgorithm.HS256)) match {
-      case Success(json) =>
-        // Convert the raw JSON into a strongly-typed UserContext
-        decode[UserContext](json.noSpaces) match {
+    // Validate the JWT (signature + expiry) and split registered claims (iat/exp) from the UserContext content
+    JwtCirce.decode(token, secretKey, Seq(JwtAlgorithm.HS256)) match {
+      case Success(claim) =>
+        // Convert the content JSON into a strongly-typed UserContext
+        decode[UserContext](claim.content) match {
           case Right(userContext) =>
             // Parse the player id string into a UUID, then build a Player
             playerFromContext(userContext) match {
-              case Some(player) => provide(player)
+              case Some(player) => rejectIfRevoked(player, claim.issuedAt)
               case None         => complete(StatusCodes.Unauthorized -> Map("error" -> "Invalid player ID or name"))
             }
           case Left(_) => complete(StatusCodes.Unauthorized -> Map("error" -> "Token payload could not be parsed"))
         }
 
       case Failure(_) => complete(StatusCodes.Unauthorized -> Map("error" -> "Token is invalid or expired"))
+    }
+
+  /** Provides the player unless their account has a revocation cutoff at or after the token's issued-at, in which case
+    * the token predates a logout/password-change and is rejected. A token with no `iat` is treated as revoked whenever
+    * a cutoff exists, since its freshness can't be proven.
+    */
+  private def rejectIfRevoked(player: Player, issuedAt: Option[Long]): Directive1[Player] =
+    onSuccess(revocationStore.revokedBefore(player.id).unsafeToFuture()).flatMap {
+      case Some(cutoff) if issuedAt.forall(_ * 1000 < cutoff.toEpochMilli) =>
+        complete(StatusCodes.Unauthorized -> Map("error" -> "Token has been revoked"))
+      case _ => provide(player)
     }
 
   /** Builds a [[Player]] from a decoded JWT payload, parsing the subject id as a UUID; `None` if it is malformed. */

--- a/game-service-server/src/main/scala/com/andy327/server/http/auth/JwtAuthenticator.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/auth/JwtAuthenticator.scala
@@ -12,15 +12,17 @@ import pdi.jwt._
 
 import com.andy327.actor.lobby.Player
 import com.andy327.server.auth.UserContext
-import com.andy327.server.config.JwtConfig.secretKey
+import com.andy327.server.config.JwtConfig
 import com.andy327.server.http.json.JsonProtocol._
 
-/** Provides a custom Pekko HTTP directive that authenticates players using JWT tokens.
+/** Authenticates players from JWT bearer tokens, as an injectable component.
   *
   * The directive parses the Authorization header, validates the JWT using the configured secret, extracts the
-  * UserContext payload, and converts it into a Player object.
+  * `UserContext` payload, and converts it into a `Player`.
+  *
+  * @param secretKey shared secret the tokens are signed with; defaults to the configured `jwt.secret`
   */
-object JwtPlayerDirectives {
+class JwtAuthenticator(secretKey: String = JwtConfig.secretKey) {
 
   /** Custom directive that extracts a Player from a valid JWT supplied in the Authorization header.
     *

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/AuthRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/AuthRoutes.scala
@@ -1,23 +1,28 @@
 package com.andy327.server.http.routes
 
+import java.time.Instant
+
 import cats.effect.unsafe.IORuntime
 
-import org.apache.pekko.http.scaladsl.model.StatusCodes
 import org.apache.pekko.http.scaladsl.model.headers.`Retry-After`
+import org.apache.pekko.http.scaladsl.model.{StatusCode, StatusCodes}
 import org.apache.pekko.http.scaladsl.server.Directives._
 import org.apache.pekko.http.scaladsl.server.{Directive1, Route}
 
+import com.andy327.actor.lobby.Player
 import com.andy327.persistence.db.Account
 import com.andy327.server.auth.{
   AuthRateLimiter,
   IdentityProvider,
   JwtIssuer,
   NoOpAuthRateLimiter,
+  NoOpRevocationStore,
   RateLimitOutcome,
   RegisterError,
+  RevocationStore,
   UserContext
 }
-import com.andy327.server.config.AuthRateLimitConfig
+import com.andy327.server.config.{AuthRateLimitConfig, JwtConfig}
 import com.andy327.server.http.auth.{
   AuthValidation,
   ChangePasswordRequest,
@@ -41,13 +46,15 @@ import com.andy327.server.http.json.JsonProtocol._
   *   - POST /auth/register - Create an account and receive a signed JWT
   *   - POST /auth/token - Authenticate with credentials and receive a signed JWT
   *   - POST /auth/password - Change the authenticated account's password
+  *   - POST /auth/logout - Revoke the account's outstanding tokens (log out everywhere)
   *   - GET /auth/whoami - Return the player's ID and name extracted from the Authorization token
   */
 class AuthRoutes(
     identityProvider: IdentityProvider,
     rateLimiter: AuthRateLimiter = NoOpAuthRateLimiter,
     limits: AuthRateLimitConfig = AuthRateLimitConfig.fromConfig(),
-    authenticator: JwtAuthenticator = new JwtAuthenticator()
+    authenticator: JwtAuthenticator = new JwtAuthenticator(),
+    revocationStore: RevocationStore = NoOpRevocationStore
 )(implicit runtime: IORuntime) {
   private val jwtIssuer = JwtIssuer.fromConfig()
 
@@ -78,6 +85,14 @@ class AuthRoutes(
 
   /** Lockout key for an account, normalized to lower case so it matches regardless of how the email was cased. */
   private def lockoutKey(email: String): String = s"login:email:${email.toLowerCase}"
+
+  /** Revokes every token the account currently holds (issued before now), then completes with `status`. The cutoff is
+    * kept for the token lifetime, after which those tokens have expired anyway. Used by logout and password change.
+    */
+  private def revokeTokensThen(player: Player, status: StatusCode): Route = {
+    val revoked = revocationStore.revokeBefore(player.id, Instant.now(), JwtConfig.ttl).as(status)
+    onSuccess(revoked.unsafeToFuture())(complete(_))
+  }
 
   val routes: Route = pathPrefix("auth") {
 
@@ -167,7 +182,7 @@ class AuthRoutes(
       * - 403: the current password is incorrect
       * - 429: too many requests from this IP; retry after the `Retry-After` header
       *
-      * Existing tokens are not revoked by a change — they remain valid until they expire.
+      * A successful change revokes the account's existing tokens, so tokens issued before it stop being accepted.
       */
     path("password") {
       post {
@@ -182,13 +197,26 @@ class AuthRoutes(
                     onSuccess(
                       identityProvider.changePassword(player.id, req.currentPassword, req.newPassword).unsafeToFuture()
                     ) {
-                      case Right(_) => complete(StatusCodes.NoContent)
+                      case Right(_) => revokeTokensThen(player, StatusCodes.NoContent)
                       case Left(_) => complete(StatusCodes.Forbidden -> Map("error" -> "Current password is incorrect"))
                     }
                 }
               }
             }
           }
+        }
+      }
+    } ~
+    /** Logs the caller out by revoking every token their account currently holds ("log out everywhere").
+      *
+      * - Auth: Bearer token required
+      * - 204: the account's outstanding tokens are revoked; they will no longer be accepted
+      * - 401: missing, invalid, or expired token
+      */
+    path("logout") {
+      post {
+        authenticator.authenticatePlayer { player =>
+          revokeTokensThen(player, StatusCodes.NoContent)
         }
       }
     } ~

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/AuthRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/AuthRoutes.scala
@@ -18,8 +18,13 @@ import com.andy327.server.auth.{
   UserContext
 }
 import com.andy327.server.config.AuthRateLimitConfig
-import com.andy327.server.http.auth.JwtPlayerDirectives._
-import com.andy327.server.http.auth.{AuthValidation, ChangePasswordRequest, LoginRequest, RegisterRequest}
+import com.andy327.server.http.auth.{
+  AuthValidation,
+  ChangePasswordRequest,
+  JwtAuthenticator,
+  LoginRequest,
+  RegisterRequest
+}
 import com.andy327.server.http.json.JsonProtocol._
 
 /** HTTP routes for registration, authentication, and token issuance.
@@ -28,9 +33,9 @@ import com.andy327.server.http.json.JsonProtocol._
   * asserted by the client: the
   * token a caller receives attests to the account the server authenticated, and its id comes from that account.
   *
-  * The credential-bearing endpoints are rate limited via an [[AuthRateLimiter]]: a per-IP fixed-window throttle guards
-  * register/login/password against spraying, and repeated failed logins lock an account (by email) for a cool-off
-  * period. Both default to no-ops.
+  * The credential-bearing endpoints are rate limited via an [[server.auth.AuthRateLimiter]]: a per-IP fixed-window
+  * throttle guards register/login/password against spraying, and repeated failed logins lock an account (by email) for
+  * a cool-off period. Both default to no-ops.
   *
   * Route Summary:
   *   - POST /auth/register - Create an account and receive a signed JWT
@@ -41,7 +46,8 @@ import com.andy327.server.http.json.JsonProtocol._
 class AuthRoutes(
     identityProvider: IdentityProvider,
     rateLimiter: AuthRateLimiter = NoOpAuthRateLimiter,
-    limits: AuthRateLimitConfig = AuthRateLimitConfig.fromConfig()
+    limits: AuthRateLimitConfig = AuthRateLimitConfig.fromConfig(),
+    authenticator: JwtAuthenticator = new JwtAuthenticator()
 )(implicit runtime: IORuntime) {
   private val jwtIssuer = JwtIssuer.fromConfig()
 
@@ -167,7 +173,7 @@ class AuthRoutes(
       post {
         clientIp { ip =>
           ipThrottle("password", ip) {
-            authenticatePlayer { player =>
+            authenticator.authenticatePlayer { player =>
               entity(as[ChangePasswordRequest]) { req =>
                 AuthValidation.validatePasswordChange(req) match {
                   case Left(error) =>
@@ -195,7 +201,7 @@ class AuthRoutes(
       * - 401: missing token, invalid or expired token, undecodable payload, or malformed player ID
       */
     path("whoami") {
-      authenticatePlayer { player =>
+      authenticator.authenticatePlayer { player =>
         get {
           complete(player)
         }

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/AuthRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/AuthRoutes.scala
@@ -3,11 +3,21 @@ package com.andy327.server.http.routes
 import cats.effect.unsafe.IORuntime
 
 import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.model.headers.`Retry-After`
 import org.apache.pekko.http.scaladsl.server.Directives._
-import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.server.{Directive1, Route}
 
 import com.andy327.persistence.db.Account
-import com.andy327.server.auth.{IdentityProvider, JwtIssuer, RegisterError, UserContext}
+import com.andy327.server.auth.{
+  AuthRateLimiter,
+  IdentityProvider,
+  JwtIssuer,
+  NoOpAuthRateLimiter,
+  RateLimitOutcome,
+  RegisterError,
+  UserContext
+}
+import com.andy327.server.config.AuthRateLimitConfig
 import com.andy327.server.http.auth.JwtPlayerDirectives._
 import com.andy327.server.http.auth.{AuthValidation, ChangePasswordRequest, LoginRequest, RegisterRequest}
 import com.andy327.server.http.json.JsonProtocol._
@@ -18,17 +28,50 @@ import com.andy327.server.http.json.JsonProtocol._
   * asserted by the client: the
   * token a caller receives attests to the account the server authenticated, and its id comes from that account.
   *
+  * The credential-bearing endpoints are rate limited via an [[AuthRateLimiter]]: a per-IP fixed-window throttle guards
+  * register/login/password against spraying, and repeated failed logins lock an account (by email) for a cool-off
+  * period. Both default to no-ops.
+  *
   * Route Summary:
   *   - POST /auth/register - Create an account and receive a signed JWT
   *   - POST /auth/token - Authenticate with credentials and receive a signed JWT
   *   - POST /auth/password - Change the authenticated account's password
   *   - GET /auth/whoami - Return the player's ID and name extracted from the Authorization token
   */
-class AuthRoutes(identityProvider: IdentityProvider)(implicit runtime: IORuntime) {
+class AuthRoutes(
+    identityProvider: IdentityProvider,
+    rateLimiter: AuthRateLimiter = NoOpAuthRateLimiter,
+    limits: AuthRateLimitConfig = AuthRateLimitConfig.fromConfig()
+)(implicit runtime: IORuntime) {
   private val jwtIssuer = JwtIssuer.fromConfig()
 
   private def tokenFor(account: Account): String =
     jwtIssuer.issue(UserContext(account.id.toString, account.username))
+
+  /** The originating client IP, preferring the first `X-Forwarded-For` entry (the real client when behind a proxy such
+    * as Render), then the direct remote address, and finally the literal `"unknown"` when neither is available.
+    */
+  private def clientIp: Directive1[String] =
+    optionalHeaderValueByName("X-Forwarded-For").flatMap {
+      case Some(xff) if xff.trim.nonEmpty => provide(xff.split(",").head.trim)
+      case _                              => extractClientIP.map(_.toOption.map(_.getHostAddress).getOrElse("unknown"))
+    }
+
+  /** Counts one request against the per-IP throttle for `endpoint` and either runs `inner` or completes with 429. */
+  private def ipThrottle(endpoint: String, ip: String)(inner: => Route): Route =
+    onSuccess(rateLimiter.throttle(s"$endpoint:ip:$ip", limits.ipMaxAttempts, limits.ipWindow).unsafeToFuture()) {
+      case RateLimitOutcome.Allowed             => inner
+      case RateLimitOutcome.Limited(retryAfter) => tooManyRequests("Too many requests; slow down", retryAfter)
+    }
+
+  /** A 429 response carrying a `Retry-After` header (at least one second) and a JSON error body. */
+  private def tooManyRequests(message: String, retryAfter: scala.concurrent.duration.FiniteDuration): Route =
+    respondWithHeader(`Retry-After`(math.max(1L, retryAfter.toSeconds))) {
+      complete(StatusCodes.TooManyRequests -> Map("error" -> message))
+    }
+
+  /** Lockout key for an account, normalized to lower case so it matches regardless of how the email was cased. */
+  private def lockoutKey(email: String): String = s"login:email:${email.toLowerCase}"
 
   val routes: Route = pathPrefix("auth") {
 
@@ -38,20 +81,25 @@ class AuthRoutes(identityProvider: IdentityProvider)(implicit runtime: IORuntime
       * - 201: `{ "token": "<jwt>" }` — signed JWT for the new account
       * - 400: a field is blank, malformed, or out of range
       * - 409: the email is already registered
+      * - 429: too many requests from this IP; retry after the `Retry-After` header
       */
     path("register") {
       post {
-        entity(as[RegisterRequest]) { req =>
-          AuthValidation.validateRegister(req) match {
-            case Left(error) =>
-              complete(StatusCodes.BadRequest -> Map("error" -> error))
-            case Right(valid) =>
-              onSuccess(identityProvider.register(valid.username, valid.email, valid.password).unsafeToFuture()) {
-                case Right(account) =>
-                  complete(StatusCodes.Created -> Map("token" -> tokenFor(account)))
-                case Left(RegisterError.EmailAlreadyRegistered) =>
-                  complete(StatusCodes.Conflict -> Map("error" -> "Email already registered"))
+        clientIp { ip =>
+          ipThrottle("register", ip) {
+            entity(as[RegisterRequest]) { req =>
+              AuthValidation.validateRegister(req) match {
+                case Left(error) =>
+                  complete(StatusCodes.BadRequest -> Map("error" -> error))
+                case Right(valid) =>
+                  onSuccess(identityProvider.register(valid.username, valid.email, valid.password).unsafeToFuture()) {
+                    case Right(account) =>
+                      complete(StatusCodes.Created -> Map("token" -> tokenFor(account)))
+                    case Left(RegisterError.EmailAlreadyRegistered) =>
+                      complete(StatusCodes.Conflict -> Map("error" -> "Email already registered"))
+                  }
               }
+            }
           }
         }
       }
@@ -62,18 +110,43 @@ class AuthRoutes(identityProvider: IdentityProvider)(implicit runtime: IORuntime
       * - 200: `{ "token": "<jwt>" }` — signed JWT for the authenticated account
       * - 400: email or password is blank
       * - 401: unknown email or wrong password (not distinguished)
+      * - 429: too many requests from this IP, or the account is temporarily locked after repeated failures
       */
     path("token") {
       post {
-        entity(as[LoginRequest]) { req =>
-          AuthValidation.validateLogin(req) match {
-            case Left(error) =>
-              complete(StatusCodes.BadRequest -> Map("error" -> error))
-            case Right(valid) =>
-              onSuccess(identityProvider.authenticate(valid.email, valid.password).unsafeToFuture()) {
-                case Right(account) => complete(Map("token" -> tokenFor(account)))
-                case Left(_)        => complete(StatusCodes.Unauthorized -> Map("error" -> "Invalid email or password"))
+        clientIp { ip =>
+          ipThrottle("login", ip) {
+            entity(as[LoginRequest]) { req =>
+              AuthValidation.validateLogin(req) match {
+                case Left(error) =>
+                  complete(StatusCodes.BadRequest -> Map("error" -> error))
+                case Right(valid) =>
+                  val lockKey = lockoutKey(valid.email)
+                  onSuccess(rateLimiter.lockStatus(lockKey).unsafeToFuture()) {
+                    case Some(retryAfter) =>
+                      tooManyRequests("Account temporarily locked after repeated failed logins", retryAfter)
+                    case None =>
+                      // Clear the failure count on success, or record a failure (which may trip the lock) on rejection.
+                      val attempt = identityProvider.authenticate(valid.email, valid.password).flatMap {
+                        case success @ Right(_) => rateLimiter.clearFailures(lockKey).as(success)
+                        case failure @ Left(_)  =>
+                          rateLimiter
+                            .recordFailure(
+                              lockKey,
+                              limits.lockoutThreshold,
+                              limits.lockoutWindow,
+                              limits.lockoutDuration
+                            )
+                            .as(failure)
+                      }
+                      onSuccess(attempt.unsafeToFuture()) {
+                        case Right(account) => complete(Map("token" -> tokenFor(account)))
+                        case Left(_)        =>
+                          complete(StatusCodes.Unauthorized -> Map("error" -> "Invalid email or password"))
+                      }
+                  }
               }
+            }
           }
         }
       }
@@ -86,23 +159,28 @@ class AuthRoutes(identityProvider: IdentityProvider)(implicit runtime: IORuntime
       * - 400: the current password is blank or the new password is out of range
       * - 401: missing, invalid, or expired token
       * - 403: the current password is incorrect
+      * - 429: too many requests from this IP; retry after the `Retry-After` header
       *
       * Existing tokens are not revoked by a change — they remain valid until they expire.
       */
     path("password") {
       post {
-        authenticatePlayer { player =>
-          entity(as[ChangePasswordRequest]) { req =>
-            AuthValidation.validatePasswordChange(req) match {
-              case Left(error) =>
-                complete(StatusCodes.BadRequest -> Map("error" -> error))
-              case Right(_) =>
-                onSuccess(
-                  identityProvider.changePassword(player.id, req.currentPassword, req.newPassword).unsafeToFuture()
-                ) {
-                  case Right(_) => complete(StatusCodes.NoContent)
-                  case Left(_)  => complete(StatusCodes.Forbidden -> Map("error" -> "Current password is incorrect"))
+        clientIp { ip =>
+          ipThrottle("password", ip) {
+            authenticatePlayer { player =>
+              entity(as[ChangePasswordRequest]) { req =>
+                AuthValidation.validatePasswordChange(req) match {
+                  case Left(error) =>
+                    complete(StatusCodes.BadRequest -> Map("error" -> error))
+                  case Right(_) =>
+                    onSuccess(
+                      identityProvider.changePassword(player.id, req.currentPassword, req.newPassword).unsafeToFuture()
+                    ) {
+                      case Right(_) => complete(StatusCodes.NoContent)
+                      case Left(_) => complete(StatusCodes.Forbidden -> Map("error" -> "Current password is incorrect"))
+                    }
                 }
+              }
             }
           }
         }

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/GameRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/GameRoutes.scala
@@ -28,7 +28,7 @@ import com.andy327.actor.core.GameManager.{
 }
 import com.andy327.actor.game.{GameOperation, GameRegistry}
 import com.andy327.model.core.GameType
-import com.andy327.server.http.auth.JwtPlayerDirectives._
+import com.andy327.server.http.auth.JwtAuthenticator
 import com.andy327.server.http.json.JsonProtocol._
 import com.andy327.server.http.routes.RouteDirectives._
 
@@ -49,7 +49,11 @@ import com.andy327.server.http.routes.RouteDirectives._
   *   - POST /{gameType}/{roomId}/subscribe - Start spectating a game (push events over the player's WebSocket)
   *   - DELETE /{gameType}/{roomId}/subscribe - Stop spectating a game
   */
-class GameRoutes(gameType: GameType, system: ActorSystem[Command]) {
+class GameRoutes(
+    gameType: GameType,
+    system: ActorSystem[Command],
+    authenticator: JwtAuthenticator = new JwtAuthenticator()
+) {
   implicit val scheduler: Scheduler = system.scheduler
   implicit val timeout: Timeout = 3.seconds
   implicit val ec: ExecutionContext = system.executionContext
@@ -99,7 +103,7 @@ class GameRoutes(gameType: GameType, system: ActorSystem[Command]) {
           * - 500: unexpected error
           */
         path("move") {
-          authenticatePlayer { player =>
+          authenticator.authenticatePlayer { player =>
             post {
               extractRequest { req =>
                 onSuccess(decodeJsonEntity(module.moveDecoder)(req)) {
@@ -190,7 +194,7 @@ class GameRoutes(gameType: GameType, system: ActorSystem[Command]) {
           */
         path("subscribe") {
           post {
-            authenticatePlayer { player =>
+            authenticator.authenticatePlayer { player =>
               onSuccess(system.ask[GameResponse](GameManager.SubscribePlayerToGame(roomId, player.id, _))) {
                 case ack: SubscribeAcknowledged => complete(ack)
                 case ErrorResponse(msg)         => complete(StatusCodes.BadRequest -> msg)
@@ -211,7 +215,7 @@ class GameRoutes(gameType: GameType, system: ActorSystem[Command]) {
             * - 500: unexpected error
             */
           delete {
-            authenticatePlayer { player =>
+            authenticator.authenticatePlayer { player =>
               onSuccess(system.ask[GameResponse](GameManager.UnsubscribePlayerFromGame(roomId, player.id, _))) {
                 case ack: UnsubscribeAcknowledged => complete(ack)
                 case unknown => complete(StatusCodes.InternalServerError -> s"Unexpected response: $unknown")

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/LobbyRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/LobbyRoutes.scala
@@ -27,7 +27,7 @@ import com.andy327.actor.core.GameManager.{
 }
 import com.andy327.actor.lobby.LobbyError
 import com.andy327.model.core.GameType
-import com.andy327.server.http.auth.JwtPlayerDirectives._
+import com.andy327.server.http.auth.JwtAuthenticator
 import com.andy327.server.http.json.JsonProtocol._
 import com.andy327.server.http.routes.RouteDirectives._
 
@@ -47,7 +47,10 @@ import com.andy327.server.http.routes.RouteDirectives._
   *   - POST /lobby/{roomId}/subscribe - Start spectating a lobby (push events over the player's WebSocket)
   *   - DELETE /lobby/{roomId}/subscribe - Stop spectating a lobby
   */
-class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
+class LobbyRoutes(
+    system: ActorSystem[GameManager.Command],
+    authenticator: JwtAuthenticator = new JwtAuthenticator()
+) {
   implicit val timeout: Timeout = 3.seconds
   implicit val scheduler: Scheduler = system.scheduler
 
@@ -102,7 +105,7 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
     path("create" / Segment) { gameTypeStr =>
       parseGameType(gameTypeStr) { gameType =>
         post {
-          authenticatePlayer { player =>
+          authenticator.authenticatePlayer { player =>
             onSuccess(system.ask[GameResponse](replyTo => GameManager.CreateLobby(gameType, player, replyTo))) {
               case created: LobbyCreated => complete(created)
               case other                 => complete(StatusCodes.InternalServerError -> s"Unexpected response: $other")
@@ -143,7 +146,7 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
             * - 500: unexpected error
             */
           delete {
-            authenticatePlayer { player =>
+            authenticator.authenticatePlayer { player =>
               onSuccess(system.ask[GameResponse](replyTo => GameManager.CancelLobby(roomId, player.id, replyTo))) {
                 case left @ LobbyLeft(_, _)    => complete(left)
                 case LobbyErrorResponse(error) => complete(statusFor(error) -> error.message)
@@ -165,7 +168,7 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
           */
         path("join") {
           post {
-            authenticatePlayer { player =>
+            authenticator.authenticatePlayer { player =>
               onSuccess(system.ask[GameResponse](replyTo => GameManager.JoinLobby(roomId, player, replyTo))) {
                 case joined: LobbyJoined       => complete(joined)
                 case LobbyErrorResponse(error) => complete(statusFor(error) -> error.message)
@@ -192,7 +195,7 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
           */
         path("leave") {
           post {
-            authenticatePlayer { player =>
+            authenticator.authenticatePlayer { player =>
               onSuccess(system.ask[GameResponse](replyTo => GameManager.LeaveLobby(roomId, player, replyTo))) {
                 case left @ LobbyLeft(_, _)    => complete(left)
                 case GameForfeited(_, state)   => complete(state)
@@ -217,7 +220,7 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
           */
         path("start") {
           post {
-            authenticatePlayer { player =>
+            authenticator.authenticatePlayer { player =>
               onSuccess(system.ask[GameResponse](replyTo => GameManager.StartGame(roomId, player.id, replyTo))) {
                 case gs @ GameStarted(_)       => complete(gs)
                 case LobbyErrorResponse(error) => complete(statusFor(error) -> error.message)
@@ -241,7 +244,7 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
           */
         path("subscribe") {
           post {
-            authenticatePlayer { player =>
+            authenticator.authenticatePlayer { player =>
               onSuccess(
                 system.ask[GameResponse](replyTo => GameManager.SubscribePlayerToLobby(roomId, player.id, replyTo))
               ) {
@@ -264,7 +267,7 @@ class LobbyRoutes(system: ActorSystem[GameManager.Command]) {
             * - 500: unexpected error
             */
           delete {
-            authenticatePlayer { player =>
+            authenticator.authenticatePlayer { player =>
               onSuccess(
                 system.ask[GameResponse](replyTo => GameManager.UnsubscribePlayerFromLobby(roomId, player.id, replyTo))
               ) {

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/PlayerRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/PlayerRoutes.scala
@@ -14,8 +14,7 @@ import org.apache.pekko.util.Timeout
 import com.andy327.actor.core.GameManager
 import com.andy327.actor.core.GameManager.{GameResponse, PlayerSessions}
 import com.andy327.persistence.db.{InMemoryPlayerHistoryRepository, PlayerHistoryRepository}
-import com.andy327.server.http.auth.JwtPlayerDirectives._
-import com.andy327.server.http.auth.{PlayerGameSummary, PlayerHistory}
+import com.andy327.server.http.auth.{JwtAuthenticator, PlayerGameSummary, PlayerHistory}
 import com.andy327.server.http.json.JsonProtocol._
 
 /** HTTP routes for a player's own data: their current participation and their completed-game history.
@@ -33,7 +32,8 @@ import com.andy327.server.http.json.JsonProtocol._
   */
 class PlayerRoutes(
     system: ActorSystem[GameManager.Command],
-    playerHistoryRepo: PlayerHistoryRepository = new InMemoryPlayerHistoryRepository
+    playerHistoryRepo: PlayerHistoryRepository = new InMemoryPlayerHistoryRepository,
+    authenticator: JwtAuthenticator = new JwtAuthenticator()
 )(implicit runtime: IORuntime) {
   implicit val timeout: Timeout = 3.seconds
   implicit val scheduler: Scheduler = system.scheduler
@@ -52,7 +52,7 @@ class PlayerRoutes(
       */
     path("sessions") {
       get {
-        authenticatePlayer { player =>
+        authenticator.authenticatePlayer { player =>
           onSuccess(system.ask[GameResponse](GameManager.GetPlayerSessions(player.id, _))) {
             case sessions: PlayerSessions => complete(sessions)
             case other                    => complete(StatusCodes.InternalServerError -> s"Unexpected response: $other")
@@ -70,7 +70,7 @@ class PlayerRoutes(
       */
     path("history") {
       get {
-        authenticatePlayer { player =>
+        authenticator.authenticatePlayer { player =>
           onSuccess(playerHistoryRepo.findByPlayer(player.id).unsafeToFuture()) { records =>
             val games = records.map(r => PlayerGameSummary(r.matchId, r.gameType, r.result, r.forfeit, r.finishedAt))
             complete(PlayerHistory(games))

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/TraceRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/TraceRoutes.scala
@@ -16,7 +16,7 @@ import org.apache.pekko.util.Timeout
 
 import com.andy327.actor.core.GameManager
 import com.andy327.actor.tracing.{TraceCollector, TraceEvent}
-import com.andy327.server.http.auth.JwtPlayerDirectives._
+import com.andy327.server.http.auth.JwtAuthenticator
 import com.andy327.server.http.json.JsonProtocol._
 
 /** Debug HTTP route that streams live `TraceEvent`s for actor message tracing visualization.
@@ -35,14 +35,17 @@ import com.andy327.server.http.json.JsonProtocol._
   *   - Sends to: `GameManager` (`GetTraceCollector` on connect), the resolved `trace-collector`
   *     (`TraceCollector.Subscribe` on connect, `TraceCollector.Unsubscribe` on close)
   */
-class TraceRoutes(gameManager: ActorSystem[GameManager.Command]) {
+class TraceRoutes(
+    gameManager: ActorSystem[GameManager.Command],
+    authenticator: JwtAuthenticator = new JwtAuthenticator()
+) {
   implicit private val system: ActorSystem[GameManager.Command] = gameManager
   implicit private val timeout: Timeout = Timeout(5.seconds)
   implicit private val mat: Materializer = Materializer(system)
   private val ec = system.executionContext
 
   val routes: Route = path("ws" / "trace") {
-    authenticatePlayerAllowingQueryParam { _ =>
+    authenticator.authenticatePlayerAllowingQueryParam { _ =>
       onSuccess(gameManager ? GameManager.GetTraceCollector) {
         case Some(collector) => handleWebSocketMessages(buildFlow(collector))
         case None            => complete(StatusCodes.ServiceUnavailable -> "tracing is disabled")

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/WebSocketRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/WebSocketRoutes.scala
@@ -18,7 +18,7 @@ import org.apache.pekko.util.Timeout
 
 import com.andy327.actor.core.{GameManager, PlayerActor, PlayerEvent}
 import com.andy327.actor.lobby.Player
-import com.andy327.server.http.auth.JwtPlayerDirectives._
+import com.andy327.server.http.auth.JwtAuthenticator
 import com.andy327.server.http.json.ClientMessage
 import com.andy327.server.http.json.JsonProtocol._
 
@@ -41,7 +41,10 @@ import com.andy327.server.http.json.JsonProtocol._
   *   - Sends to: `GameManager` (`RegisterPlayer` on connect, `SendChat` on an inbound chat frame, `PlayerDisconnected`
   *     on close)
   */
-class WebSocketRoutes(gameManager: ActorSystem[GameManager.Command]) {
+class WebSocketRoutes(
+    gameManager: ActorSystem[GameManager.Command],
+    authenticator: JwtAuthenticator = new JwtAuthenticator()
+) {
   implicit private val system: ActorSystem[GameManager.Command] = gameManager
   implicit private val timeout: Timeout = Timeout(5.seconds)
   implicit private val mat: Materializer = Materializer(system)
@@ -49,7 +52,7 @@ class WebSocketRoutes(gameManager: ActorSystem[GameManager.Command]) {
   private val logger = LoggerFactory.getLogger(getClass)
 
   val routes: Route = path("ws") {
-    authenticatePlayerAllowingQueryParam { player =>
+    authenticator.authenticatePlayerAllowingQueryParam { player =>
       handleWebSocketMessages(buildFlow(player))
     }
   }

--- a/game-service-server/src/test/scala/com/andy327/server/auth/AuthRateLimiterSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/auth/AuthRateLimiterSpec.scala
@@ -1,0 +1,126 @@
+package com.andy327.server.auth
+
+import java.time.{Clock, Instant, ZoneId, ZoneOffset}
+
+import scala.concurrent.duration._
+
+import cats.effect.unsafe.implicits.global
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/** A [[Clock]] whose current instant can be advanced by the test, so window/lockout expiry is deterministic. */
+private class MutableClock(start: Instant) extends Clock {
+  @volatile private var current: Instant = start
+  def advance(by: FiniteDuration): Unit = current = current.plusMillis(by.toMillis)
+  override def instant(): Instant = current
+  override def getZone: ZoneId = ZoneOffset.UTC
+  override def withZone(zone: ZoneId): Clock = this
+}
+
+class AuthRateLimiterSpec extends AnyWordSpec with Matchers {
+
+  private def newLimiter(clock: MutableClock): InMemoryAuthRateLimiter = {
+    implicit val c: Clock = clock
+    new InMemoryAuthRateLimiter
+  }
+
+  "InMemoryAuthRateLimiter.throttle" should {
+    "admit requests up to the limit and throttle the next one" in {
+      val clock = new MutableClock(Instant.parse("2026-07-05T00:00:00Z"))
+      val limiter = newLimiter(clock)
+
+      limiter.throttle("ip", limit = 2, window = 1.minute).unsafeRunSync() shouldBe RateLimitOutcome.Allowed
+      limiter.throttle("ip", limit = 2, window = 1.minute).unsafeRunSync() shouldBe RateLimitOutcome.Allowed
+
+      limiter.throttle("ip", limit = 2, window = 1.minute).unsafeRunSync() match {
+        case RateLimitOutcome.Limited(retryAfter) => retryAfter should ((be <= 1.minute).and(be > 0.seconds))
+        case other                                => fail(s"expected Limited, got $other")
+      }
+    }
+
+    "reset the window once it elapses" in {
+      val clock = new MutableClock(Instant.parse("2026-07-05T00:00:00Z"))
+      val limiter = newLimiter(clock)
+
+      limiter.throttle("ip", limit = 1, window = 1.minute).unsafeRunSync() shouldBe RateLimitOutcome.Allowed
+      limiter.throttle("ip", limit = 1, window = 1.minute).unsafeRunSync() shouldBe a[RateLimitOutcome.Limited]
+
+      clock.advance(61.seconds)
+      limiter.throttle("ip", limit = 1, window = 1.minute).unsafeRunSync() shouldBe RateLimitOutcome.Allowed
+    }
+
+    "count keys independently" in {
+      val clock = new MutableClock(Instant.parse("2026-07-05T00:00:00Z"))
+      val limiter = newLimiter(clock)
+
+      limiter.throttle("a", limit = 1, window = 1.minute).unsafeRunSync() shouldBe RateLimitOutcome.Allowed
+      limiter.throttle("b", limit = 1, window = 1.minute).unsafeRunSync() shouldBe RateLimitOutcome.Allowed
+      limiter.throttle("a", limit = 1, window = 1.minute).unsafeRunSync() shouldBe a[RateLimitOutcome.Limited]
+    }
+  }
+
+  "InMemoryAuthRateLimiter lockout" should {
+    "lock a key only once the failure threshold is reached" in {
+      val clock = new MutableClock(Instant.parse("2026-07-05T00:00:00Z"))
+      val limiter = newLimiter(clock)
+      def recordFail(): Unit = limiter.recordFailure("acct", threshold = 3, window = 15.minutes, lockout = 15.minutes)
+        .unsafeRunSync()
+
+      recordFail()
+      recordFail()
+      limiter.lockStatus("acct").unsafeRunSync() shouldBe None
+
+      recordFail()
+      limiter.lockStatus("acct").unsafeRunSync() match {
+        case Some(remaining) => remaining should ((be <= 15.minutes).and(be > 0.seconds))
+        case None            => fail("expected the account to be locked")
+      }
+    }
+
+    "release the lock after the lockout elapses" in {
+      val clock = new MutableClock(Instant.parse("2026-07-05T00:00:00Z"))
+      val limiter = newLimiter(clock)
+      (1 to 3).foreach(_ =>
+        limiter.recordFailure("acct", threshold = 3, window = 15.minutes, lockout = 15.minutes).unsafeRunSync()
+      )
+      limiter.lockStatus("acct").unsafeRunSync() shouldBe defined
+
+      clock.advance(16.minutes)
+      limiter.lockStatus("acct").unsafeRunSync() shouldBe None
+    }
+
+    "not count failures that fall outside the rolling window toward the threshold" in {
+      val clock = new MutableClock(Instant.parse("2026-07-05T00:00:00Z"))
+      val limiter = newLimiter(clock)
+      def recordFail(): Unit = limiter.recordFailure("acct", threshold = 2, window = 5.minutes, lockout = 15.minutes)
+        .unsafeRunSync()
+
+      recordFail()
+      clock.advance(6.minutes) // first failure's window has elapsed
+      recordFail()
+      limiter.lockStatus("acct").unsafeRunSync() shouldBe None
+    }
+
+    "clear the failure count and any lock on success" in {
+      val clock = new MutableClock(Instant.parse("2026-07-05T00:00:00Z"))
+      val limiter = newLimiter(clock)
+      (1 to 3).foreach(_ =>
+        limiter.recordFailure("acct", threshold = 3, window = 15.minutes, lockout = 15.minutes).unsafeRunSync()
+      )
+      limiter.lockStatus("acct").unsafeRunSync() shouldBe defined
+
+      limiter.clearFailures("acct").unsafeRunSync()
+      limiter.lockStatus("acct").unsafeRunSync() shouldBe None
+    }
+  }
+
+  "NoOpAuthRateLimiter" should {
+    "never throttle or lock" in {
+      NoOpAuthRateLimiter.throttle("ip", limit = 0, window = 1.minute).unsafeRunSync() shouldBe RateLimitOutcome.Allowed
+      NoOpAuthRateLimiter.recordFailure("acct", threshold = 1, window = 1.minute, lockout = 1.minute).unsafeRunSync()
+      NoOpAuthRateLimiter.clearFailures("acct").unsafeRunSync()
+      NoOpAuthRateLimiter.lockStatus("acct").unsafeRunSync() shouldBe None
+    }
+  }
+}

--- a/game-service-server/src/test/scala/com/andy327/server/auth/RedisAuthRateLimiterSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/auth/RedisAuthRateLimiterSpec.scala
@@ -1,0 +1,87 @@
+package com.andy327.server.auth
+
+import scala.concurrent.duration._
+
+import com.typesafe.config.ConfigFactory
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+
+import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
+import dev.profunktor.redis4cats.RedisCommands
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.testcontainers.containers.wait.strategy.Wait
+
+import com.andy327.persistence.db.redis.RedisClientResource
+
+class RedisAuthRateLimiterSpec extends AnyWordSpec with Matchers with ForAllTestContainer {
+
+  private val RedisPort = 6379
+
+  override val container: GenericContainer = GenericContainer(
+    dockerImage = "redis:7-alpine",
+    exposedPorts = Seq(RedisPort),
+    waitStrategy = Wait.forListeningPort()
+  )
+
+  private def redisConfig = ConfigFactory.parseString(s"""
+    pekko-game-service.redis {
+      uri = "redis://${container.containerIpAddress}:${container.mappedPort(RedisPort)}"
+    }
+  """)
+
+  private def withLimiter[A](f: (RedisAuthRateLimiter, RedisCommands[IO, String, String]) => IO[A]): A =
+    RedisClientResource(redisConfig).use { redis =>
+      redis.flushAll *> f(new RedisAuthRateLimiter(redis), redis)
+    }.unsafeRunSync()
+
+  "RedisAuthRateLimiter.throttle" should {
+    "admit up to the limit, then throttle with a Retry-After bounded by the window" in withLimiter { (limiter, _) =>
+      for {
+        a <- limiter.throttle("ip", limit = 2, window = 1.minute)
+        b <- limiter.throttle("ip", limit = 2, window = 1.minute)
+        c <- limiter.throttle("ip", limit = 2, window = 1.minute)
+      } yield {
+        a shouldBe RateLimitOutcome.Allowed
+        b shouldBe RateLimitOutcome.Allowed
+        c match {
+          case RateLimitOutcome.Limited(retryAfter) => retryAfter should ((be <= 1.minute).and(be > 0.seconds))
+          case other                                => fail(s"expected Limited, got $other")
+        }
+      }
+    }
+
+    "give the throttle counter a TTL so it self-expires" in withLimiter { (limiter, redis) =>
+      for {
+        _ <- limiter.throttle("ip", limit = 1, window = 30.seconds)
+        ttl <- redis.ttl("auth-rl:count:ip")
+      } yield ttl match {
+        case Some(remaining) => remaining should ((be <= 30.seconds).and(be > 0.seconds))
+        case None            => fail("expected the throttle counter to carry a TTL")
+      }
+    }
+  }
+
+  "RedisAuthRateLimiter lockout" should {
+    "lock only once the failure threshold is reached, and clear on success" in withLimiter { (limiter, _) =>
+      val recordFail = limiter.recordFailure("acct", threshold = 3, window = 15.minutes, lockout = 15.minutes)
+      for {
+        _ <- recordFail
+        _ <- recordFail
+        beforeThreshold <- limiter.lockStatus("acct")
+        _ <- recordFail
+        afterThreshold <- limiter.lockStatus("acct")
+        _ <- limiter.clearFailures("acct")
+        afterClear <- limiter.lockStatus("acct")
+      } yield {
+        beforeThreshold shouldBe None
+        afterThreshold match {
+          case Some(remaining) => remaining should ((be <= 15.minutes).and(be > 0.seconds))
+          case None            => fail("expected the account to be locked")
+        }
+        afterClear shouldBe None
+      }
+    }
+  }
+}

--- a/game-service-server/src/test/scala/com/andy327/server/auth/RedisRevocationStoreSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/auth/RedisRevocationStoreSpec.scala
@@ -1,0 +1,67 @@
+package com.andy327.server.auth
+
+import java.time.Instant
+import java.util.UUID
+
+import scala.concurrent.duration._
+
+import com.typesafe.config.ConfigFactory
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+
+import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
+import dev.profunktor.redis4cats.RedisCommands
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.testcontainers.containers.wait.strategy.Wait
+
+import com.andy327.persistence.db.redis.RedisClientResource
+
+class RedisRevocationStoreSpec extends AnyWordSpec with Matchers with ForAllTestContainer {
+
+  private val RedisPort = 6379
+
+  override val container: GenericContainer = GenericContainer(
+    dockerImage = "redis:7-alpine",
+    exposedPorts = Seq(RedisPort),
+    waitStrategy = Wait.forListeningPort()
+  )
+
+  private def redisConfig = ConfigFactory.parseString(s"""
+    pekko-game-service.redis {
+      uri = "redis://${container.containerIpAddress}:${container.mappedPort(RedisPort)}"
+    }
+  """)
+
+  private def withStore[A](f: (RedisRevocationStore, RedisCommands[IO, String, String]) => IO[A]): A =
+    RedisClientResource(redisConfig).use { redis =>
+      redis.flushAll *> f(new RedisRevocationStore(redis), redis)
+    }.unsafeRunSync()
+
+  "RedisRevocationStore" should {
+    "round-trip a cutoff (to millisecond precision) and report None for an unknown account" in withStore { (store, _) =>
+      val id = UUID.randomUUID()
+      val cutoff = Instant.ofEpochMilli(1_780_000_000_000L)
+      for {
+        before <- store.revokedBefore(id)
+        _ <- store.revokeBefore(id, cutoff, 1.hour)
+        after <- store.revokedBefore(id)
+      } yield {
+        before shouldBe None
+        after shouldBe Some(cutoff)
+      }
+    }
+
+    "give the cutoff key a TTL so it self-expires" in withStore { (store, redis) =>
+      val id = UUID.randomUUID()
+      for {
+        _ <- store.revokeBefore(id, Instant.now(), 30.seconds)
+        ttl <- redis.ttl(s"auth:revoked-before:$id")
+      } yield ttl match {
+        case Some(remaining) => remaining should ((be <= 30.seconds).and(be > 0.seconds))
+        case None            => fail("expected the cutoff key to carry a TTL")
+      }
+    }
+  }
+}

--- a/game-service-server/src/test/scala/com/andy327/server/auth/RevocationStoreSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/auth/RevocationStoreSpec.scala
@@ -1,0 +1,66 @@
+package com.andy327.server.auth
+
+import java.time.{Clock, Instant, ZoneId, ZoneOffset}
+import java.util.UUID
+
+import scala.concurrent.duration._
+
+import cats.effect.unsafe.implicits.global
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/** A [[Clock]] whose current instant can be advanced by the test, so the cutoff TTL is deterministic. */
+private class MovableClock(start: Instant) extends Clock {
+  @volatile private var current: Instant = start
+  def advance(by: FiniteDuration): Unit = current = current.plusMillis(by.toMillis)
+  override def instant(): Instant = current
+  override def getZone: ZoneId = ZoneOffset.UTC
+  override def withZone(zone: ZoneId): Clock = this
+}
+
+class RevocationStoreSpec extends AnyWordSpec with Matchers {
+
+  "InMemoryRevocationStore" should {
+    "return the cutoff last written for an account, and None for an unknown one" in {
+      val store = new InMemoryRevocationStore
+      val id = UUID.randomUUID()
+      val cutoff = Instant.parse("2026-07-05T12:00:00Z")
+
+      store.revokedBefore(id).unsafeRunSync() shouldBe None
+      store.revokeBefore(id, cutoff, 1.hour).unsafeRunSync()
+      store.revokedBefore(id).unsafeRunSync() shouldBe Some(cutoff)
+    }
+
+    "keep accounts independent" in {
+      val store = new InMemoryRevocationStore
+      val (a, b) = (UUID.randomUUID(), UUID.randomUUID())
+      val cutoff = Instant.parse("2026-07-05T12:00:00Z")
+
+      store.revokeBefore(a, cutoff, 1.hour).unsafeRunSync()
+      store.revokedBefore(a).unsafeRunSync() shouldBe Some(cutoff)
+      store.revokedBefore(b).unsafeRunSync() shouldBe None
+    }
+
+    "forget the cutoff once its TTL elapses" in {
+      val clock = new MovableClock(Instant.parse("2026-07-05T12:00:00Z"))
+      implicit val c: Clock = clock
+      val store = new InMemoryRevocationStore
+      val id = UUID.randomUUID()
+
+      store.revokeBefore(id, Instant.parse("2026-07-05T12:00:00Z"), 1.hour).unsafeRunSync()
+      store.revokedBefore(id).unsafeRunSync() shouldBe defined
+
+      clock.advance(61.minutes)
+      store.revokedBefore(id).unsafeRunSync() shouldBe None
+    }
+  }
+
+  "NoOpRevocationStore" should {
+    "never record or report a revocation" in {
+      val id = UUID.randomUUID()
+      NoOpRevocationStore.revokeBefore(id, Instant.now(), 1.hour).unsafeRunSync()
+      NoOpRevocationStore.revokedBefore(id).unsafeRunSync() shouldBe None
+    }
+  }
+}

--- a/game-service-server/src/test/scala/com/andy327/server/config/AuthRateLimitConfigSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/config/AuthRateLimitConfigSpec.scala
@@ -1,0 +1,40 @@
+package com.andy327.server.config
+
+import scala.concurrent.duration._
+
+import com.typesafe.config.ConfigFactory
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class AuthRateLimitConfigSpec extends AnyWordSpec with Matchers {
+
+  "AuthRateLimitConfig.fromConfig" should {
+    "read every field from the auth.rate-limit stanza" in {
+      val config = ConfigFactory.parseString("""
+        auth.rate-limit {
+          enabled = true
+          ip { window = 10m, max-attempts = 30 }
+          lockout { threshold = 4, window = 5m, duration = 20m }
+        }
+      """)
+
+      AuthRateLimitConfig.fromConfig(config) shouldBe AuthRateLimitConfig(
+        enabled = true,
+        ipWindow = 10.minutes,
+        ipMaxAttempts = 30,
+        lockoutThreshold = 4,
+        lockoutWindow = 5.minutes,
+        lockoutDuration = 20.minutes
+      )
+    }
+
+    "load the packaged application.conf defaults" in {
+      val config = AuthRateLimitConfig.fromConfig()
+      config.enabled shouldBe true
+      config.ipMaxAttempts should be > 0
+      config.lockoutThreshold should be > 0
+      config.lockoutDuration should be > 0.seconds
+    }
+  }
+}

--- a/game-service-server/src/test/scala/com/andy327/server/http/auth/JwtAuthenticatorRevocationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/auth/JwtAuthenticatorRevocationSpec.scala
@@ -1,0 +1,71 @@
+package com.andy327.server.http.auth
+
+import java.time.Instant
+
+import scala.concurrent.duration._
+
+import cats.effect.unsafe.implicits.global
+
+import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.model.headers.RawHeader
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import com.andy327.actor.lobby.Player
+import com.andy327.server.auth.{InMemoryRevocationStore, JwtIssuer, UserContext}
+
+class JwtAuthenticatorRevocationSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
+
+  private val issuer = JwtIssuer.fromConfig()
+
+  /** Mints a token whose `iat` is "now" for a fresh player, returning both. */
+  private def tokenForNewPlayer(name: String): (Player, String) = {
+    val player = Player(name)
+    (player, issuer.issue(UserContext(player.id.toString, player.name)))
+  }
+
+  private def routeWith(store: InMemoryRevocationStore): Route =
+    new JwtAuthenticator(revocationStore = store).authenticatePlayer(player => complete(player.name))
+
+  private def get(token: String, route: Route) =
+    Get("/").withHeaders(RawHeader("Authorization", s"Bearer $token")) ~> route
+
+  "JwtAuthenticator revocation" should {
+    "reject a token issued before the account's revocation cutoff" in {
+      val store = new InMemoryRevocationStore
+      val (player, token) = tokenForNewPlayer("frank")
+      // Cutoff comfortably after the token's issued-at, so the token predates it.
+      store.revokeBefore(player.id, Instant.now().plusSeconds(60), 1.hour).unsafeRunSync()
+
+      get(token, routeWith(store)) ~> check {
+        status shouldBe StatusCodes.Unauthorized
+        responseAs[String] should include("Token has been revoked")
+      }
+    }
+
+    "accept a token issued after the account's revocation cutoff" in {
+      val store = new InMemoryRevocationStore
+      val (player, token) = tokenForNewPlayer("grace")
+      // Cutoff well before the token's issued-at, so this token survives it.
+      store.revokeBefore(player.id, Instant.now().minusSeconds(60), 1.hour).unsafeRunSync()
+
+      get(token, routeWith(store)) ~> check {
+        status shouldBe StatusCodes.OK
+        responseAs[String] shouldBe "grace"
+      }
+    }
+
+    "accept any token when nothing is revoked" in {
+      val store = new InMemoryRevocationStore
+      val (_, token) = tokenForNewPlayer("heidi")
+
+      get(token, routeWith(store)) ~> check {
+        status shouldBe StatusCodes.OK
+        responseAs[String] shouldBe "heidi"
+      }
+    }
+  }
+}

--- a/game-service-server/src/test/scala/com/andy327/server/http/auth/JwtAuthenticatorSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/auth/JwtAuthenticatorSpec.scala
@@ -14,15 +14,17 @@ import com.andy327.actor.lobby.Player
 import com.andy327.server.auth.UserContext
 import com.andy327.server.config.JwtConfig
 
-class JwtPlayerDirectivesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
+class JwtAuthenticatorSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
+
+  private val authenticator = new JwtAuthenticator()
 
   val testRoute: Route =
-    JwtPlayerDirectives.authenticatePlayer { player =>
+    authenticator.authenticatePlayer { player =>
       complete(s"Hello, ${player.name}!")
     }
 
   val queryParamRoute: Route =
-    JwtPlayerDirectives.authenticatePlayerAllowingQueryParam { player =>
+    authenticator.authenticatePlayerAllowingQueryParam { player =>
       complete(s"Hello, ${player.name}!")
     }
 
@@ -33,7 +35,7 @@ class JwtPlayerDirectivesSpec extends AnyWordSpec with Matchers with ScalatestRo
     (player, JwtCirce.encode(userContext.asJson, JwtConfig.secretKey, JwtAlgorithm.HS256))
   }
 
-  "JwtPlayerDirectives.authenticatePlayer" should {
+  "JwtAuthenticator.authenticatePlayer" should {
     "reject if Authorization header is missing" in
       Get("/") ~> testRoute ~> check {
         status shouldBe StatusCodes.Unauthorized
@@ -92,7 +94,7 @@ class JwtPlayerDirectivesSpec extends AnyWordSpec with Matchers with ScalatestRo
     }
   }
 
-  "JwtPlayerDirectives.authenticatePlayerAllowingQueryParam" should {
+  "JwtAuthenticator.authenticatePlayerAllowingQueryParam" should {
     "accept a valid JWT from the access_token query parameter" in {
       val (_, token) = tokenForNewPlayer("carol")
       Get(s"/?access_token=$token") ~> queryParamRoute ~> check {

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/AuthRoutesRateLimitSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/AuthRoutesRateLimitSpec.scala
@@ -1,0 +1,121 @@
+package com.andy327.server.http.routes
+
+import scala.concurrent.duration._
+
+import cats.effect.unsafe.implicits.global
+
+import io.circe.parser.decode
+import io.circe.syntax._
+import org.apache.pekko.http.scaladsl.model.headers.RawHeader
+import org.apache.pekko.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import com.andy327.persistence.db.InMemoryUserRepository
+import com.andy327.server.auth.{InMemoryAuthRateLimiter, PasswordHasher, PasswordIdentityProvider}
+import com.andy327.server.config.AuthRateLimitConfig
+import com.andy327.server.http.auth.{LoginRequest, RegisterRequest}
+import com.andy327.server.http.json.JsonProtocol._
+
+class AuthRoutesRateLimitSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
+
+  /** Generous IP limit so the per-account lockout can be exercised without the IP throttle firing first. */
+  private def lockoutConfig(ipMax: Int = 100, threshold: Int = 3): AuthRateLimitConfig =
+    AuthRateLimitConfig(
+      enabled = true,
+      ipWindow = 1.minute,
+      ipMaxAttempts = ipMax,
+      lockoutThreshold = threshold,
+      lockoutWindow = 15.minutes,
+      lockoutDuration = 15.minutes
+    )
+
+  private def newRoutes(config: AuthRateLimitConfig): Route =
+    new AuthRoutes(
+      new PasswordIdentityProvider(new InMemoryUserRepository, new PasswordHasher(256, 1, 1)),
+      new InMemoryAuthRateLimiter,
+      config
+    ).routes
+
+  private def registerEntity(req: RegisterRequest): HttpEntity.Strict =
+    HttpEntity(ContentTypes.`application/json`, req.asJson.noSpaces)
+  private def loginEntity(req: LoginRequest): HttpEntity.Strict =
+    HttpEntity(ContentTypes.`application/json`, req.asJson.noSpaces)
+  private def fieldsOf(body: String): Map[String, String] =
+    decode[Map[String, String]](body).fold(err => fail(s"not a JSON object of strings: $err"), identity)
+
+  private def forwardedFor(ip: String) = RawHeader("X-Forwarded-For", ip)
+
+  "AuthRoutes per-IP throttle" should {
+    "admit requests up to the limit, then reject with 429 and a Retry-After header" in {
+      val routes = newRoutes(lockoutConfig(ipMax = 2))
+      def register(n: Int) =
+        Post("/auth/register", registerEntity(RegisterRequest(s"alice$n", s"alice$n@example.com", "s3cretpw")))
+          .withHeaders(forwardedFor("1.2.3.4"))
+
+      register(1) ~> routes ~> check(status shouldBe StatusCodes.Created)
+      register(2) ~> routes ~> check(status shouldBe StatusCodes.Created)
+      register(3) ~> routes ~> check {
+        status shouldBe StatusCodes.TooManyRequests
+        header("Retry-After") shouldBe defined
+        fieldsOf(responseAs[String])("error") should include("Too many requests")
+      }
+    }
+
+    "count each source IP independently" in {
+      val routes = newRoutes(lockoutConfig(ipMax = 1))
+      def register(n: Int, ip: String) =
+        Post("/auth/register", registerEntity(RegisterRequest(s"bob$n", s"bob$n@example.com", "s3cretpw")))
+          .withHeaders(forwardedFor(ip))
+
+      register(1, "10.0.0.1") ~> routes ~> check(status shouldBe StatusCodes.Created)
+      register(2, "10.0.0.2") ~> routes ~> check(status shouldBe StatusCodes.Created) // different IP, own bucket
+      register(3, "10.0.0.1") ~> routes ~> check(status shouldBe StatusCodes.TooManyRequests)
+    }
+  }
+
+  "AuthRoutes per-account lockout" should {
+    "lock an account after the failed-login threshold, rejecting even correct credentials with 429" in {
+      val routes = newRoutes(lockoutConfig(threshold = 3))
+      Post("/auth/register", registerEntity(RegisterRequest("carol", "carol@example.com", "correctpw"))) ~> routes ~>
+      check(status shouldBe StatusCodes.Created)
+
+      def badLogin() =
+        Post("/auth/token", loginEntity(LoginRequest("carol@example.com", "wrongpw"))) ~> routes ~> check {
+          status shouldBe StatusCodes.Unauthorized
+        }
+      badLogin()
+      badLogin()
+      badLogin() // third failure trips the lock
+
+      // Even the correct password is now refused while the lock is in force.
+      Post("/auth/token", loginEntity(LoginRequest("carol@example.com", "correctpw"))) ~> routes ~> check {
+        status shouldBe StatusCodes.TooManyRequests
+        header("Retry-After") shouldBe defined
+        fieldsOf(responseAs[String])("error") should include("locked")
+      }
+    }
+
+    "reset the failure count on a successful login so it does not accumulate across sessions" in {
+      val routes = newRoutes(lockoutConfig(threshold = 3))
+      Post("/auth/register", registerEntity(RegisterRequest("dave", "dave@example.com", "correctpw"))) ~> routes ~>
+      check(status shouldBe StatusCodes.Created)
+
+      def badLogin() =
+        Post("/auth/token", loginEntity(LoginRequest("dave@example.com", "wrongpw"))) ~> routes ~>
+        check(status shouldBe StatusCodes.Unauthorized)
+      def goodLogin() =
+        Post("/auth/token", loginEntity(LoginRequest("dave@example.com", "correctpw"))) ~> routes ~>
+        check(status shouldBe StatusCodes.OK)
+
+      badLogin()
+      badLogin()
+      goodLogin() // clears the two failures
+      badLogin()
+      badLogin() // only two failures since the reset — still under the threshold
+      goodLogin() // so a correct login still succeeds rather than being locked out
+    }
+  }
+}

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/AuthRoutesRevocationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/AuthRoutesRevocationSpec.scala
@@ -1,0 +1,100 @@
+package com.andy327.server.http.routes
+
+import java.time.{Clock, Instant, ZoneOffset}
+import java.util.UUID
+
+import cats.effect.unsafe.implicits.global
+
+import io.circe.parser.decode
+import io.circe.syntax._
+import org.apache.pekko.http.scaladsl.model.headers.RawHeader
+import org.apache.pekko.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import com.andy327.actor.lobby.Player
+import com.andy327.persistence.db.InMemoryUserRepository
+import com.andy327.server.auth.{
+  InMemoryRevocationStore,
+  JwtIssuer,
+  PasswordHasher,
+  PasswordIdentityProvider,
+  UserContext
+}
+import com.andy327.server.config.JwtConfig
+import com.andy327.server.http.auth.{ChangePasswordRequest, JwtAuthenticator, RegisterRequest}
+import com.andy327.server.http.json.JsonProtocol._
+
+class AuthRoutesRevocationSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
+
+  private def newSetup(): (Route, InMemoryRevocationStore) = {
+    val store = new InMemoryRevocationStore
+    val authenticator = new JwtAuthenticator(revocationStore = store)
+    val routes = new AuthRoutes(
+      new PasswordIdentityProvider(new InMemoryUserRepository, new PasswordHasher(256, 1, 1)),
+      authenticator = authenticator,
+      revocationStore = store
+    ).routes
+    (routes, store)
+  }
+
+  /** A token whose `iat` is 10 seconds in the past, so a cutoff written "now" strictly post-dates it. */
+  private def pastToken(player: Player): String = {
+    val past = Clock.fixed(Instant.now().minusSeconds(10), ZoneOffset.UTC)
+    new JwtIssuer(JwtConfig.secretKey, JwtConfig.ttl)(past).issue(UserContext(player.id.toString, player.name))
+  }
+
+  private def bearer(token: String) = RawHeader("Authorization", s"Bearer $token")
+  private def fieldsOf(body: String): Map[String, String] =
+    decode[Map[String, String]](body).fold(err => fail(s"not a JSON object of strings: $err"), identity)
+
+  private def registerEntity(req: RegisterRequest): HttpEntity.Strict =
+    HttpEntity(ContentTypes.`application/json`, req.asJson.noSpaces)
+  private def changePasswordEntity(req: ChangePasswordRequest): HttpEntity.Strict =
+    HttpEntity(ContentTypes.`application/json`, req.asJson.noSpaces)
+
+  "AuthRoutes POST /auth/logout" should {
+    "revoke the caller's outstanding tokens so a previously-valid token is then rejected" in {
+      val (routes, _) = newSetup()
+      val player = Player("eve")
+      val token = pastToken(player)
+
+      Get("/auth/whoami").withHeaders(bearer(token)) ~> routes ~> check(status shouldBe StatusCodes.OK)
+
+      Post("/auth/logout").withHeaders(bearer(token)) ~> routes ~> check(status shouldBe StatusCodes.NoContent)
+
+      Get("/auth/whoami").withHeaders(bearer(token)) ~> routes ~> check {
+        status shouldBe StatusCodes.Unauthorized
+        responseAs[String] should include("Token has been revoked")
+      }
+    }
+
+    "reject an unauthenticated logout with 401" in
+      Post("/auth/logout") ~> newSetup()._1 ~> check(status shouldBe StatusCodes.Unauthorized)
+  }
+
+  "AuthRoutes POST /auth/password" should {
+    "record a revocation cutoff for the account on a successful change" in {
+      val (routes, store) = newSetup()
+      val token =
+        Post("/auth/register", registerEntity(RegisterRequest("ivan", "ivan@example.com", "oldpw123"))) ~> routes ~>
+        check {
+          status shouldBe StatusCodes.Created
+          fieldsOf(responseAs[String])("token")
+        }
+      val id = Get("/auth/whoami").withHeaders(bearer(token)) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+        UUID.fromString(fieldsOf(responseAs[String])("id"))
+      }
+
+      store.revokedBefore(id).unsafeRunSync() shouldBe None
+
+      Post("/auth/password", changePasswordEntity(ChangePasswordRequest("oldpw123", "newpw456")))
+        .withHeaders(bearer(token)) ~> routes ~> check(status shouldBe StatusCodes.NoContent)
+
+      store.revokedBefore(id).unsafeRunSync() shouldBe defined
+    }
+  }
+}


### PR DESCRIPTION
### Summary

Implements the two auth-hardening follow-ups from the post-#29 backlog as one focused pass: stateless JWTs can now be revoked before expiry, and the credential endpoints are throttled and lockout-protected. Both are backed by Redis with self-expiring keys, and both default to no-ops so nothing changes unless wired in.

### Token revocation (#44)

- Adds a `RevocationStore` (trait + in-memory + Redis + no-op): a per-account "revoked-before" cutoff, `SETEX`-stored under `auth:revoked-before:<id>` with TTL = token lifetime, so it self-prunes.
- `JwtAuthenticator` now reads the token's `iat` (via `JwtCirce.decode`) and rejects any token issued before the account's cutoff with `401 "Token has been revoked"`.
- New `POST /auth/logout` ("log out everywhere") and a successful `POST /auth/password` both advance the cutoff to now, so already-issued tokens stop being accepted.

### Rate limiting & lockout (#45)

- Adds an `AuthRateLimiter` (trait + in-memory + Redis + no-op) with two mechanisms: a per-IP fixed-window throttle and a per-account failed-login lockout, keyed under `auth-rl:*`.
- `/auth/register`, `/auth/token`, and `/auth/password` are throttled per client IP; repeated failed logins lock the account for a cool-off. Over-limit returns `429` with a `Retry-After` header.
- Client IP is taken from `X-Forwarded-For` (the real client behind Render's proxy), falling back to the peer address; `remote-address-attribute = on` enables the latter.
- Policy is configurable under `auth.rate-limit` (enable switch, window, per-IP limit, lockout threshold/window/duration).

### Refactor

- Extracts the shared `object JwtPlayerDirectives` into an injectable `class JwtAuthenticator`, threaded through all six route classes and constructed once in `GameServer`. Pure, behavior-preserving refactor (its own commit) that gives revocation a single enforcement seam.

### Configuration

- New `auth.rate-limit` stanza in `application.conf` (all env-overridable; `AUTH_RATE_LIMIT_ENABLED` master switch).
- `pekko.http.server.remote-address-attribute = on`.

### Testing

- Unit specs for the in-memory and Redis (Testcontainers) implementations of both stores, the config reader, and revocation enforcement in `JwtAuthenticator`.
- Route specs for throttle limits + `Retry-After`, per-IP independence, account lockout, logout end-to-end, and password-change revocation wiring.
- Full server suite green at 231 tests; formatting/scalafix clean.

Closes #44
Closes #45