### PR TITLE
Add optional host-chosen lobby names

### DIFF
--- a/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
@@ -46,8 +46,9 @@ object GameManager {
 
   // --- Lobby commands (forwarded verbatim to LobbyManager) ---
 
-  /** Create a new lobby; replies with [[LobbyCreated]]. */
-  final case class CreateLobby(gameType: GameType, host: Player, replyTo: ActorRef[GameResponse]) extends Command
+  /** Create a new lobby, optionally named `name`; replies with [[LobbyCreated]]. */
+  final case class CreateLobby(gameType: GameType, host: Player, name: Option[String], replyTo: ActorRef[GameResponse])
+      extends Command
 
   /** Join an existing lobby; replies with [[LobbyJoined]] or a [[LobbyErrorResponse]]. */
   final case class JoinLobby(roomId: RoomId, player: Player, replyTo: ActorRef[GameResponse]) extends Command
@@ -564,9 +565,9 @@ object GameManager {
   )(implicit runtime: IORuntime): Behavior[Command] =
     Behaviors.receive { (context, message) =>
       message match {
-        case CreateLobby(gameType, host, replyTo) =>
+        case CreateLobby(gameType, host, name, replyTo) =>
           val adapter = context.messageAdapter[GameResponse](LobbyResponseIntercepted(_, host.id, replyTo))
-          lobbyManager ! LobbyManager.CreateLobby(gameType, host, adapter)
+          lobbyManager ! LobbyManager.CreateLobby(gameType, host, name, adapter)
           Behaviors.same
 
         case JoinLobby(roomId, player, replyTo) =>

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
@@ -50,9 +50,15 @@ object LobbyManager {
 
   // --- Commands received from GameManager (all handled locally by LobbyManager) ---
 
-  /** Create a new lobby for `gameType` hosted by `host`; replies with [[GameManager.LobbyCreated]]. */
-  final case class CreateLobby(gameType: GameType, host: Player, replyTo: ActorRef[GameManager.GameResponse])
-      extends Command
+  /** Create a new lobby for `gameType` hosted by `host`, optionally named `name`; replies with
+    * [[GameManager.LobbyCreated]].
+    */
+  final case class CreateLobby(
+      gameType: GameType,
+      host: Player,
+      name: Option[String],
+      replyTo: ActorRef[GameManager.GameResponse]
+  ) extends Command
 
   /** Add `player` to an existing joinable lobby; replies with [[GameManager.LobbyJoined]] or an error. */
   final case class JoinLobby(roomId: RoomId, player: Player, replyTo: ActorRef[GameManager.GameResponse])
@@ -240,9 +246,9 @@ object LobbyManager {
       emptyRoomGrace: FiniteDuration
   )(implicit runtime: IORuntime): Behavior[Command] = Behaviors.receive[Command] { (context, message) =>
     message match {
-      case CreateLobby(gameType, host, replyTo) =>
+      case CreateLobby(gameType, host, name, replyTo) =>
         context.log.info(s"Creating new lobby for game type $gameType with host ${host.name}")
-        val lobby = LobbyMetadata.newLobby(gameType, host)
+        val lobby = LobbyMetadata.newLobby(gameType, host, name)
         replyTo ! GameManager.LobbyCreated(lobby.roomId, host)
         persist(lobbyRepo.saveLobby(lobby))
         running(lobbies + (lobby.roomId -> lobby), recentlyEnded, subscribers, gameManager, lobbyRepo, emptyRoomGrace)

--- a/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyMetadata.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyMetadata.scala
@@ -14,13 +14,23 @@ object LobbyMetadata {
     *
     * @param gameType the type of game (e.g., TicTacToe)
     * @param host the player who is creating and hosting the lobby
+    * @param name optional host-chosen display name for the lobby
     * @return a new LobbyMetadata instance representing the initialized lobby
     */
-  def newLobby(gameType: GameType, host: Player): LobbyMetadata = {
+  def newLobby(gameType: GameType, host: Player, name: Option[String] = None): LobbyMetadata = {
     val roomId = UUID.randomUUID()
     val players = Map(host.id -> host)
     val now = Instant.now()
-    LobbyMetadata(roomId, gameType, players, host.id, GameLifecycleStatus.WaitingForPlayers, now, lastActivityAt = now)
+    LobbyMetadata(
+      roomId,
+      gameType,
+      players,
+      host.id,
+      GameLifecycleStatus.WaitingForPlayers,
+      now,
+      lastActivityAt = now,
+      name = name
+    )
   }
 }
 
@@ -40,6 +50,8 @@ object LobbyMetadata {
   *                   rotate the seating so the first-move seat alternates across rematches
   * @param lastActivityAt server time of the last activity in this room (start, leave, chat, match end); used to reap
   *                       idle post-game (Finished) rooms
+  * @param name optional host-chosen display name for the lobby, shown in the lobby list so friends can recognize the
+  *             room; when absent, clients fall back to a default "{host}'s {game}" label
   */
 case class LobbyMetadata(
     roomId: RoomId,
@@ -50,5 +62,6 @@ case class LobbyMetadata(
     createdAt: Instant,
     currentMatchId: Option[MatchId] = None,
     matchCount: Int = 0,
-    lastActivityAt: Instant = Instant.EPOCH
+    lastActivityAt: Instant = Instant.EPOCH,
+    name: Option[String] = None
 )

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
@@ -118,7 +118,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val gm = spawn(GameManager(persistProbe.ref, slowRepo, noOpLobbyRepo))
 
       // Send a command that would be stashed during initialization
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
 
       // Initially, no response because it's still initializing
       responseProbe.expectNoMessage(500.millis)
@@ -168,7 +168,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
 
       val response = responseProbe.expectMessageType[GameManager.LobbyCreated]
       response.roomId.toString should not be empty
@@ -202,7 +202,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
@@ -218,7 +218,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       gm ! GameManager.JoinLobby(roomId, alice, responseProbe.ref)
@@ -258,7 +258,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       // Alice creates the lobby
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, _) = responseProbe.receiveMessage()
 
       // Bob joins
@@ -283,7 +283,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       // Alice creates the lobby
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, host) = responseProbe.receiveMessage()
 
       // Bob joins
@@ -310,7 +310,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, host) = responseProbe.receiveMessage()
 
       gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
@@ -335,7 +335,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, _) = responseProbe.receiveMessage()
 
       gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
@@ -373,7 +373,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       // Game 1: InProgress
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId1, _) = responseProbe.receiveMessage()
       gm ! GameManager.JoinLobby(roomId1, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
@@ -381,13 +381,13 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       responseProbe.expectMessageType[GameManager.GameStarted]
 
       // Game 2: ReadyToStart
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId2, _) = responseProbe.receiveMessage()
       gm ! GameManager.JoinLobby(roomId2, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
 
       // Game 2: WaitingForPlayers
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId3, _) = responseProbe.receiveMessage()
 
       // joinable lobbies plus the live game are all listable (so a browser can spectate an in-progress match);
@@ -406,13 +406,13 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       // Lobby A: alice + bob, left in a pre-game (joinable) state
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(lobbyA, _) = responseProbe.receiveMessage()
       gm ! GameManager.JoinLobby(lobbyA, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
 
       // Lobby B: alice + bob, started — now a live game
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(gameB, hostB) = responseProbe.receiveMessage()
       gm ! GameManager.JoinLobby(gameB, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
@@ -433,7 +433,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, host) = responseProbe.receiveMessage()
       gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
@@ -483,7 +483,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       // start a game so the room resolves to a live match (the move log is keyed by match id, not room id)
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, Player("alice"), responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, Player("alice"), None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, host) = responseProbe.receiveMessage()
       gm ! GameManager.JoinLobby(roomId, Player("bob"), responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
@@ -536,7 +536,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, host) = responseProbe.receiveMessage()
 
       gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
@@ -755,7 +755,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
       // Alice creates the lobby
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, _) = responseProbe.receiveMessage()
 
       // Bob joins
@@ -787,7 +787,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, host) = responseProbe.receiveMessage()
       gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
@@ -816,7 +816,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, host) = responseProbe.receiveMessage()
       gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
@@ -856,7 +856,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, host) = responseProbe.receiveMessage()
 
       // Bob joins
