### PR TITLE
Add per-turn timeouts for idle or disconnected players

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Although it runs as a single instance today, the system is **designed for horizo
 - 🔁 Post-game rooms — a finished match keeps its room alive for chat, and the host can start a same-roster rematch; idle/empty rooms are evicted automatically
 - 🎲 Multiple game types — Tic-Tac-Toe, Connect Four, Battleship, Pig, Mastermind, Liar's Dice, and Texas Hold 'Em
 - ✅ Server-side move validation (turn order and legality enforced by the game model)
+- ⏱️ Per-turn timeouts — an idle or disconnected player can't stall a match: when a seat's clock runs out the game applies a safe fallback (Texas Hold 'Em auto-checks or folds, Pig auto-holds) or forfeits the seat, so play always progresses. Opt-in per game type.
 - ⚡ Real-time state delivery to all participants over WebSockets
 - 🌫️ Per-viewer / fog-of-war state projection for hidden-information games and spectators
 - 💬 In-match chat with persisted backscroll history
@@ -124,6 +125,8 @@ Every setting has a working default for local development and can be overridden 
 | `CHAT_MAX_MESSAGES` | `100` | Per-match chat backscroll retained for `GET /chat` |
 | `ARGON2_MEMORY_KIB` / `ARGON2_ITERATIONS` / `ARGON2_PARALLELISM` | `19456` / `2` / `1` | Argon2id password-hashing cost (OWASP baseline) |
 | `AUTH_RATE_LIMIT_ENABLED` | `true` | Master switch for auth throttling/lockout; the window, per-IP limit, and lockout thresholds are further tunable under `auth.rate-limit` |
+
+Per-turn timeouts are configured under the `pekko-game-service.turn-timeouts` HOCON stanza rather than an environment variable: each key is a game type and its value a duration (e.g. `texasholdem = 60s`). A game type with no entry has no turn clock and waits indefinitely, so the feature is opt-in — the shipped default enables only Texas Hold 'Em.
 
 ### A two-minute walkthrough
 

--- a/game-service-actor/src/main/resources/reference.conf
+++ b/game-service-actor/src/main/resources/reference.conf
@@ -21,5 +21,19 @@ pekko-game-service {
   # fallback action (a safe auto-move or a forfeit). Each key is a game-type name as accepted by GameType.fromString
   # (e.g. "texasholdem"); its value is a HOCON duration. A game type with no entry here has no turn clock — the actor
   # never arms a timer for it and waits indefinitely, the original behavior — so the feature is opt-in per game.
-  turn-timeouts {}
+  turn-timeouts {
+    # Texas Hold 'Em auto-checks (if free) or auto-folds after this long, so one idle or disconnected seat cannot
+    # stall the table; persistent timeouts blind the player down until they bust naturally.
+    texasholdem = 60s
+
+    # Other game types have no turn clock by default (they wait indefinitely). Uncomment to enable; the fallback action
+    # is per game: Pig auto-holds (banks/passes the turn), while the others forfeit (handing two-player games to the
+    # opponent). Values are examples.
+    # tictactoe = 30s
+    # connectfour = 30s
+    # battleship = 30s
+    # pig = 60s
+    # mastermind = 120s
+    # liarsdice = 60s
+  }
 }

--- a/game-service-actor/src/main/resources/reference.conf
+++ b/game-service-actor/src/main/resources/reference.conf
@@ -16,4 +16,10 @@ pekko-game-service {
     # with no entry here uses sample-rate. Empty by default. Ignored when enabled = false.
     message-sample-rates {}
   }
+
+  # Per-turn clocks: how long a seated player may take before the shared TurnBasedGameActor applies that game's
+  # fallback action (a safe auto-move or a forfeit). Each key is a game-type name as accepted by GameType.fromString
+  # (e.g. "texasholdem"); its value is a HOCON duration. A game type with no entry here has no turn clock — the actor
+  # never arms a timer for it and waits indefinitely, the original behavior — so the feature is opt-in per game.
+  turn-timeouts {}
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/TurnBasedGameActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/TurnBasedGameActor.scala
@@ -1,9 +1,10 @@
 package com.andy327.actor.core
 
+import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag
 
 import io.circe.Encoder
-import org.apache.pekko.actor.typed.scaladsl.{ActorContext, Behaviors}
+import org.apache.pekko.actor.typed.scaladsl.{ActorContext, Behaviors, TimerScheduler}
 import org.apache.pekko.actor.typed.{ActorRef, Behavior, Terminated}
 
 import com.andy327.actor.events.{EventPublisher, GameEvent}
@@ -61,6 +62,33 @@ object TurnBasedGameActor {
     * state change while the game is active.
     */
   final case class SnapshotSaved(result: Either[Throwable, Unit]) extends Command[Nothing]
+
+  /** Fired by the per-turn timer when `playerId`'s clock expires. Keyed to the turn it was armed for: `forMoveCount` is
+    * the game's `moveCount` at arm time, so a timeout that arrives after the player already moved (and the game
+    * advanced) no longer matches the current turn and is ignored by the active behavior's handler. Internal — only the
+    * actor's own `TimerScheduler` sends it.
+    */
+  final case class TurnTimeout(playerId: PlayerId, forMoveCount: Int) extends Command[Nothing]
+
+  /** The fallback the shared actor applies when a player's turn clock expires. Supplied per game type via the
+    * `timeoutAction` seam: a game with a safe "no-op" move returns [[TimeoutAction.AutoMove]] (auto-played and recorded
+    * like a normal move), while a game with no pass returns [[TimeoutAction.Forfeit]] (routed through
+    * `Game.playerLeft`, handing two-player games to the opponent).
+    *
+    * @tparam M the game's move type; covariant so `Forfeit` fits any game's actor
+    */
+  sealed trait TimeoutAction[+M]
+  object TimeoutAction {
+
+    /** Auto-play `move` on behalf of the timed-out player (e.g. Pig auto-hold, Hold 'Em auto-check-or-fold). */
+    final case class AutoMove[M](move: M) extends TimeoutAction[M]
+
+    /** Forfeit the timed-out player via `Game.playerLeft`. */
+    case object Forfeit extends TimeoutAction[Nothing]
+  }
+
+  /** Timer key for the single per-turn clock; re-arming with this key replaces any prior turn's timer. */
+  private case object TurnTimerKey
 }
 
 /** The single [[GameActor]] implementation shared by every turn-based game.
@@ -97,6 +125,13 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
 
   type Command = TurnBasedGameActor.Command[M]
 
+  /** Per-game policy for an expired turn clock, given the current game: a safe auto-move or a forfeit. Defaults to
+    * `TimeoutAction.Forfeit`, which suits every game with no "pass"; games with a safe no-op (Pig, Texas Hold 'Em)
+    * override it. Only consulted when a turn clock is configured for this game type (see
+    * `pekko-game-service.turn-timeouts`).
+    */
+  protected def timeoutAction(game: G): TimeoutAction[M] = TimeoutAction.Forfeit
+
   override def subscribeCommand(playerRef: ActorRef[PlayerActor.Command], playerId: PlayerId): GameActor.GameCommand =
     Subscribe(playerRef, playerId)
 
@@ -125,6 +160,28 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
       case _                       => None
     }
 