@@ -886,7 +886,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, host) = responseProbe.receiveMessage()
 
       // Bob joins
@@ -953,7 +953,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       // Alice creates a lobby
       val responseProbe = TestProbe[GameManager.GameResponse]()
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       // Auto-subscribe fires: alice's PlayerActor receives SendEvent(LobbyUpdated) and forwards it as a SessionEvent
@@ -974,7 +974,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       // Alice creates a lobby without a WebSocket connection — no auto-subscribe for alice
       val responseProbe = TestProbe[GameManager.GameResponse]()
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       // Bob connects via WebSocket, then joins
@@ -1006,7 +1006,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       // Alice creates a lobby
       val responseProbe = TestProbe[GameManager.GameResponse]()
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       // Spectator subscribes to lobby events
@@ -1027,7 +1027,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       // Alice has no WebSocket connection
@@ -1044,7 +1044,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, host) = responseProbe.expectMessageType[GameManager.LobbyCreated]
       gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
@@ -1077,7 +1077,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       // Start a game
       val responseProbe = TestProbe[GameManager.GameResponse]()
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, host) = responseProbe.expectMessageType[GameManager.LobbyCreated]
       gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
@@ -1106,7 +1106,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, host) = responseProbe.expectMessageType[GameManager.LobbyCreated]
       gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