+  /** The turn clock configured for this game type, read from the actor system's config so a test can inject a short
+    * (or absent) duration. `None` means no timer is ever armed — the original wait-forever behavior.
+    */
+  private def turnTimeoutFor(context: ActorContext[Command]): Option[FiniteDuration] =
+    TurnTimeoutConfig.fromConfig(context.system.settings.config).forGameType(gameType)
+
+  /** The platform id of the seat whose turn it is, resolved from the game's `currentPlayer` token. */
+  private def currentPlayerId(game: G): Option[PlayerId] =
+    game.players.find(pid => game.playerFor(pid).contains(game.currentPlayer))
+
+  /** Arm (or re-arm) the single per-turn timer for the current player, keyed to `moveCount` so a stale fire is
+    * ignored. A no-op when no clock is configured or the game is not in progress. Re-arming replaces any prior turn's
+    * timer, so each move restarts the clock for the next player.
+    */
+  private def armTurnTimer(timers: TimerScheduler[Command], game: G, timeout: Option[FiniteDuration]): Unit =
+    timeout.foreach { duration =>
+      if (game.gameStatus == InProgress)
+        currentPlayerId(game).foreach { pid =>
+          timers.startSingleTimer(TurnTimerKey, TurnTimeout(pid, game.moveCount), duration)
+        }
+    }
+
   /** Initializes a new game actor with an empty game. */
   override def create(
       matchId: MatchId,
@@ -137,7 +194,11 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
     val game = newGame(players)
     val behavior = Behaviors.setup[Command] { context =>
       context.log.info(s"[$matchId] starting new game")
-      active(game, matchId, roomId, persist, gameManager, Map.empty, publisher)
+      Behaviors.withTimers[Command] { timers =>
+        val timeout = turnTimeoutFor(context)
+        armTurnTimer(timers, game, timeout)
+        active(game, matchId, roomId, persist, gameManager, Map.empty, publisher, timers, timeout)
+      }
     }
     (game, behavior)
   }
@@ -162,7 +223,11 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
           game.gameStatus match {
             case InProgress =>
               context.log.info(s"[$matchId] restored in-progress game")
-              active(game, matchId, roomId, persist, gameManager, Map.empty, publisher)
+              Behaviors.withTimers[Command] { timers =>
+                val timeout = turnTimeoutFor(context)
+                armTurnTimer(timers, game, timeout)
+                active(game, matchId, roomId, persist, gameManager, Map.empty, publisher, timers, timeout)
+              }
             case Won(_) | Draw =>
               context.log.info(s"[$matchId] restored as already-completed game — notifying GameManager and stopping")
               gameManager ! GameManager.GameCompleted(matchId, roomId, GameLifecycleStatus.Completed)
@@ -203,7 +268,9 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
       subscribers: Map[ActorRef[PlayerActor.Command], PlayerId],
       publisher: EventPublisher,
       forfeit: Boolean,
-      replyTo: ActorRef[Either[GameError, GameState]]
+      replyTo: ActorRef[Either[GameError, GameState]],
+      timers: TimerScheduler[Command],
+      timeout: Option[FiniteDuration]
   )(appendMove: => Unit = ()): Behavior[Command] = {
     context.log.info(s"Match $matchId updated:\n$nextState")
 
@@ -252,10 +319,14 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
         // chat and the post-game state; re-key by playerId to match the GameCompleted/MatchEnded shape
         val subscribersByPlayer = subscribers.map { case (ref, pid) => pid -> ref }
         gameManager ! GameManager.GameCompleted(matchId, roomId, GameLifecycleStatus.Completed, subscribersByPlayer)
+        // the game is over: cancel any pending turn clock so it cannot fire during terminating
+        timers.cancel(TurnTimerKey)
         terminating(matchId)
 
       case InProgress =>
-        active(nextState, matchId, roomId, persist, gameManager, subscribers, publisher)
+        // the turn advanced (or a multi-seat fold-out kept the game going): restart the clock for the new player
+        armTurnTimer(timers, nextState, timeout)
+        active(nextState, matchId, roomId, persist, gameManager, subscribers, publisher, timers, timeout)
     }
   }
 
@@ -273,7 +344,9 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
       persist: ActorRef[PersistenceProtocol.Command],
       gameManager: ActorRef[GameManager.Command],
       subscribers: Map[ActorRef[PlayerActor.Command], PlayerId],
-      publisher: EventPublisher
+      publisher: EventPublisher,
+      timers: TimerScheduler[Command],
+      timeout: Option[FiniteDuration]
   ): Behavior[Command] = Behaviors.receive[Command] { (context, msg) =>
     msg match {
       case MakeMove(playerId, move, replyTo) =>
@@ -293,7 +366,9 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
                   subscribers,
                   publisher,
                   forfeit = false,
-                  replyTo
+                  replyTo,
+                  timers,
+                  timeout
                 ) {
                   // record the move in the append-only history log; seq is the pre-move count (0-based ordinal)
                   persist ! PersistenceProtocol.AppendMove(matchId, game.moveCount, playerId, moveEncoder(move))
@@ -328,7 +403,9 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
               subscribers,
               publisher,
               forfeit = true,
-              replyTo
+              replyTo,
+              timers,
+              timeout
             )()
 
           case Left(err) =>
@@ -336,6 +413,74 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
             replyTo ! Left(err)
             Behaviors.same
         }
+
+      case TurnTimeout(playerId, forMoveCount) =>
+        // stale-timer guard: only act if this fire still matches the current turn. A move already applied (advancing
+        // moveCount, and usually currentPlayer) makes an in-flight timeout from the prior turn a no-op.
+        val isCurrentTurn =
+          game.gameStatus == InProgress && game.moveCount == forMoveCount && currentPlayerId(game).contains(playerId)
+        if (!isCurrentTurn) {
+          context.log.debug(s"[$matchId] stale turn timeout for $playerId@$forMoveCount ignored")
+          Behaviors.same
+        } else
+          timeoutAction(game) match {
+            case TimeoutAction.Forfeit =>
+              context.log.info(s"[$matchId] turn timeout: $playerId forfeits")
+              game.playerLeft(playerId) match {
+                case Right(nextState) =>
+                  applyTransition(
+                    context,
+                    nextState,
+                    playerId,
+                    matchId,
+                    roomId,
+                    persist,
+                    gameManager,
+                    subscribers,
+                    publisher,
+                    forfeit = true,
+                    context.system.ignoreRef,
+                    timers,
+                    timeout
+                  )()
+
+                // unreachable: the isCurrentTurn guard already established InProgress and that playerId is the current
+                // participant, so a game's playerLeft cannot reject this forfeit
+                case Left(err) =>
+                  context.log.warn(s"[$matchId] timeout forfeit rejected: $err")
+                  Behaviors.same
+              }
+
+            case TimeoutAction.AutoMove(move) =>
+              // isCurrentTurn guarantees currentPlayer is playerId's seat, so play on that token
+              game.play(game.currentPlayer, move) match {
+                case Right(nextState) =>
+                  context.log.info(s"[$matchId] turn timeout: auto-move for $playerId")
+                  applyTransition(
+                    context,
+                    nextState,
+                    playerId,
+                    matchId,
+                    roomId,
+                    persist,
+                    gameManager,
+                    subscribers,
+                    publisher,
+                    forfeit = false,
+                    context.system.ignoreRef,
+                    timers,
+                    timeout
+                  ) {
+                    // an auto-move is a real move: record it in the history log and emit the analytics event
+                    persist ! PersistenceProtocol.AppendMove(matchId, game.moveCount, playerId, moveEncoder(move))
+                    publisher.publish(GameEvent.MoveMade(matchId, gameType, playerId, game.moveCount))
+                  }
+
+                case Left(err) =>
+                  context.log.warn(s"[$matchId] timeout auto-move rejected: $err")
+                  Behaviors.same
+              }
+          }
 
       case GetState(replyTo) =>
         replyTo ! Right(view.fromGame(game, None))
@@ -350,12 +495,13 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
         val viewState = view.fromGame(game, Some(playerId))
         val event = PlayerEvent.GameStateUpdated(roomId, viewState, spectatorCount(updatedSubscribers, game))
         playerRef ! PlayerActor.SendEvent(event)
-        active(game, matchId, roomId, persist, gameManager, updatedSubscribers, publisher)
+        // a spectator (un)subscribing does not change whose turn it is, so the running turn clock is left untouched
+        active(game, matchId, roomId, persist, gameManager, updatedSubscribers, publisher, timers, timeout)
 
       case Unsubscribe(playerRef) =>
         context.unwatch(playerRef)
         val updatedSubscribers = subscribers - playerRef
-        active(game, matchId, roomId, persist, gameManager, updatedSubscribers, publisher)
+        active(game, matchId, roomId, persist, gameManager, updatedSubscribers, publisher, timers, timeout)
 
       case Broadcast(event) =>
         // chat and other broadcasts carry no hidden state, so every viewer gets the same event
@@ -372,6 +518,7 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
   }.receiveSignal { case (context, Terminated(ref)) =>
     // a subscribed PlayerActor stopped; drop its (now-dead) ref so we stop fanning events to it
     context.log.debug(s"[$matchId] subscriber $ref terminated; removing from subscribers")
-    active(game, matchId, roomId, persist, gameManager, subscribers.filterNot { case (r, _) => r == ref }, publisher)
+    val remaining = subscribers.filterNot { case (r, _) => r == ref }
+    active(game, matchId, roomId, persist, gameManager, remaining, publisher, timers, timeout)
   }
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/TurnTimeoutConfig.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/TurnTimeoutConfig.scala
@@ -1,0 +1,49 @@
+package com.andy327.actor.core
+
+import scala.concurrent.duration.FiniteDuration
+import scala.jdk.CollectionConverters._
+import scala.jdk.DurationConverters._
+
+import com.typesafe.config.{Config, ConfigFactory}
+
+import com.andy327.model.core.GameType
+
+/** Per-game-type turn clock: how long a seated player may take before the shared [[TurnBasedGameActor]] applies that
+  * game's fallback action (a safe auto-move or a forfeit).
+  *
+  * Loaded from the `pekko-game-service.turn-timeouts` stanza in `application.conf` (or the reference defaults). Each
+  * key is a game-type name as accepted by `GameType.fromString` (e.g. `texasholdem`), and its value is a HOCON duration
+  * (e.g. `45s`). A game type with no entry has no turn clock — the actor never arms a timer for it, preserving the
+  * original wait-forever behavior — so the feature is opt-in per game.
+  *
+  * @param perGameType configured turn clock for each game type that has one; absent types map to no timeout
+  */
+final case class TurnTimeoutConfig(perGameType: Map[GameType, FiniteDuration]) {
+
+  /** The turn clock configured for `gameType`, or `None` if it has no timeout (the actor arms no timer). */
+  def forGameType(gameType: GameType): Option[FiniteDuration] = perGameType.get(gameType)
+}
+
+object TurnTimeoutConfig {
+  private val Namespace = "pekko-game-service.turn-timeouts"
+
+  /** Parse the `turn-timeouts` stanza. Keys are resolved back to a `GameType` via `GameType.fromString`; an
+    * unrecognized key (e.g. a typo) is ignored rather than failing, which means it simply has no effect. An absent
+    * stanza yields an empty config (no timeouts anywhere).
+    */
+  def fromConfig(config: Config): TurnTimeoutConfig =
+    if (!config.hasPath(Namespace)) TurnTimeoutConfig(Map.empty)
+    else {
+      val stanza = config.getConfig(Namespace)
+      val perGameType = stanza
+        .root()
+        .keySet()
+        .asScala
+        .flatMap(key => GameType.fromString(key).map(_ -> stanza.getDuration(key).toScala))
+        .toMap
+      TurnTimeoutConfig(perGameType)
+    }
+
+  /** Loads from the standard `ConfigFactory.load()` resolution chain (application.conf → reference.conf). */
+  lazy val default: TurnTimeoutConfig = fromConfig(ConfigFactory.load())
+}