@@ -1146,7 +1146,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, host) = responseProbe.receiveMessage()
 
       gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
@@ -1211,7 +1211,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       val wsProbe = TestProbe[PlayerActor.SessionOutput]()
@@ -1237,7 +1237,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val gm = spawn(GameManager(persistProbe.ref, new InMemRepo, noOpLobbyRepo, publisher = recordingPublisher))
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, host, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, host, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, _) = responseProbe.receiveMessage()
       gm ! GameManager.JoinLobby(roomId, guest, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]
@@ -1280,7 +1280,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       gm ! GameManager.RegisterPlayer(alice, wsProbe.ref, playerRefProbe.ref)
       playerRefProbe.expectMessageType[ActorRef[PlayerActor.Command]]
 
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
       wsProbe.expectMessageType[PlayerActor.SessionEvent] // initial lobby state from the auto-subscribe
 
@@ -1343,7 +1343,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val gm = spawn(GameManager(persistProbe.ref, gameRepo, noOpLobbyRepo))
 
       val responseProbe = TestProbe[GameManager.GameResponse]()
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, host) = responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       // Alice connects via WebSocket and subscribes before the game starts
@@ -1398,7 +1398,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val gm = spawn(GameManager(persistProbe.ref, new InMemRepo, noOpLobbyRepo))
       val responseProbe = TestProbe[GameManager.GameResponse]()
 
-      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      gm ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, host) = responseProbe.receiveMessage()
       gm ! GameManager.JoinLobby(roomId, bob, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyJoined]

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
@@ -48,7 +48,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
 
   /** Create a lobby with alice as host and have bob join. Returns (roomId, host). */
   private def createReadyLobby(f: LobbyFixture): (RoomId, Player) = {
-    f.lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, f.responseProbe.ref)
+    f.lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, None, f.responseProbe.ref)
     val GameManager.LobbyCreated(roomId, host) = f.responseProbe.expectMessageType[GameManager.LobbyCreated]
     f.lm ! LobbyManager.JoinLobby(roomId, bob, f.responseProbe.ref)
     f.responseProbe.expectMessageType[GameManager.LobbyJoined]
@@ -67,7 +67,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
     "create a lobby and return its metadata" in {
       val LobbyFixture(lm, _, responseProbe) = newLobby()
 
-      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
 
       val GameManager.LobbyCreated(roomId, host) = responseProbe.expectMessageType[GameManager.LobbyCreated]
       roomId.toString should not be empty
@@ -276,7 +276,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val f = newLobby()
       val subscriberProbe = TestProbe[PlayerActor.Command]()
 
-      f.lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, f.responseProbe.ref)
+      f.lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, None, f.responseProbe.ref)
       val GameManager.LobbyCreated(roomId, _) = f.responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       f.lm ! LobbyManager.SubscribeToLobby(roomId, alice.id, subscriberProbe.ref, f.responseProbe.ref)
@@ -292,7 +292,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val f = newLobby()
       val subscriberProbe = TestProbe[PlayerActor.Command]()
 