--- a/game-service-actor/src/main/scala/com/andy327/actor/pig/PigActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/pig/PigActor.scala
@@ -4,6 +4,7 @@ import io.circe.Encoder
 import io.circe.syntax._
 
 import com.andy327.actor.core.TurnBasedGameActor
+import com.andy327.actor.core.TurnBasedGameActor.TimeoutAction
 import com.andy327.actor.game.PigState
 import com.andy327.model.pig.{Hold, Pig, PigMove, Roll}
 
@@ -11,6 +12,9 @@ import com.andy327.model.pig.{Hold, Pig, PigMove, Roll}
   *
   * All behavior lives in [[core.TurnBasedGameActor]]. The die is rolled by [[game.modules.PigModule]] before the move
   * reaches the model, so `Pig.play` remains a pure function.
+  *
+  * On a turn timeout Pig auto-holds — banking the current turn's accumulated points rather than forfeiting — so an
+  * idle seat simply passes its turn and the game keeps moving.
   */
 object PigActor
     extends TurnBasedGameActor[Pig, PigMove, Int, PigState](
@@ -19,4 +23,7 @@ object PigActor
         case Roll(result) => Map("action" -> "roll", "result" -> result.toString).asJson
         case Hold         => Map("action" -> "hold").asJson
       }
-    )
+    ) {
+
+  override protected def timeoutAction(game: Pig): TimeoutAction[PigMove] = TimeoutAction.AutoMove(Hold)
+}

--- a/game-service-actor/src/main/scala/com/andy327/actor/texasholdem/TexasHoldEmActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/texasholdem/TexasHoldEmActor.scala
@@ -4,6 +4,7 @@ import io.circe.syntax._
 import io.circe.{Encoder, Json}
 
 import com.andy327.actor.core.TurnBasedGameActor
+import com.andy327.actor.core.TurnBasedGameActor.TimeoutAction
 import com.andy327.actor.game.HoldEmState
 import com.andy327.actor.game.modules.TexasHoldEmModule
 import com.andy327.model.holdem.Action.{Bet, Call, Check, Fold, Raise}
@@ -18,6 +19,11 @@ import com.andy327.model.holdem.{HoldEmMove, TexasHoldEm}
   *
   * The move-log encoder records a bet's or raise's amount but omits the deck each move carries: that deck is internal
   * server randomness for the next hand, not meaningful public history.
+  *
+  * On a turn timeout Hold 'Em plays the soft, never-forfeiting safe action: auto-check when checking is free
+  * (`toCall == 0`), otherwise auto-fold. The player only loses the current hand and stays in the sit-and-go; repeated
+  * timeouts blind them down until they bust naturally. The auto-fold carries a fresh deck like any other action, since
+  * folding can end the hand and deal the next.
   */
 object TexasHoldEmActor
     extends TurnBasedGameActor[TexasHoldEm, HoldEmMove, Int, HoldEmState](
@@ -31,4 +37,10 @@ object TexasHoldEmActor
           case Raise(a) => Json.obj("action" -> "raise".asJson, "amount" -> a.asJson)
         }
       }
-    )
+    ) {
+
+  override protected def timeoutAction(game: TexasHoldEm): TimeoutAction[HoldEmMove] = {
+    val action = if (game.toCall(game.currentPlayer) == 0) Check else Fold
+    TimeoutAction.AutoMove(HoldEmMove(action, TexasHoldEmModule.shuffledDeck()))
+  }
+}

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/TurnBasedGameActorTimeoutSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/TurnBasedGameActorTimeoutSpec.scala
@@ -1,0 +1,206 @@
+package com.andy327.actor.core
+
+import java.util.UUID
+
+import com.typesafe.config.ConfigFactory
+
+import io.circe.generic.semiauto.deriveEncoder
+import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
+import org.apache.pekko.actor.typed.ActorRef
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import com.andy327.actor.core.TurnBasedGameActor.TimeoutAction
+import com.andy327.actor.events.NoOpEventPublisher
+import com.andy327.actor.game.{GameState, GridGameState}
+import com.andy327.actor.lobby.GameLifecycleStatus
+import com.andy327.actor.persistence.PersistenceProtocol
+import com.andy327.actor.tictactoe.TicTacToeActor
+import com.andy327.model.core.{GameError, GameType, MatchId, PlayerId}
+import com.andy327.model.tictactoe.{Location, Mark, TicTacToe}
+import com.andy327.persistence.db.PlayerHistoryRepository.GameResult
+
+/** Shared per-turn timeout behavior of [[TurnBasedGameActor]], exercised through Tic-Tac-Toe (whose default policy is
+  * to forfeit). Tic-Tac-Toe has no turn clock in the shipped config, so on the default test kit no real timer is armed
+  * and a `TurnTimeout` can be injected directly for deterministic, timing-free assertions. A separate kit configured
+  * with a short clock covers the real arm-and-fire path.
+  */
+class TurnBasedGameActorTimeoutSpec extends AnyWordSpecLike with Matchers {
+  private val testKit = ActorTestKit()
+
+  /** A kit whose config gives Tic-Tac-Toe a short turn clock, so a real armed timer fires quickly. */
+  private val timedTestKit = ActorTestKit(
+    ConfigFactory
+      .parseString("pekko-game-service.turn-timeouts.tictactoe = 200ms")
+      .withFallback(ConfigFactory.load())
+  )
+
+  private val alice: PlayerId = UUID.randomUUID() // seat X, moves first
+  private val bob: PlayerId = UUID.randomUUID() // seat O
+
+  /** Spawn a fresh Tic-Tac-Toe actor on `kit` with its own persist probe. */
+  private def newActor(
+      kit: ActorTestKit,
+      gmRef: ActorRef[GameManager.Command],
+      matchId: MatchId = UUID.randomUUID()
+  ): (ActorRef[TicTacToeActor.Command], TestProbe[PersistenceProtocol.Command]) = {
+    val persistProbe = kit.createTestProbe[PersistenceProtocol.Command]()
+    val (_, behavior) =
+      TicTacToeActor.create(matchId, matchId, Seq(alice, bob), persistProbe.ref, gmRef, NoOpEventPublisher)
+    (kit.spawn(behavior), persistProbe)
+  }
+
+  /** A Tic-Tac-Toe actor whose turn-timeout policy auto-plays `move` instead of forfeiting. No shipped game returns
+    * `AutoMove` until the per-game policies land, so this test-only binding exercises the shared auto-move path (both
+    * its success and its move-rejected guard) independently of any real game's rules.
+    */
+  private class AutoMovePolicyActor(move: Location)
+      extends TurnBasedGameActor[TicTacToe, Location, Mark, GridGameState](
+        players => TicTacToe.empty(players(0), players(1)),
+        deriveEncoder[Location]
+      ) {
+    override protected def timeoutAction(game: TicTacToe): TimeoutAction[Location] = TimeoutAction.AutoMove(move)
+  }
+
+  /** Spawn an [[AutoMovePolicyActor]] with policy move `move`, on the default kit, with its own persist probe. */
+  private def newAutoMoveActor(
+      move: Location
+  ): (ActorRef[TurnBasedGameActor.Command[Location]], TestProbe[PersistenceProtocol.Command]) = {
+    val persistProbe = testKit.createTestProbe[PersistenceProtocol.Command]()
+    val gmRef = testKit.createTestProbe[GameManager.Command]().ref
+    val matchId = UUID.randomUUID()
+    val (_, behavior) =
+      new AutoMovePolicyActor(move).create(
+        matchId,
+        matchId,
+        Seq(alice, bob),
+        persistProbe.ref,
+        gmRef,
+        NoOpEventPublisher
+      )
+    (testKit.spawn(behavior), persistProbe)
+  }
+
+  "TurnBasedGameActor turn timeout" should {
+    "forfeit the current player when a matching turn timeout fires" in {
+      val gameManagerProbe = testKit.createTestProbe[GameManager.Command]()
+      val matchId: MatchId = UUID.randomUUID()
+      val (actor, persistProbe) = newActor(testKit, gameManagerProbe.ref, matchId)
+      val subscriberProbe = testKit.createTestProbe[PlayerActor.Command]()
+
+      actor ! TurnBasedGameActor.Subscribe(subscriberProbe.ref, alice)
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial state push on subscribe
+
+      // it is Alice's turn (X, moveCount 0); her clock expires → default policy forfeits her, so Bob (O) wins
+      actor ! TurnBasedGameActor.TurnTimeout(alice, 0)
+
+      // a timeout forfeit behaves exactly like a PlayerLeft: final snapshot, per-player results in seat order, no
+      // history append
+      persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+      persistProbe.expectMessage(
+        PersistenceProtocol.RecordGameResult(alice, matchId, GameType.TicTacToe, GameResult.Loss, forfeit = true)
+      )
+      persistProbe.expectMessage(
+        PersistenceProtocol.RecordGameResult(bob, matchId, GameType.TicTacToe, GameResult.Win, forfeit = true)
+      )
+      persistProbe.expectNoMessage()
+
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe a[PlayerEvent.GameStateUpdated]
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe
+        PlayerEvent.GameEnded(GameLifecycleStatus.Completed)
+      gameManagerProbe.receiveMessage() shouldBe a[GameManager.GameCompleted]
+    }
+
+    "ignore a turn timeout from a turn that has already advanced (stale-timer race)" in {
+      val gameManagerProbe = testKit.createTestProbe[GameManager.Command]()
+      val (actor, persistProbe) = newActor(testKit, gameManagerProbe.ref)
+      val subscriberProbe = testKit.createTestProbe[PlayerActor.Command]()
+      val replyProbe = testKit.createTestProbe[Either[GameError, GameState]]()
+
+      actor ! TurnBasedGameActor.Subscribe(subscriberProbe.ref, alice)
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial state push on subscribe
+
+      // Alice actually moves before her clock would fire: moveCount advances 0 → 1 and it becomes Bob's turn
+      actor ! TurnBasedGameActor.MakeMove(alice, Location(0, 0), replyProbe.ref)
+      replyProbe.expectMessageType[Right[GameError, GameState]]
+      persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+      persistProbe.expectMessageType[PersistenceProtocol.AppendMove]
+      subscriberProbe.expectMessageType[PlayerActor.SendEvent] // GameStateUpdated for the move
+
+      // the stale timer for Alice's turn 0 now fires late — it must be ignored, not forfeit Alice or anyone
+      actor ! TurnBasedGameActor.TurnTimeout(alice, 0)
+
+      persistProbe.expectNoMessage() // no snapshot, no results — nothing happened
+      subscriberProbe.expectNoMessage() // no state update, no GameEnded
+      gameManagerProbe.expectNoMessage()
+
+      // the game is still in progress with Bob to move
+      actor ! TurnBasedGameActor.GetState(replyProbe.ref)
+      val Right(GridGameState(_, current, winner, _)) = replyProbe.receiveMessage()
+      current shouldBe "O"
+      winner shouldBe None
+    }
+
+    "ignore a turn timeout naming a player who is not the current player" in {
+      val gameManagerProbe = testKit.createTestProbe[GameManager.Command]()
+      val (actor, persistProbe) = newActor(testKit, gameManagerProbe.ref)
+
+      // moveCount 0 matches, but it is Alice's turn, not Bob's — the guard rejects the mismatched player
+      actor ! TurnBasedGameActor.TurnTimeout(bob, 0)
+
+      persistProbe.expectNoMessage()
+      gameManagerProbe.expectNoMessage()
+    }
+
+    "apply the auto-move and record it when the policy returns AutoMove" in {
+      // policy auto-plays the empty top-left cell; Alice (X) is to move at turn 0
+      val (actor, persistProbe) = newAutoMoveActor(Location(0, 0))
+      val replyProbe = testKit.createTestProbe[Either[GameError, GameState]]()
+
+      actor ! TurnBasedGameActor.TurnTimeout(alice, 0)
+
+      // an auto-move is a real move: it saves a snapshot and appends to the history log (unlike a forfeit)
+      persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+      persistProbe.expectMessageType[PersistenceProtocol.AppendMove]
+
+      // the board advanced: X is placed and it is now O's turn
+      actor ! TurnBasedGameActor.GetState(replyProbe.ref)
+      val Right(GridGameState(board, current, winner, _)) = replyProbe.receiveMessage()
+      board(0)(0) shouldBe "X"
+      current shouldBe "O"
+      winner shouldBe None
+    }
+
+    "leave the game untouched when the policy's AutoMove is rejected by the model" in {
+      // policy auto-plays an out-of-bounds cell, which TicTacToe.play rejects → the guard logs and no-ops
+      val (actor, persistProbe) = newAutoMoveActor(Location(9, 9))
+      val replyProbe = testKit.createTestProbe[Either[GameError, GameState]]()
+
+      actor ! TurnBasedGameActor.TurnTimeout(alice, 0)
+
+      persistProbe.expectNoMessage() // no snapshot, no append — the rejected move changed nothing
+
+      // still a fresh game with Alice (X) to move
+      actor ! TurnBasedGameActor.GetState(replyProbe.ref)
+      val Right(GridGameState(board, current, winner, _)) = replyProbe.receiveMessage()
+      board.flatten should contain only ""
+      current shouldBe "X"
+      winner shouldBe None
+    }
+
+    "arm a turn clock and forfeit the idle current player once it expires" in {
+      val gameManagerProbe = timedTestKit.createTestProbe[GameManager.Command]()
+      val matchId: MatchId = UUID.randomUUID()
+      val (_, persistProbe) = newActor(timedTestKit, gameManagerProbe.ref, matchId)
+
+      // no one moves; the armed 200ms clock fires on its own and forfeits the idle current player (Alice), so Bob wins
+      persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+      persistProbe.expectMessage(
+        PersistenceProtocol.RecordGameResult(alice, matchId, GameType.TicTacToe, GameResult.Loss, forfeit = true)
+      )
+      persistProbe.expectMessage(
+        PersistenceProtocol.RecordGameResult(bob, matchId, GameType.TicTacToe, GameResult.Win, forfeit = true)
+      )
+    }
+  }
+}

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/TurnTimeoutConfigSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/TurnTimeoutConfigSpec.scala
@@ -58,8 +58,12 @@ class TurnTimeoutConfigSpec extends AnyWordSpecLike with Matchers {
   }
 
   "TurnTimeoutConfig.default" should {
-    "ship no turn clocks by default, so every game keeps the original wait-forever behavior until opted in" in {
-      TurnTimeoutConfig.default.perGameType shouldBe empty
+    "opt Texas Hold 'Em into a turn clock from the shipped reference.conf" in {
+      TurnTimeoutConfig.default.forGameType(GameType.TexasHoldEm) shouldBe defined
+    }
+
+    "leave the casual two-player games without a turn clock" in {
+      TurnTimeoutConfig.default.forGameType(GameType.TicTacToe) shouldBe None
     }
   }
 }

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/TurnTimeoutConfigSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/TurnTimeoutConfigSpec.scala
@@ -1,0 +1,65 @@
+package com.andy327.actor.core
+
+import scala.concurrent.duration._
+
+import com.typesafe.config.ConfigFactory
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import com.andy327.model.core.GameType
+
+class TurnTimeoutConfigSpec extends AnyWordSpecLike with Matchers {
+
+  "TurnTimeoutConfig.fromConfig" should {
+    "parse per-game-type durations keyed by GameType.fromString names" in {
+      val config = ConfigFactory.parseString("""
+        pekko-game-service.turn-timeouts {
+          texasholdem = 45s
+          pig = 2m
+        }
+      """)
+
+      val timeouts = TurnTimeoutConfig.fromConfig(config)
+
+      timeouts.forGameType(GameType.TexasHoldEm) shouldBe Some(45.seconds)
+      timeouts.forGameType(GameType.Pig) shouldBe Some(2.minutes)
+    }
+
+    "leave a game type with no entry without a timeout" in {
+      val config = ConfigFactory.parseString("""
+        pekko-game-service.turn-timeouts {
+          texasholdem = 30s
+        }
+      """)
+
+      TurnTimeoutConfig.fromConfig(config).forGameType(GameType.TicTacToe) shouldBe None
+    }
+
+    "yield an empty config when the stanza is absent" in {
+      val timeouts = TurnTimeoutConfig.fromConfig(ConfigFactory.parseString("pekko-game-service {}"))
+
+      timeouts.perGameType shouldBe empty
+      timeouts.forGameType(GameType.TexasHoldEm) shouldBe None
+    }
+
+    "ignore an unrecognized game-type key rather than failing" in {
+      val config = ConfigFactory.parseString("""
+        pekko-game-service.turn-timeouts {
+          not-a-game = 10s
+          texasholdem = 45s
+        }
+      """)
+
+      val timeouts = TurnTimeoutConfig.fromConfig(config)
+
+      timeouts.perGameType.keySet shouldBe Set(GameType.TexasHoldEm)
+    }
+  }
+
+  "TurnTimeoutConfig.default" should {
+    "ship no turn clocks by default, so every game keeps the original wait-forever behavior until opted in" in {
+      TurnTimeoutConfig.default.perGameType shouldBe empty
+    }
+  }
+}