-      f.lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, f.responseProbe.ref)
+      f.lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, None, f.responseProbe.ref)
       val GameManager.LobbyCreated(roomId, _) = f.responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       f.lm ! LobbyManager.SubscribeToLobby(roomId, alice.id, subscriberProbe.ref, f.responseProbe.ref)
@@ -309,7 +309,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val f = newLobby()
       val subscriberProbe = TestProbe[PlayerActor.Command]()
 
-      f.lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, f.responseProbe.ref)
+      f.lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, None, f.responseProbe.ref)
       val GameManager.LobbyCreated(roomId, _) = f.responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       f.lm ! LobbyManager.SubscribeToLobby(roomId, alice.id, subscriberProbe.ref, f.responseProbe.ref)
@@ -394,7 +394,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val f = newLobby()
       val subscriberProbe = TestProbe[PlayerActor.Command]()
 
-      f.lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, f.responseProbe.ref)
+      f.lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, None, f.responseProbe.ref)
       val GameManager.LobbyCreated(roomId, _) = f.responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       f.lm ! LobbyManager.SubscribeToLobby(roomId, alice.id, subscriberProbe.ref, f.responseProbe.ref)
@@ -475,7 +475,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       // a real actor we can stop to trigger a Terminated signal in the watching LobbyManager
       val dyingSubscriber = spawn(Behaviors.empty[PlayerActor.Command])
 
-      f.lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, f.responseProbe.ref)
+      f.lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, None, f.responseProbe.ref)
       val GameManager.LobbyCreated(roomId, _) = f.responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       f.lm ! LobbyManager.SubscribeToLobby(roomId, alice.id, dyingSubscriber, f.responseProbe.ref)
@@ -534,11 +534,11 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val carol = Player("carol")
 
       // created oldest-to-newest; the high-resolution creation clock makes each createdAt strictly later
-      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyCreated]
-      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, bob, responseProbe.ref)
+      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, bob, None, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyCreated]
-      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, carol, responseProbe.ref)
+      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, carol, None, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       lm ! LobbyManager.ListLobbies(None, 1, 20, listProbe.ref)
@@ -562,11 +562,11 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val listProbe = TestProbe[LobbyManager.LobbiesListed]()
       val carol = Player("carol")
 
-      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyCreated]
-      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, bob, responseProbe.ref)
+      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, bob, None, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyCreated]
-      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, carol, responseProbe.ref)
+      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, carol, None, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       lm ! LobbyManager.ListLobbies(None, 1, 2, listProbe.ref)
@@ -586,9 +586,9 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val LobbyFixture(lm, _, responseProbe) = newLobby()
       val listProbe = TestProbe[LobbyManager.LobbiesListed]()
 
-      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyCreated]
-      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, bob, responseProbe.ref)
+      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, bob, None, responseProbe.ref)
       responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       lm ! LobbyManager.ListLobbies(Some(GameType.TicTacToe), 1, 20, listProbe.ref)
@@ -607,7 +607,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val (joinedRoomId, _) = createReadyLobby(f)
 
       // a separate lobby hosted by carol that alice is not part of