--- a/game-service-actor/src/test/scala/com/andy327/actor/pig/PigActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/pig/PigActorSpec.scala
@@ -1,0 +1,93 @@
+package com.andy327.actor.pig
+
+import java.util.UUID
+
+import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
+import org.apache.pekko.actor.typed.ActorRef
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import com.andy327.actor.core.{GameManager, TurnBasedGameActor}
+import com.andy327.actor.events.NoOpEventPublisher
+import com.andy327.actor.game.{GameState, PigState}
+import com.andy327.actor.persistence.PersistenceProtocol
+import com.andy327.model.core.{GameError, PlayerId}
+import com.andy327.model.pig.Roll
+
+/** Pig-specific turn-timeout policy: on an expired clock Pig auto-holds rather than forfeits, so an idle seat just
+  * passes its turn and the (up to eight player) game keeps going. The shared timer mechanism is covered by
+  * `TurnBasedGameActorTimeoutSpec`; here Pig has no clock in the shipped config, so a `TurnTimeout` is sent directly to
+  * exercise the policy deterministically.
+  */
+class PigActorSpec extends AnyWordSpecLike with Matchers {
+  private val testKit = ActorTestKit()
+  import testKit._
+
+  private val alice: PlayerId = UUID.randomUUID() // seat 0 (P1), moves first
+  private val bob: PlayerId = UUID.randomUUID() // seat 1 (P2)
+
+  private val dummyGameManager: ActorRef[GameManager.Command] = createTestProbe[GameManager.Command]().ref
+
+  private def newActor(): (ActorRef[PigActor.Command], TestProbe[PersistenceProtocol.Command]) = {
+    val persistProbe = createTestProbe[PersistenceProtocol.Command]()
+    val (_, behavior) =
+      PigActor.create(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        Seq(alice, bob),
+        persistProbe.ref,
+        dummyGameManager,
+        NoOpEventPublisher
+      )
+    (spawn(behavior), persistProbe)
+  }
+
+  private def state(
+      actor: ActorRef[PigActor.Command],
+      replyProbe: TestProbe[Either[GameError, GameState]]
+  ): PigState = {
+    actor ! TurnBasedGameActor.GetState(replyProbe.ref)
+    replyProbe.receiveMessage().toOption.get.asInstanceOf[PigState]
+  }
+
+  "PigActor's turn-timeout policy" should {
+    "auto-hold and pass the turn when the clock fires at the start of a turn" in {
+      val (actor, persistProbe) = newActor()
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+
+      // Alice is idle from the very start of her turn (turnScore 0); the auto-hold is a no-score pass to Bob
+      actor ! TurnBasedGameActor.TurnTimeout(alice, 0)
+      persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+      persistProbe.expectMessageType[PersistenceProtocol.AppendMove].move.hcursor.get[String]("action") shouldBe
+        Right("hold")
+
+      val after = state(actor, replyProbe)
+      after.currentPlayer shouldBe "P2"
+      after.scores("P1") shouldBe 0
+      after.turnScore shouldBe 0
+      after.winner shouldBe None
+    }
+
+    "auto-hold and bank the accumulated points when the clock fires mid-turn" in {
+      val (actor, persistProbe) = newActor()
+      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+
+      // Alice rolls a 4 (turnScore 4, moveCount 0 → 1), then goes idle
+      actor ! TurnBasedGameActor.MakeMove(alice, Roll(4), replyProbe.ref)
+      replyProbe.receiveMessage()
+      persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+      persistProbe.expectMessageType[PersistenceProtocol.AppendMove]
+
+      // the clock for her turn 1 fires: auto-hold banks the 4 and passes to Bob
+      actor ! TurnBasedGameActor.TurnTimeout(alice, 1)
+      persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+      persistProbe.expectMessageType[PersistenceProtocol.AppendMove].move.hcursor.get[String]("action") shouldBe
+        Right("hold")
+
+      val after = state(actor, replyProbe)
+      after.currentPlayer shouldBe "P2"
+      after.scores("P1") shouldBe 4
+      after.turnScore shouldBe 0
+    }
+  }
+}

--- a/game-service-actor/src/test/scala/com/andy327/actor/texasholdem/TexasHoldEmActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/texasholdem/TexasHoldEmActorSpec.scala
@@ -58,6 +58,18 @@ class TexasHoldEmActorSpec extends AnyWordSpecLike with Matchers {
     persistProbe.expectMessageType[PersistenceProtocol.AppendMove].move
   }
 
+  /** Fires the turn clock for `player`'s turn `forMoveCount` and returns the JSON logged for the auto-move. */
+  private def timedOutMove(
+      actor: ActorRef[TexasHoldEmActor.Command],
+      persistProbe: TestProbe[PersistenceProtocol.Command],
+      player: PlayerId,
+      forMoveCount: Int
+  ): io.circe.Json = {
+    actor ! TurnBasedGameActor.TurnTimeout(player, forMoveCount)
+    persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+    persistProbe.expectMessageType[PersistenceProtocol.AppendMove].move
+  }
+
   "TexasHoldEmActor's move-log encoder" should {
     "record a raise's amount but never the deck it carries" in {
       val (actor, persistProbe) = newActor()
@@ -73,6 +85,23 @@ class TexasHoldEmActorSpec extends AnyWordSpecLike with Matchers {
       val json = loggedMove(actor, persistProbe, alice, HoldEmMove(Call, deck))
       json.hcursor.get[String]("action") shouldBe Right("call")
       json.asObject.map(_.keys.toList) shouldBe Some(List("action"))
+    }
+  }
+
+  "TexasHoldEmActor's turn-timeout policy" should {
+    "auto-fold the current player when they face a bet" in {
+      val (actor, persistProbe) = newActor()
+      // heads-up pre-flop, seat 0 (SB) is first to act and still owes the big blind (toCall > 0), so it folds
+      val json = timedOutMove(actor, persistProbe, alice, 0)
+      json.hcursor.get[String]("action") shouldBe Right("fold")
+    }
+
+    "auto-check the current player when checking is free" in {
+      val (actor, persistProbe) = newActor()
+      // seat 0 (SB) completes the blind; now seat 1 (BB) has the option with nothing to call (toCall == 0)
+      loggedMove(actor, persistProbe, alice, HoldEmMove(Call, deck))
+      val json = timedOutMove(actor, persistProbe, bob, 1)
+      json.hcursor.get[String]("action") shouldBe Right("check")
     }
   }
 }