-      f.lm ! LobbyManager.CreateLobby(GameType.TicTacToe, carol, f.responseProbe.ref)
+      f.lm ! LobbyManager.CreateLobby(GameType.TicTacToe, carol, None, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       f.lm ! LobbyManager.ListLobbiesForPlayer(alice.id, playerLobbiesProbe.ref)
@@ -651,7 +651,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
     "return LobbyNotReady when there are not enough players to start" in {
       val LobbyFixture(lm, gmProbe, responseProbe) = newLobby()
 
-      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      lm ! LobbyManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val GameManager.LobbyCreated(roomId, _) = responseProbe.expectMessageType[GameManager.LobbyCreated]
 
       lm ! LobbyManager.StartGame(roomId, alice.id, responseProbe.ref)

--- a/game-service-actor/src/test/scala/com/andy327/actor/lobby/LobbyCodecsSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/lobby/LobbyCodecsSpec.scala
@@ -40,6 +40,16 @@ class LobbyCodecsSpec extends AnyWordSpec with Matchers {
       LobbyCodecs.deserialize(LobbyCodecs.serialize(lobby)) shouldBe Right(lobby)
     }
 
+    "round-trip a lobby with a name" in {
+      val lobby = baseLobby.copy(name = Some("Friday night"))
+      LobbyCodecs.deserialize(LobbyCodecs.serialize(lobby)) shouldBe Right(lobby)
+    }
+
+    "default name to None when decoding legacy JSON that predates the field" in {
+      val legacyJson = LobbyCodecs.serialize(baseLobby).replaceAll(""",?"name":null""", "")
+      LobbyCodecs.deserialize(legacyJson) shouldBe Right(baseLobby.copy(name = None))
+    }
+
     "return Left for a lobby JSON containing an unknown status value" in {
       val json = LobbyCodecs.serialize(baseLobby).replace("WaitingForPlayers", "Exploded")
       LobbyCodecs.deserialize(json) shouldBe a[Left[_, _]]

--- a/game-service-server/src/main/resources/web/index.html
+++ b/game-service-server/src/main/resources/web/index.html
@@ -51,6 +51,7 @@
     <h2>Lobbies</h2>
     <div class="row">
       <span>New game:</span>
+      <input id="lobby-name" type="text" maxlength="40" placeholder="Lobby name (optional)" />
       <button data-gametype="tictactoe">Tic-Tac-Toe</button>
       <button data-gametype="connectfour">Connect Four</button>
       <button data-gametype="battleship">Battleship</button>

--- a/game-service-server/src/main/resources/web/lobby.js
+++ b/game-service-server/src/main/resources/web/lobby.js
@@ -11,8 +11,12 @@ import { resetCopyLinkButton } from "./deeplinks.js";
 
 export async function createGame(gameType) {
   setError("lobby-error", "");
-  const res = await api(`/lobby/create/${gameType}`, { method: "POST", body: {} });
+  // Optional host-chosen lobby name; the server trims it and treats a blank value as unnamed.
+  const name = $("lobby-name").value.trim();
+  const query = name ? `?name=${encodeURIComponent(name)}` : "";
+  const res = await api(`/lobby/create/${gameType}${query}`, { method: "POST", body: {} });
   if (!res.ok) return flashError("lobby-error", res.data?.error || res.data || "Could not create game");
+  $("lobby-name").value = "";
   await enterGame({ roomId: res.data.roomId, gameType, isHost: true });
 }
 
@@ -56,11 +60,13 @@ export async function refreshLobbies() {
     const li = document.createElement("li");
 
     const watching = entry.spectatorCount > 0 ? ` — ${entry.spectatorCount} watching` : "";
+    const named = lobby.name ? `${lobby.name} — ` : ""; // host-chosen label leads the line when present
     const meta = document.createElement("span");
     meta.className = "meta";
+    // textContent (not innerHTML) renders the player-supplied name as literal text, so it can't inject markup.
     meta.textContent = phase
-      ? `${GAMES[type].label} — hosted by ${hostName} — ${phase}${watching}`
-      : `${GAMES[type].label} — hosted by ${hostName} — ${count}/${max} players${watching}`;
+      ? `${named}${GAMES[type].label} — hosted by ${hostName} — ${phase}${watching}`
+      : `${named}${GAMES[type].label} — hosted by ${hostName} — ${count}/${max} players${watching}`;
 
     li.appendChild(meta);
 
@@ -170,7 +176,8 @@ function renderMySessions(data) {
     const youHost = Boolean(session.me) && l.hostId === session.me.id;
     const count = Object.keys(l.players).length;
     const phase = l.status === "Finished" ? "finished — chat/rematch" : `lobby (${count}/${GAMES[type].maxPlayers})`;
-    const label = `${GAMES[type].label} — ${phase}${youHost ? " · you host" : ""}`;
+    const named = l.name ? `${l.name} — ` : "";
+    const label = `${named}${GAMES[type].label} — ${phase}${youHost ? " · you host" : ""}`;
     ul.appendChild(sessionRow(label, "Return", () => enterGame({ roomId: l.roomId, gameType: type, isHost: youHost })));
   }
 }

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/LobbyRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/LobbyRoutes.scala
@@ -95,20 +95,32 @@ class LobbyRoutes(
     } ~
     /** Creates a new game lobby for the specified game type using the authenticated player as host.
       *
+      * An optional `name` query parameter sets a host-chosen display label for the lobby. It is trimmed, and a blank
+      * name is treated as absent; names longer than [[LobbyRoutes.MaxNameLength]] characters are rejected.
+      *
       * - Auth: Bearer token required
       * - Path: `gameType` — the type of game to create (e.g., `tictactoe`)
+      * - Query `name` (optional): display label, e.g. `Friday night poker`
       * - 200: `LobbyCreated` with the new game ID and host player info
-      * - 400: invalid game type
+      * - 400: invalid game type, or lobby name too long
       * - 401: missing or invalid token
       * - 500: unexpected error
       */
     path("create" / Segment) { gameTypeStr =>
       parseGameType(gameTypeStr) { gameType =>
         post {
-          authenticator.authenticatePlayer { player =>
-            onSuccess(system.ask[GameResponse](replyTo => GameManager.CreateLobby(gameType, player, replyTo))) {
-              case created: LobbyCreated => complete(created)
-              case other                 => complete(StatusCodes.InternalServerError -> s"Unexpected response: $other")
+          parameter("name".?) { nameParam =>
+            authenticator.authenticatePlayer { player =>
+              LobbyRoutes.normalizeName(nameParam) match {
+                case Left(err)   => complete(StatusCodes.BadRequest -> err)
+                case Right(name) =>
+                  onSuccess(
+                    system.ask[GameResponse](replyTo => GameManager.CreateLobby(gameType, player, name, replyTo))
+                  ) {
+                    case created: LobbyCreated => complete(created)
+                    case other => complete(StatusCodes.InternalServerError -> s"Unexpected response: $other")
+                  }
+              }
             }
           }
         }
@@ -280,4 +292,20 @@ class LobbyRoutes(
       }
     }
   }
+}
+
+object LobbyRoutes {
+
+  /** Maximum allowed length, in characters, of a host-chosen lobby name. */
+  val MaxNameLength: Int = 40
+
+  /** Normalizes an optional lobby name: trims surrounding whitespace and treats a blank result as absent (`None`).
+    * Returns the cleaned name on the right, or an error message on the left when the trimmed name exceeds
+    * [[MaxNameLength]] characters.
+    */
+  def normalizeName(name: Option[String]): Either[String, Option[String]] =
+    name.map(_.trim).filter(_.nonEmpty) match {
+      case Some(n) if n.length > MaxNameLength => Left(s"Lobby name must be at most $MaxNameLength characters")
+      case cleaned                             => Right(cleaned)
+    }
 }

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/LobbyRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/LobbyRoutesSpec.scala
@@ -79,6 +79,37 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
         responseAs[String] should include("Invalid game type")
       }
 
+    "create a lobby with a host-chosen name" in {
+      val roomId = Post("/lobby/create/tictactoe?name=Friday%20night").withHeaders(aliceHeader) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+        responseAs[GameManager.LobbyCreated].roomId
+      }
+
+      Get(s"/lobby/$roomId") ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+        responseAs[LobbyMetadata].name shouldBe Some("Friday night")
+      }
+    }
+
+    "trim a lobby name and treat a blank name as unnamed" in {
+      val roomId = Post("/lobby/create/tictactoe?name=%20%20").withHeaders(aliceHeader) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+        responseAs[GameManager.LobbyCreated].roomId
+      }
+
+      Get(s"/lobby/$roomId") ~> routes ~> check {
+        responseAs[LobbyMetadata].name shouldBe None
+      }
+    }
+
+    "reject creating a lobby with a name that is too long" in {
+      val longName = "x" * (LobbyRoutes.MaxNameLength + 1)
+      Post(s"/lobby/create/tictactoe?name=$longName").withHeaders(aliceHeader) ~> routes ~> check {
+        status shouldBe StatusCodes.BadRequest
+        responseAs[String] should include("at most")
+      }
+    }
+
     "join a lobby with a second player" in {
       val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
         responseAs[GameManager.LobbyCreated].roomId
@@ -349,7 +380,7 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
     "return 500 for unexpected responses" in {
       val fakeId = UUID.randomUUID()
       val unexpectedBehavior = Behaviors.receiveMessage[GameManager.Command] {
-        case GameManager.CreateLobby(_, _, replyTo) =>
+        case GameManager.CreateLobby(_, _, _, replyTo) =>
           replyTo ! GameManager.Ready // triggers /create fallback
           Behaviors.same
 

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/PlayerRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/PlayerRoutesSpec.scala
@@ -76,11 +76,11 @@ class PlayerRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest
 
     "report the player's joined lobby and active game" in {
       // Lobby A: alice + bob, left joinable
-      val GameManager.LobbyCreated(lobbyA, _) = ask(GameManager.CreateLobby(GameType.TicTacToe, alice, _))
+      val GameManager.LobbyCreated(lobbyA, _) = ask(GameManager.CreateLobby(GameType.TicTacToe, alice, None, _))
       ask(GameManager.JoinLobby(lobbyA, bob, _))
 
       // Lobby B: alice + bob, started into a live game
-      val GameManager.LobbyCreated(gameB, hostB) = ask(GameManager.CreateLobby(GameType.TicTacToe, alice, _))
+      val GameManager.LobbyCreated(gameB, hostB) = ask(GameManager.CreateLobby(GameType.TicTacToe, alice, None, _))
       ask(GameManager.JoinLobby(gameB, bob, _))
       ask(GameManager.StartGame(gameB, hostB.id, _))
 

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/WebSocketRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/WebSocketRoutesSpec.scala
@@ -67,7 +67,7 @@ class WebSocketRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteT
       val responseProbe = typedKit.createTestProbe[GameManager.GameResponse]()
 
       // a lobby alice can subscribe to once her WebSocket session is registered
-      typedSystem ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      typedSystem ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val roomId = responseProbe.expectMessageType[GameManager.LobbyCreated].roomId
 
       val wsClient = WSProbe()
@@ -97,7 +97,7 @@ class WebSocketRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteT
       val token = createTestToken(alice)
       val responseProbe = typedKit.createTestProbe[GameManager.GameResponse]()
 
-      typedSystem ! GameManager.CreateLobby(GameType.TicTacToe, alice, responseProbe.ref)
+      typedSystem ! GameManager.CreateLobby(GameType.TicTacToe, alice, None, responseProbe.ref)
       val roomId = responseProbe.expectMessageType[GameManager.LobbyCreated].roomId
 
       val wsClient = WSProbe()


### PR DESCRIPTION
Closes #70.

### Summary
- Lets a host give a lobby a human-readable name at creation so friends can pick the right room out of the open-lobby list without needing a share link.
- The name is optional end-to-end: existing lobbies, API clients, and the web client all keep working unchanged when it is omitted.

### Backend
- Added `name: Option[String]` to `LobbyMetadata`, defaulted to `None` so the Redis `deriveCodec` still decodes lobbies persisted before this change.
- Threaded the name through the `CreateLobby` command (`GameManager` → `LobbyManager`) and `LobbyMetadata.newLobby`.
- `POST /lobby/create/{gameType}` gains an optional `?name=` query parameter. It is trimmed, a blank value is treated as absent, and a name longer than `LobbyRoutes.MaxNameLength` (40) is rejected with 400. A query param (over a request body) keeps body-less POSTs working, so no existing client or test breaks.
- The name rides the shared `LobbyMetadata` codec, so it appears automatically in `/lobby/list`, `/lobby/{roomId}`, and the sessions view with no extra wiring.

### Web client
- Added an optional lobby-name input (`maxlength=40`) to the "New game" row; `createGame` sends it URL-encoded as `?name=` only when non-blank and clears the field on success.
- The open-lobby list and the sessions list lead with the name when present, falling back to the existing "{game} — hosted by {host}" label. Both render through `textContent`, so a player-supplied name is always literal text and can never inject markup.

### Tests
- `LobbyCodecsSpec`: round-trips a named lobby and decodes legacy JSON (no `name` key) back to `None`.
- `LobbyRoutesSpec`: create-with-name round-trips through the actor, a whitespace-only name normalizes to unnamed, and an over-length name returns 400.
- Updated the existing `CreateLobby` construction sites across the actor and server specs for the new argument.

### Verification
`Test/compile` clean; the affected suites pass (36 in `LobbyRoutesSpec`, 111 across `LobbyCodecsSpec`/`LobbyManagerSpec`/`GameManagerSpec`); `scalafmtCheckAll` clean and `server/doc` links resolve. The web change is confined to label construction and was reviewed statically.