--- a/game-service-model/src/main/scala/com/andy327/model/pig/GameError.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/pig/GameError.scala
@@ -1,8 +1,0 @@
-package com.andy327.model.pig
-
-import com.andy327.model.core.GameError
-
-/** The player attempted to Hold without having rolled at all this turn. */
-case object NothingToHold extends GameError {
-  val message = "You must roll at least once before holding."
-}

--- a/game-service-model/src/main/scala/com/andy327/model/pig/Pig.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/pig/Pig.scala
@@ -70,7 +70,8 @@ final case class Pig(
     *   - result 2–6: added to `turnScore`; the turn continues (a win can only be triggered by Hold, not Roll)
     *
     * On `Hold`: banks `turnScore` into `scores`; if that reaches [[Pig.WinScore]] the current player wins, otherwise
-    * the turn passes. Holding with zero turn score (no roll yet this turn) is rejected.
+    * the turn passes. Holding with zero turn score banks nothing and simply passes the turn — a legal no-score pass
+    * that lets an idle player's turn clock advance the game rather than stall it.
     */
   def play(player: Int, move: PigMove): Either[GameError, Pig] =
     if (gameStatus != InProgress)
@@ -89,21 +90,19 @@ final case class Pig(
           }
 
         case Hold =>
-          if (turnScore == 0)
-            Left(NothingToHold)
-          else {
-            val banked = scores(currentSeat) + turnScore
-            val base = copy(
-              scores = scores.updated(currentSeat, banked),
-              turnScore = 0,
-              lastRoll = None,
-              moveCount = moveCount + 1
-            )
-            if (banked >= WinScore)
-              Right(base.copy(winner = Some(currentSeat)))
-            else
-              Right(base.copy(currentSeat = nextSeat))
-          }
+          // holding with no accumulated points (turnScore 0) is a legal no-score pass: it banks nothing and advances
+          // to the next player. this lets the shared per-turn timeout auto-hold an idle player who has not yet rolled.
+          val banked = scores(currentSeat) + turnScore
+          val base = copy(
+            scores = scores.updated(currentSeat, banked),
+            turnScore = 0,
+            lastRoll = None,
+            moveCount = moveCount + 1
+          )
+          if (banked >= WinScore)
+            Right(base.copy(winner = Some(currentSeat)))
+          else
+            Right(base.copy(currentSeat = nextSeat))
       }
 
   /** The leaver forfeits; the non-leaver with the highest banked score wins (lowest seat index breaks a tie).

--- a/game-service-model/src/test/scala/com/andy327/model/pig/PigSpec.scala
+++ b/game-service-model/src/test/scala/com/andy327/model/pig/PigSpec.scala
@@ -108,9 +108,12 @@ class PigSpec extends AnyWordSpec with Matchers {
       held.scores(0) shouldBe 101
     }
 
-    "reject Hold when no roll has been made this turn" in {
+    "pass the turn on Hold with no roll this turn, banking nothing" in {
       val game = Pig.newGame(Seq(alice, bob))
-      game.play(0, Hold) shouldBe Left(NothingToHold)
+      val Right(passed) = game.play(0, Hold)
+      passed.scores(0) shouldBe 0
+      passed.currentSeat shouldBe 1
+      passed.gameStatus shouldBe InProgress
     }
 
     "wrap the turn back to the first seat after the last" in {


### PR DESCRIPTION
### Summary

Adds a generic per-turn clock to the shared turn-based game actor so an idle or disconnected player can no longer stall a match indefinitely. When a seat's clock expires the game applies a per-game fallback — a safe auto-move or a forfeit — so play always progresses. The feature is opt-in per game type via config; only Texas Hold 'Em ships with a clock enabled, so every other game's behavior is unchanged by default.

### How it works

- A single per-turn timer lives in `TurnBasedGameActor` (`Behaviors.withTimers`), armed only at turn-change points (`create`, snapshot restore, and each applied transition) so a spectator subscribing/unsubscribing never resets a player's clock.
- The fallback is supplied per game through a new `timeoutAction` seam (`protected def` on the actor binding), returning either `AutoMove(move)` or `Forfeit`. It defaults to `Forfeit`, so games with no "pass" need no changes.
- **Stale-timer correctness:** the fired message is keyed to `(currentPlayer, moveCount)` and is applied only if it still matches the current turn — a timeout armed for a turn the player already completed is ignored. This is covered by a dedicated race test.
- The clock duration is read from the actor system config; a game type with no entry arms no timer (the original wait-forever behavior).

### Per-game policies

| Game | On turn timeout |
|------|-----------------|
| Texas Hold 'Em | auto-check if free, else auto-fold (soft — loses only the hand, blinds down to a natural bust) |
| Pig | auto-hold (banks the turn and passes; a zero-score hold is now a legal no-score pass) |
| Tic-Tac-Toe, Connect Four, Battleship, Mastermind, Liar's Dice | forfeit via `Game.playerLeft` |

### Configuration

Configured under the `pekko-game-service.turn-timeouts` HOCON stanza, keyed by game type; absent = no clock (opt-in):

```hocon
pekko-game-service.turn-timeouts {
  texasholdem = 60s
}
```

### Commits

- `add per-turn timeout config plumbing`
- `add shared per-turn timer with forfeit-by-default policy`
- `relax Pig Hold at zero turn score to pass the turn`
- `wire per-game turn-timeout policies and enable Texas Hold 'Em clock`
- `document per-turn timeouts in README`

### Testing

- Full suite green (model, persistence, server, actor); `scalafmt`, `scalafix`, and scaladoc-link checks clean.
- New coverage: the shared timeout spec (forfeit, arm-and-fire, stale-timer race, and both auto-move branches via a test-only policy), plus per-game policy specs for Pig (auto-hold) and Texas Hold 'Em (auto-check/fold). One unreachable defensive guard is marked `$COVERAGE-OFF$`.

### Notes / follow-ups

- The Pig model now treats `Hold` at zero turn score as a legal no-score pass (the previously-rejected `NothingToHold` case is removed), which is what lets an idle Pig seat be advanced rather than stalled.
- Every other game is one config line from having a clock; enabling the multi-seat games (Pig, Liar's Dice), where one idle seat blocks several players, is a natural config-only follow-up.

Closes #58