### PR TITLE
Unify HTTP responses on typed wire types and one shared error envelope

### DIFF
--- a/game-service-server/src/main/scala/com/andy327/server/http/auth/AuthResponses.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/auth/AuthResponses.scala
@@ -2,6 +2,13 @@ package com.andy327.server.http.auth
 
 import java.util.UUID
 
+/** Body of the token-issuing endpoints `POST /auth/register` and `POST /auth/token` — the signed JWT the caller
+  * presents as a Bearer token on subsequent requests. The body is `{ "token": "<jwt>" }`.
+  *
+  * @param token the signed JWT attesting to the authenticated account
+  */
+case class TokenResponse(token: String)
+
 /** Body of `GET /auth/whoami` — the authenticated caller's identity plus their email-verification state.
   *
   * `verified` is surfaced as a flag rather than enforced: an unverified account can still authenticate and play, so

--- a/game-service-server/src/main/scala/com/andy327/server/http/auth/JwtAuthenticator.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/auth/JwtAuthenticator.scala
@@ -16,6 +16,7 @@ import com.andy327.actor.lobby.Player
 import com.andy327.server.auth.{NoOpRevocationStore, RevocationStore, UserContext}
 import com.andy327.server.config.JwtConfig
 import com.andy327.server.http.json.JsonProtocol._
+import com.andy327.server.http.model.ErrorResponse
 
 /** Authenticates players from JWT bearer tokens, as an injectable component.
   *
@@ -68,10 +69,10 @@ class JwtAuthenticator(
       case _ if allowQueryParam =>
         parameter("access_token".?).flatMap {
           case Some(token) => provide(token)
-          case None        => complete(StatusCodes.Unauthorized -> Map("error" -> "Missing access token"))
+          case None        => complete(StatusCodes.Unauthorized -> ErrorResponse("Missing access token"))
         }
       case _ =>
-        complete(StatusCodes.Unauthorized -> Map("error" -> "Missing Authorization header"))
+        complete(StatusCodes.Unauthorized -> ErrorResponse("Missing Authorization header"))
     }
 
   /** Validates a raw JWT and provides the [[Player]] it identifies, or rejects with an Unauthorized response. */
@@ -85,12 +86,12 @@ class JwtAuthenticator(
             // Parse the player id string into a UUID, then build a Player
             playerFromContext(userContext) match {
               case Some(player) => rejectIfRevoked(player, claim.issuedAt)
-              case None         => complete(StatusCodes.Unauthorized -> Map("error" -> "Invalid player ID or name"))
+              case None         => complete(StatusCodes.Unauthorized -> ErrorResponse("Invalid player ID or name"))
             }
-          case Left(_) => complete(StatusCodes.Unauthorized -> Map("error" -> "Token payload could not be parsed"))
+          case Left(_) => complete(StatusCodes.Unauthorized -> ErrorResponse("Token payload could not be parsed"))
         }
 
-      case Failure(_) => complete(StatusCodes.Unauthorized -> Map("error" -> "Token is invalid or expired"))
+      case Failure(_) => complete(StatusCodes.Unauthorized -> ErrorResponse("Token is invalid or expired"))
     }
 
   /** Provides the player unless their account has a revocation cutoff at or after the token's issued-at, in which case
@@ -100,7 +101,7 @@ class JwtAuthenticator(
   private def rejectIfRevoked(player: Player, issuedAt: Option[Long]): Directive1[Player] =
     onSuccess(revocationStore.revokedBefore(player.id).unsafeToFuture()).flatMap {
       case Some(cutoff) if issuedAt.forall(_ * 1000 < cutoff.toEpochMilli) =>
-        complete(StatusCodes.Unauthorized -> Map("error" -> "Token has been revoked"))
+        complete(StatusCodes.Unauthorized -> ErrorResponse("Token has been revoked"))
       case _ => provide(player)
     }
 

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -58,11 +58,10 @@ import com.andy327.server.http.player.{PlayerGameSummary, PlayerHistory}
 /** Circe codecs and Pekko HTTP marshallers for all API types.
   *
   * Case-class codecs are derived via `deriveCodec`. The value codecs for `Player`, `GameLifecycleStatus`, and
-  * `LobbyMetadata` (which also fixes the `GameType` and UUID-key formats) are reused from
-  * `LobbyCodecs` and re-exported as members here, so the wire format is defined once and is
-  * shared by the HTTP layer and Redis persistence. [[playerEventEncoder]] is write-only (server-push only). Marshalling
-  * is provided by [[CirceSupport]]: any type with an `Encoder` can be `complete`d, any type with a `Decoder` read with
-  * `entity(as[A])`.
+  * `LobbyMetadata` (which also fixes the `GameType` and UUID-key formats) are reused from `LobbyCodecs` and re-exported
+  * as members here, so the wire format is defined once and is shared by the HTTP layer and Redis persistence.
+  * [[playerEventEncoder]] is write-only (server-push only). Marshalling is provided by [[CirceSupport]]: any type with
+  * an `Encoder` can be `complete`d, any type with a `Decoder` read with `entity(as[A])`.
   */
 object JsonProtocol extends CirceSupport {
 

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -9,7 +9,6 @@ import com.andy327.actor.chat.ChatCodecs
 import com.andy327.actor.core.GameManager.{
   ActiveGameSummary,
   ChatHistory,
-  ErrorResponse,
   GameStarted,
   LobbiesListed,
   LobbyCreated,
@@ -54,6 +53,7 @@ import com.andy327.server.http.auth.{
   VerifyEmailRequest,
   WhoamiResponse
 }
+import com.andy327.server.http.model.{ErrorResponse, MessageResponse}
 
 /** Circe codecs and Pekko HTTP marshallers for all API types.
   *
@@ -88,6 +88,13 @@ object JsonProtocol extends CirceSupport {
 
   implicit val whoamiResponseCodec: Codec[WhoamiResponse] = deriveCodec[WhoamiResponse]
 
+  // Shared HTTP envelopes: ErrorResponse is the single body for every non-2xx response; MessageResponse carries an
+  // advisory note on a 2xx with nothing else to return. Both are neutral wire types, translated from actor replies at
+  // the route boundary so this protocol never marshals an actor message directly.
+  implicit val errorResponseCodec: Codec[ErrorResponse] = deriveCodec[ErrorResponse]
+
+  implicit val messageResponseCodec: Codec[MessageResponse] = deriveCodec[MessageResponse]
+
   implicit val lobbyCreatedCodec: Codec[LobbyCreated] = deriveCodec[LobbyCreated]
 
   implicit val lobbyJoinedCodec: Codec[LobbyJoined] = deriveCodec[LobbyJoined]
@@ -99,8 +106,6 @@ object JsonProtocol extends CirceSupport {
   implicit val lobbySummaryCodec: Codec[LobbySummary] = deriveCodec[LobbySummary]
 
   implicit val lobbiesListedCodec: Codec[LobbiesListed] = deriveCodec[LobbiesListed]
-
-  implicit val errorResponseCodec: Codec[ErrorResponse] = deriveCodec[ErrorResponse]
 
   implicit val subscribeAcknowledgedCodec: Codec[SubscribeAcknowledged] = deriveCodec[SubscribeAcknowledged]
 

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -45,8 +45,6 @@ import com.andy327.server.http.auth.{
   ChangePasswordRequest,
   ForgotPasswordRequest,
   LoginRequest,
-  PlayerGameSummary,
-  PlayerHistory,
   RegisterRequest,
   ResendVerificationRequest,
   ResetPasswordRequest,
@@ -55,6 +53,7 @@ import com.andy327.server.http.auth.{
   WhoamiResponse
 }
 import com.andy327.server.http.model.{ErrorResponse, MessageResponse}
+import com.andy327.server.http.player.{PlayerGameSummary, PlayerHistory}
 
 /** Circe codecs and Pekko HTTP marshallers for all API types.
   *

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -50,6 +50,7 @@ import com.andy327.server.http.auth.{
   RegisterRequest,
   ResendVerificationRequest,
   ResetPasswordRequest,
+  TokenResponse,
   VerifyEmailRequest,
   WhoamiResponse
 }
@@ -85,6 +86,8 @@ object JsonProtocol extends CirceSupport {
 
   implicit val resendVerificationRequestCodec: Codec[ResendVerificationRequest] =
     deriveCodec[ResendVerificationRequest]
+
+  implicit val tokenResponseCodec: Codec[TokenResponse] = deriveCodec[TokenResponse]
 
   implicit val whoamiResponseCodec: Codec[WhoamiResponse] = deriveCodec[WhoamiResponse]
 

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -71,59 +71,44 @@ object JsonProtocol extends CirceSupport {
   implicit val gameLifecycleStatusCodec: Codec[GameLifecycleStatus] = LobbyCodecs.statusCodec
   implicit val lobbyMetadataCodec: Codec[LobbyMetadata] = LobbyCodecs.lobbyMetadataCodec
 
+  // Auth request bodies.
   implicit val registerRequestCodec: Codec[RegisterRequest] = deriveCodec[RegisterRequest]
-
   implicit val loginRequestCodec: Codec[LoginRequest] = deriveCodec[LoginRequest]
-
   implicit val changePasswordRequestCodec: Codec[ChangePasswordRequest] = deriveCodec[ChangePasswordRequest]
-
   implicit val forgotPasswordRequestCodec: Codec[ForgotPasswordRequest] = deriveCodec[ForgotPasswordRequest]
-
   implicit val resetPasswordRequestCodec: Codec[ResetPasswordRequest] = deriveCodec[ResetPasswordRequest]
-
   implicit val verifyEmailRequestCodec: Codec[VerifyEmailRequest] = deriveCodec[VerifyEmailRequest]
-
   implicit val resendVerificationRequestCodec: Codec[ResendVerificationRequest] =
     deriveCodec[ResendVerificationRequest]
 
+  // Auth response bodies.
   implicit val tokenResponseCodec: Codec[TokenResponse] = deriveCodec[TokenResponse]
-
   implicit val whoamiResponseCodec: Codec[WhoamiResponse] = deriveCodec[WhoamiResponse]
 
   // Shared HTTP envelopes: ErrorResponse is the single body for every non-2xx response; MessageResponse carries an
   // advisory note on a 2xx with nothing else to return. Both are neutral wire types, translated from actor replies at
   // the route boundary so this protocol never marshals an actor message directly.
   implicit val errorResponseCodec: Codec[ErrorResponse] = deriveCodec[ErrorResponse]
-
   implicit val messageResponseCodec: Codec[MessageResponse] = deriveCodec[MessageResponse]
 
+  // Lobby and game responses completed directly by the routes.
   implicit val lobbyCreatedCodec: Codec[LobbyCreated] = deriveCodec[LobbyCreated]
-
   implicit val lobbyJoinedCodec: Codec[LobbyJoined] = deriveCodec[LobbyJoined]
-
   implicit val lobbyLeftCodec: Codec[LobbyLeft] = deriveCodec[LobbyLeft]
-
   implicit val gameStartedCodec: Codec[GameStarted] = deriveCodec[GameStarted]
-
   implicit val lobbySummaryCodec: Codec[LobbySummary] = deriveCodec[LobbySummary]
-
   implicit val lobbiesListedCodec: Codec[LobbiesListed] = deriveCodec[LobbiesListed]
-
   implicit val subscribeAcknowledgedCodec: Codec[SubscribeAcknowledged] = deriveCodec[SubscribeAcknowledged]
-
   implicit val unsubscribeAcknowledgedCodec: Codec[UnsubscribeAcknowledged] = deriveCodec[UnsubscribeAcknowledged]
-
   implicit val moveRecordCodec: Codec[MoveRecord] = deriveCodec[MoveRecord]
+  implicit val moveHistoryCodec: Codec[MoveHistory] = deriveCodec[MoveHistory]
 
   // Write-only: pushed over the debug trace WebSocket (TraceRoutes), never read back from a request body.
   implicit val traceEventEncoder: Encoder[TraceEvent] = deriveEncoder[TraceEvent]
 
-  implicit val moveHistoryCodec: Codec[MoveHistory] = deriveCodec[MoveHistory]
-
   // Chat history records use the plain (untagged) chat-message form from ChatCodecs — see its scaladoc for how this
   // differs from the tagged ChatMessage envelope that playerEventEncoder emits for live WebSocket push.
   implicit val chatMessageCodec: Codec[PlayerEvent.ChatMessage] = ChatCodecs.chatMessageCodec
-
   implicit val chatHistoryCodec: Codec[ChatHistory] = deriveCodec[ChatHistory]
 
   // Player history: a GameResult travels as its stable lower-case label ("win"/"loss"/"draw"); the GameType field
@@ -132,41 +117,26 @@ object JsonProtocol extends CirceSupport {
     Decoder.decodeString.emap(s => GameResult.fromLabel(s).toRight(s"Unknown GameResult: $s")),
     Encoder.encodeString.contramap[GameResult](_.label)
   )
-
   implicit val playerGameSummaryCodec: Codec[PlayerGameSummary] = deriveCodec[PlayerGameSummary]
-
   implicit val playerHistoryCodec: Codec[PlayerHistory] = deriveCodec[PlayerHistory]
 
   // Player sessions: the live "what am I in?" view, completed directly like LobbiesListed. ActiveGameSummary reuses the
   // canonical GameType wire format; the lobbies field reuses the shared LobbyMetadata codec, matching the /lobby shape.
   implicit val activeGameSummaryCodec: Codec[ActiveGameSummary] = deriveCodec[ActiveGameSummary]
-
   implicit val playerSessionsCodec: Codec[PlayerSessions] = deriveCodec[PlayerSessions]
 
   // Game state views
-
   implicit val gridGameStateCodec: Codec[GridGameState] = deriveCodec[GridGameState]
-
   implicit val battleshipStateCodec: Codec[BattleshipState] = deriveCodec[BattleshipState]
-
   implicit val pigStateCodec: Codec[PigState] = deriveCodec[PigState]
-
   implicit val guessResultCodec: Codec[GuessResult] = deriveCodec[GuessResult]
-
   implicit val mastermindStateCodec: Codec[MastermindState] = deriveCodec[MastermindState]
-
   implicit val bidViewCodec: Codec[BidView] = deriveCodec[BidView]
-
   implicit val revealViewCodec: Codec[RevealView] = deriveCodec[RevealView]
-
   implicit val liarsDiceStateCodec: Codec[LiarsDiceState] = deriveCodec[LiarsDiceState]
-
   implicit val holdEmSeatCodec: Codec[HoldEmSeat] = deriveCodec[HoldEmSeat]
-
   implicit val holdEmPotAwardCodec: Codec[HoldEmPotAward] = deriveCodec[HoldEmPotAward]
-
   implicit val holdEmHandResultCodec: Codec[HoldEmHandResult] = deriveCodec[HoldEmHandResult]
-
   implicit val holdEmStateCodec: Codec[HoldEmState] = deriveCodec[HoldEmState]
 
   /** Encoder for the polymorphic `GameState` hierarchy (grid games share `GridGameState`; Battleship has its own

--- a/game-service-server/src/main/scala/com/andy327/server/http/model/Responses.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/model/Responses.scala
@@ -1,0 +1,17 @@
+package com.andy327.server.http.model
+
+/** The single error envelope for every non-2xx HTTP response across the API. Whatever the failure — a validation
+  * rejection, an auth failure, a not-found, a rate-limit, or an internal error translated from an actor reply — the
+  * body is `{ "error": "<human-readable message>" }`, so clients read one shape regardless of which route produced it.
+  *
+  * @param error a human-readable description of what went wrong; not machine-parseable and safe to surface to a user
+  */
+case class ErrorResponse(error: String)
+
+/** An advisory 2xx body carrying a single human-readable message, used where a success has nothing to return but a
+  * note to the caller — e.g. the deliberately non-committal 202 from the forgot-password and resend-verification
+  * endpoints. The body is `{ "message": "<text>" }`.
+  *
+  * @param message a human-readable note about the outcome
+  */
+case class MessageResponse(message: String)

--- a/game-service-server/src/main/scala/com/andy327/server/http/player/PlayerHistory.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/player/PlayerHistory.scala
@@ -1,4 +1,4 @@
-package com.andy327.server.http.auth
+package com.andy327.server.http.player
 
 import java.time.Instant
 

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/AuthRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/AuthRoutes.scala
@@ -44,6 +44,7 @@ import com.andy327.server.http.auth.{
   WhoamiResponse
 }
 import com.andy327.server.http.json.JsonProtocol._
+import com.andy327.server.http.model.{ErrorResponse, MessageResponse}
 
 /** HTTP routes for registration, authentication, and token issuance.
   *
@@ -126,7 +127,7 @@ class AuthRoutes(
   /** A 429 response carrying a `Retry-After` header (at least one second) and a JSON error body. */
   private def tooManyRequests(message: String, retryAfter: scala.concurrent.duration.FiniteDuration): Route =
     respondWithHeader(`Retry-After`(math.max(1L, retryAfter.toSeconds))) {
-      complete(StatusCodes.TooManyRequests -> Map("error" -> message))
+      complete(StatusCodes.TooManyRequests -> ErrorResponse(message))
     }
 
   /** Lockout key for an account, normalized to lower case so it matches regardless of how the email was cased. */
@@ -159,7 +160,7 @@ class AuthRoutes(
             entity(as[RegisterRequest]) { req =>
               AuthValidation.validateRegister(req) match {
                 case Left(error) =>
-                  complete(StatusCodes.BadRequest -> Map("error" -> error))
+                  complete(StatusCodes.BadRequest -> ErrorResponse(error))
                 case Right(valid) =>
                   val registered = identityProvider.register(valid.username, valid.email, valid.password).flatMap {
                     case created @ Right(account) => sendVerification(account).as(created)
@@ -169,7 +170,7 @@ class AuthRoutes(
                     case Right(account) =>
                       complete(StatusCodes.Created -> Map("token" -> tokenFor(account)))
                     case Left(RegisterError.EmailAlreadyRegistered) =>
-                      complete(StatusCodes.Conflict -> Map("error" -> "Email already registered"))
+                      complete(StatusCodes.Conflict -> ErrorResponse("Email already registered"))
                   }
               }
             }
@@ -192,7 +193,7 @@ class AuthRoutes(
             entity(as[LoginRequest]) { req =>
               AuthValidation.validateLogin(req) match {
                 case Left(error) =>
-                  complete(StatusCodes.BadRequest -> Map("error" -> error))
+                  complete(StatusCodes.BadRequest -> ErrorResponse(error))
                 case Right(valid) =>
                   val lockKey = lockoutKey(valid.email)
                   onSuccess(rateLimiter.lockStatus(lockKey).unsafeToFuture()) {
@@ -215,7 +216,7 @@ class AuthRoutes(
                       onSuccess(attempt.unsafeToFuture()) {
                         case Right(account) => complete(Map("token" -> tokenFor(account)))
                         case Left(_)        =>
-                          complete(StatusCodes.Unauthorized -> Map("error" -> "Invalid email or password"))
+                          complete(StatusCodes.Unauthorized -> ErrorResponse("Invalid email or password"))
                       }
                   }
               }
@@ -244,13 +245,13 @@ class AuthRoutes(
               entity(as[ChangePasswordRequest]) { req =>
                 AuthValidation.validatePasswordChange(req) match {
                   case Left(error) =>
-                    complete(StatusCodes.BadRequest -> Map("error" -> error))
+                    complete(StatusCodes.BadRequest -> ErrorResponse(error))
                   case Right(_) =>
                     onSuccess(
                       identityProvider.changePassword(player.id, req.currentPassword, req.newPassword).unsafeToFuture()
                     ) {
                       case Right(_) => revokeTokensThen(player, StatusCodes.NoContent)
-                      case Left(_) => complete(StatusCodes.Forbidden -> Map("error" -> "Current password is incorrect"))
+                      case Left(_)  => complete(StatusCodes.Forbidden -> ErrorResponse("Current password is incorrect"))
                     }
                 }
               }
@@ -288,7 +289,7 @@ class AuthRoutes(
               val settled = dispatch
                 .handleErrorWith(t => IO(logger.warn("forgot-password dispatch failed", t)))
                 .as(StatusCodes.Accepted)
-              onSuccess(settled.unsafeToFuture())(status => complete(status -> Map("status" -> ForgotPasswordMessage)))
+              onSuccess(settled.unsafeToFuture())(status => complete(status -> MessageResponse(ForgotPasswordMessage)))
             }
           }
         }
@@ -308,7 +309,7 @@ class AuthRoutes(
             entity(as[ResetPasswordRequest]) { req =>
               AuthValidation.validateResetPassword(req) match {
                 case Left(error) =>
-                  complete(StatusCodes.BadRequest -> Map("error" -> error))
+                  complete(StatusCodes.BadRequest -> ErrorResponse(error))
                 case Right(_) =>
                   val reset: IO[Boolean] = tokenStore.consume(TokenPurpose.PasswordReset, req.token).flatMap {
                     case Some(accountId) =>
@@ -319,7 +320,7 @@ class AuthRoutes(
                   }
                   onSuccess(reset.unsafeToFuture()) {
                     case true  => complete(StatusCodes.NoContent)
-                    case false => complete(StatusCodes.BadRequest -> Map("error" -> "Invalid or expired reset token"))
+                    case false => complete(StatusCodes.BadRequest -> ErrorResponse("Invalid or expired reset token"))
                   }
               }
             }
@@ -341,7 +342,7 @@ class AuthRoutes(
             entity(as[VerifyEmailRequest]) { req =>
               AuthValidation.validateVerifyEmail(req) match {
                 case Left(error) =>
-                  complete(StatusCodes.BadRequest -> Map("error" -> error))
+                  complete(StatusCodes.BadRequest -> ErrorResponse(error))
                 case Right(_) =>
                   val verified: IO[Boolean] = tokenStore.consume(TokenPurpose.EmailVerification, req.token).flatMap {
                     // markVerified is idempotent, so a fresh token for an already-verified account still 204s.
@@ -351,7 +352,7 @@ class AuthRoutes(
                   onSuccess(verified.unsafeToFuture()) {
                     case true  => complete(StatusCodes.NoContent)
                     case false =>
-                      complete(StatusCodes.BadRequest -> Map("error" -> "Invalid or expired verification token"))
+                      complete(StatusCodes.BadRequest -> ErrorResponse("Invalid or expired verification token"))
                   }
               }
             }
@@ -385,7 +386,7 @@ class AuthRoutes(
                 .handleErrorWith(t => IO(logger.warn("verify-resend dispatch failed", t)))
                 .as(StatusCodes.Accepted)
               onSuccess(settled.unsafeToFuture())(status =>
-                complete(status -> Map("status" -> ResendVerificationMessage))
+                complete(status -> MessageResponse(ResendVerificationMessage))
               )
             }
           }

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/AuthRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/AuthRoutes.scala
@@ -40,6 +40,7 @@ import com.andy327.server.http.auth.{
   RegisterRequest,
   ResendVerificationRequest,
   ResetPasswordRequest,
+  TokenResponse,
   VerifyEmailRequest,
   WhoamiResponse
 }
@@ -168,7 +169,7 @@ class AuthRoutes(
                   }
                   onSuccess(registered.unsafeToFuture()) {
                     case Right(account) =>
-                      complete(StatusCodes.Created -> Map("token" -> tokenFor(account)))
+                      complete(StatusCodes.Created -> TokenResponse(tokenFor(account)))
                     case Left(RegisterError.EmailAlreadyRegistered) =>
                       complete(StatusCodes.Conflict -> ErrorResponse("Email already registered"))
                   }
@@ -214,7 +215,7 @@ class AuthRoutes(
                             .as(failure)
                       }
                       onSuccess(attempt.unsafeToFuture()) {
-                        case Right(account) => complete(Map("token" -> tokenFor(account)))
+                        case Right(account) => complete(TokenResponse(tokenFor(account)))
                         case Left(_)        =>
                           complete(StatusCodes.Unauthorized -> ErrorResponse("Invalid email or password"))
                       }

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/GameRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/GameRoutes.scala
@@ -17,7 +17,6 @@ import com.andy327.actor.core.GameManager
 import com.andy327.actor.core.GameManager.{
   ChatHistory,
   Command,
-  ErrorResponse,
   GameNotFound,
   GameResponse,
   GameStatus,
@@ -30,6 +29,7 @@ import com.andy327.actor.game.{GameOperation, GameRegistry}
 import com.andy327.model.core.GameType
 import com.andy327.server.http.auth.JwtAuthenticator
 import com.andy327.server.http.json.JsonProtocol._
+import com.andy327.server.http.model.ErrorResponse
 import com.andy327.server.http.routes.RouteDirectives._
 
 /** HTTP routes for managing a specific type of game.
@@ -110,15 +110,18 @@ class GameRoutes(
                   case Right(move) =>
                     val op = GameOperation.MakeMove(player.id, move)
                     onSuccess(system.ask[GameResponse](GameManager.RunGameOperation(roomId, op, _))) {
-                      case GameStatus(state)  => complete(state)
-                      case GameNotFound(id)   => complete(StatusCodes.NotFound -> s"No game found for room $id")
-                      case MoveRejected(msg)  => complete(StatusCodes.Conflict -> msg)
-                      case ErrorResponse(msg) => complete(StatusCodes.InternalServerError -> msg)
-                      case unknown => complete(StatusCodes.InternalServerError -> s"Unexpected response: $unknown")
+                      case GameStatus(state) => complete(state)
+                      case GameNotFound(id)  =>
+                        complete(StatusCodes.NotFound -> ErrorResponse(s"No game found for room $id"))
+                      case MoveRejected(msg)              => complete(StatusCodes.Conflict -> ErrorResponse(msg))
+                      case GameManager.ErrorResponse(msg) =>
+                        complete(StatusCodes.InternalServerError -> ErrorResponse(msg))
+                      case unknown =>
+                        complete(StatusCodes.InternalServerError -> ErrorResponse(s"Unexpected response: $unknown"))
                     }
 
                   case Left(decodingError) =>
-                    complete(StatusCodes.BadRequest -> s"Invalid JSON: $decodingError")
+                    complete(StatusCodes.BadRequest -> ErrorResponse(s"Invalid JSON: $decodingError"))
                 }
               }
             }
@@ -135,11 +138,12 @@ class GameRoutes(
         path("status") {
           get {
             onSuccess(system.ask[GameResponse](GameManager.RunGameOperation(roomId, GameOperation.GetState, _))) {
-              case GameStatus(state)  => complete(state)
-              case GameNotFound(id)   => complete(StatusCodes.NotFound -> s"No game found for room $id")
-              case MoveRejected(msg)  => complete(StatusCodes.Conflict -> msg)
-              case ErrorResponse(msg) => complete(StatusCodes.InternalServerError -> msg)
-              case unknown            => complete(StatusCodes.InternalServerError -> s"Unexpected response: $unknown")
+              case GameStatus(state) => complete(state)
+              case GameNotFound(id)  => complete(StatusCodes.NotFound -> ErrorResponse(s"No game found for room $id"))
+              case MoveRejected(msg) => complete(StatusCodes.Conflict -> ErrorResponse(msg))
+              case GameManager.ErrorResponse(msg) => complete(StatusCodes.InternalServerError -> ErrorResponse(msg))
+              case unknown                        =>
+                complete(StatusCodes.InternalServerError -> ErrorResponse(s"Unexpected response: $unknown"))
             }
           }
         } ~
@@ -156,9 +160,10 @@ class GameRoutes(
         path("history") {
           get {
             onSuccess(system.ask[GameResponse](GameManager.GetMoveHistory(roomId, _))) {
-              case history: MoveHistory => complete(history)
-              case ErrorResponse(msg)   => complete(StatusCodes.InternalServerError -> msg)
-              case unknown              => complete(StatusCodes.InternalServerError -> s"Unexpected response: $unknown")
+              case history: MoveHistory           => complete(history)
+              case GameManager.ErrorResponse(msg) => complete(StatusCodes.InternalServerError -> ErrorResponse(msg))
+              case unknown                        =>
+                complete(StatusCodes.InternalServerError -> ErrorResponse(s"Unexpected response: $unknown"))
             }
           }
         } ~
@@ -175,9 +180,10 @@ class GameRoutes(
         path("chat") {
           get {
             onSuccess(system.ask[GameResponse](GameManager.GetChatHistory(roomId, _))) {
-              case history: ChatHistory => complete(history)
-              case ErrorResponse(msg)   => complete(StatusCodes.InternalServerError -> msg)
-              case unknown              => complete(StatusCodes.InternalServerError -> s"Unexpected response: $unknown")
+              case history: ChatHistory           => complete(history)
+              case GameManager.ErrorResponse(msg) => complete(StatusCodes.InternalServerError -> ErrorResponse(msg))
+              case unknown                        =>
+                complete(StatusCodes.InternalServerError -> ErrorResponse(s"Unexpected response: $unknown"))
             }
           }
         } ~
@@ -196,9 +202,10 @@ class GameRoutes(
           post {
             authenticator.authenticatePlayer { player =>
               onSuccess(system.ask[GameResponse](GameManager.SubscribePlayerToGame(roomId, player.id, _))) {
-                case ack: SubscribeAcknowledged => complete(ack)
-                case ErrorResponse(msg)         => complete(StatusCodes.BadRequest -> msg)
-                case unknown => complete(StatusCodes.InternalServerError -> s"Unexpected response: $unknown")
+                case ack: SubscribeAcknowledged     => complete(ack)
+                case GameManager.ErrorResponse(msg) => complete(StatusCodes.BadRequest -> ErrorResponse(msg))
+                case unknown                        =>
+                  complete(StatusCodes.InternalServerError -> ErrorResponse(s"Unexpected response: $unknown"))
               }
             }
           } ~
@@ -218,7 +225,8 @@ class GameRoutes(
             authenticator.authenticatePlayer { player =>
               onSuccess(system.ask[GameResponse](GameManager.UnsubscribePlayerFromGame(roomId, player.id, _))) {
                 case ack: UnsubscribeAcknowledged => complete(ack)
-                case unknown => complete(StatusCodes.InternalServerError -> s"Unexpected response: $unknown")
+                case unknown                      =>
+                  complete(StatusCodes.InternalServerError -> ErrorResponse(s"Unexpected response: $unknown"))
               }
             }
           }

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/LobbyRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/LobbyRoutes.scala
@@ -11,7 +11,6 @@ import org.apache.pekko.util.Timeout
 
 import com.andy327.actor.core.GameManager
 import com.andy327.actor.core.GameManager.{
-  ErrorResponse,
   GameForfeited,
   GameResponse,
   GameStarted,
@@ -29,6 +28,7 @@ import com.andy327.actor.lobby.LobbyError
 import com.andy327.model.core.GameType
 import com.andy327.server.http.auth.JwtAuthenticator
 import com.andy327.server.http.json.JsonProtocol._
+import com.andy327.server.http.model.ErrorResponse
 import com.andy327.server.http.routes.RouteDirectives._
 
 /** LobbyRoutes defines the HTTP routes for interacting with multiplayer game lobbies.
@@ -80,14 +80,15 @@ class LobbyRoutes(
               case Some(s) => GameType.fromString(s).toRight(s"Unknown game type: $s").map(Some(_))
             }
             gameTypeResult match {
-              case Left(err)                            => complete(StatusCodes.BadRequest -> err)
-              case Right(_) if page < 1                 => complete(StatusCodes.BadRequest -> "page must be >= 1")
+              case Left(err)            => complete(StatusCodes.BadRequest -> ErrorResponse(err))
+              case Right(_) if page < 1 => complete(StatusCodes.BadRequest -> ErrorResponse("page must be >= 1"))
               case Right(_) if limit < 1 || limit > 100 =>
-                complete(StatusCodes.BadRequest -> "limit must be between 1 and 100")
+                complete(StatusCodes.BadRequest -> ErrorResponse("limit must be between 1 and 100"))
               case Right(gameTypeFilter) =>
                 onSuccess(system.ask[GameResponse](GameManager.ListLobbies(gameTypeFilter, page, limit, _))) {
                   case listed: LobbiesListed => complete(listed)
-                  case other => complete(StatusCodes.InternalServerError -> s"Unexpected response: $other")
+                  case other                 =>
+                    complete(StatusCodes.InternalServerError -> ErrorResponse(s"Unexpected response: $other"))
                 }
             }
         }
@@ -112,13 +113,14 @@ class LobbyRoutes(
           parameter("name".?) { nameParam =>
             authenticator.authenticatePlayer { player =>
               LobbyRoutes.normalizeName(nameParam) match {
-                case Left(err)   => complete(StatusCodes.BadRequest -> err)
+                case Left(err)   => complete(StatusCodes.BadRequest -> ErrorResponse(err))
                 case Right(name) =>
                   onSuccess(
                     system.ask[GameResponse](replyTo => GameManager.CreateLobby(gameType, player, name, replyTo))
                   ) {
                     case created: LobbyCreated => complete(created)
-                    case other => complete(StatusCodes.InternalServerError -> s"Unexpected response: $other")
+                    case other                 =>
+                      complete(StatusCodes.InternalServerError -> ErrorResponse(s"Unexpected response: $other"))
                   }
               }
             }
@@ -140,8 +142,8 @@ class LobbyRoutes(
           get {
             onSuccess(system.ask[GameResponse](replyTo => GameManager.GetLobbyInfo(roomId, replyTo))) {
               case LobbyInfo(metadata)       => complete(metadata)
-              case LobbyErrorResponse(error) => complete(statusFor(error) -> error.message)
-              case other => complete(StatusCodes.InternalServerError -> s"Unexpected response: $other")
+              case LobbyErrorResponse(error) => complete(statusFor(error) -> ErrorResponse(error.message))
+              case other => complete(StatusCodes.InternalServerError -> ErrorResponse(s"Unexpected response: $other"))
             }
           } ~
           /** Cancels a pre-game lobby. Only the host may call this; it ends the lobby for everyone (subscribers
@@ -161,8 +163,8 @@ class LobbyRoutes(
             authenticator.authenticatePlayer { player =>
               onSuccess(system.ask[GameResponse](replyTo => GameManager.CancelLobby(roomId, player.id, replyTo))) {
                 case left @ LobbyLeft(_, _)    => complete(left)
-                case LobbyErrorResponse(error) => complete(statusFor(error) -> error.message)
-                case other => complete(StatusCodes.InternalServerError -> s"Unexpected response: $other")
+                case LobbyErrorResponse(error) => complete(statusFor(error) -> ErrorResponse(error.message))
+                case other => complete(StatusCodes.InternalServerError -> ErrorResponse(s"Unexpected response: $other"))
               }
             }
           }
@@ -183,8 +185,8 @@ class LobbyRoutes(
             authenticator.authenticatePlayer { player =>
               onSuccess(system.ask[GameResponse](replyTo => GameManager.JoinLobby(roomId, player, replyTo))) {
                 case joined: LobbyJoined       => complete(joined)
-                case LobbyErrorResponse(error) => complete(statusFor(error) -> error.message)
-                case other => complete(StatusCodes.InternalServerError -> s"Unexpected response: $other")
+                case LobbyErrorResponse(error) => complete(statusFor(error) -> ErrorResponse(error.message))
+                case other => complete(StatusCodes.InternalServerError -> ErrorResponse(s"Unexpected response: $other"))
               }
             }
           }
@@ -211,9 +213,9 @@ class LobbyRoutes(
               onSuccess(system.ask[GameResponse](replyTo => GameManager.LeaveLobby(roomId, player, replyTo))) {
                 case left @ LobbyLeft(_, _)    => complete(left)
                 case GameForfeited(_, state)   => complete(state)
-                case MoveRejected(msg)         => complete(StatusCodes.Conflict -> msg)
-                case LobbyErrorResponse(error) => complete(statusFor(error) -> error.message)
-                case other => complete(StatusCodes.InternalServerError -> s"Unexpected response: $other")
+                case MoveRejected(msg)         => complete(StatusCodes.Conflict -> ErrorResponse(msg))
+                case LobbyErrorResponse(error) => complete(statusFor(error) -> ErrorResponse(error.message))
+                case other => complete(StatusCodes.InternalServerError -> ErrorResponse(s"Unexpected response: $other"))
               }
             }
           }
@@ -235,8 +237,8 @@ class LobbyRoutes(
             authenticator.authenticatePlayer { player =>
               onSuccess(system.ask[GameResponse](replyTo => GameManager.StartGame(roomId, player.id, replyTo))) {
                 case gs @ GameStarted(_)       => complete(gs)
-                case LobbyErrorResponse(error) => complete(statusFor(error) -> error.message)
-                case other => complete(StatusCodes.InternalServerError -> s"Unexpected response: $other")
+                case LobbyErrorResponse(error) => complete(statusFor(error) -> ErrorResponse(error.message))
+                case other => complete(StatusCodes.InternalServerError -> ErrorResponse(s"Unexpected response: $other"))
               }
             }
           }
@@ -260,10 +262,10 @@ class LobbyRoutes(
               onSuccess(
                 system.ask[GameResponse](replyTo => GameManager.SubscribePlayerToLobby(roomId, player.id, replyTo))
               ) {
-                case ack: SubscribeAcknowledged => complete(ack)
-                case ErrorResponse(msg)         => complete(StatusCodes.BadRequest -> msg)
-                case LobbyErrorResponse(error)  => complete(statusFor(error) -> error.message)
-                case other => complete(StatusCodes.InternalServerError -> s"Unexpected response: $other")
+                case ack: SubscribeAcknowledged     => complete(ack)
+                case GameManager.ErrorResponse(msg) => complete(StatusCodes.BadRequest -> ErrorResponse(msg))
+                case LobbyErrorResponse(error)      => complete(statusFor(error) -> ErrorResponse(error.message))
+                case other => complete(StatusCodes.InternalServerError -> ErrorResponse(s"Unexpected response: $other"))
               }
             }
           } ~
@@ -284,7 +286,7 @@ class LobbyRoutes(
                 system.ask[GameResponse](replyTo => GameManager.UnsubscribePlayerFromLobby(roomId, player.id, replyTo))
               ) {
                 case ack: UnsubscribeAcknowledged => complete(ack)
-                case other => complete(StatusCodes.InternalServerError -> s"Unexpected response: $other")
+                case other => complete(StatusCodes.InternalServerError -> ErrorResponse(s"Unexpected response: $other"))
               }
             }
           }

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/PlayerRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/PlayerRoutes.scala
@@ -14,9 +14,10 @@ import org.apache.pekko.util.Timeout
 import com.andy327.actor.core.GameManager
 import com.andy327.actor.core.GameManager.{GameResponse, PlayerSessions}
 import com.andy327.persistence.db.{InMemoryPlayerHistoryRepository, PlayerHistoryRepository}
-import com.andy327.server.http.auth.{JwtAuthenticator, PlayerGameSummary, PlayerHistory}
+import com.andy327.server.http.auth.JwtAuthenticator
 import com.andy327.server.http.json.JsonProtocol._
 import com.andy327.server.http.model.ErrorResponse
+import com.andy327.server.http.player.{PlayerGameSummary, PlayerHistory}
 
 /** HTTP routes for a player's own data: their current participation and their completed-game history.
   *

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/PlayerRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/PlayerRoutes.scala
@@ -16,6 +16,7 @@ import com.andy327.actor.core.GameManager.{GameResponse, PlayerSessions}
 import com.andy327.persistence.db.{InMemoryPlayerHistoryRepository, PlayerHistoryRepository}
 import com.andy327.server.http.auth.{JwtAuthenticator, PlayerGameSummary, PlayerHistory}
 import com.andy327.server.http.json.JsonProtocol._
+import com.andy327.server.http.model.ErrorResponse
 
 /** HTTP routes for a player's own data: their current participation and their completed-game history.
   *
@@ -55,7 +56,7 @@ class PlayerRoutes(
         authenticator.authenticatePlayer { player =>
           onSuccess(system.ask[GameResponse](GameManager.GetPlayerSessions(player.id, _))) {
             case sessions: PlayerSessions => complete(sessions)
-            case other                    => complete(StatusCodes.InternalServerError -> s"Unexpected response: $other")
+            case other => complete(StatusCodes.InternalServerError -> ErrorResponse(s"Unexpected response: $other"))
           }
         }
       }

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -10,14 +10,7 @@ import io.circe.syntax._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import com.andy327.actor.core.GameManager.{
-  ErrorResponse,
-  LobbyCreated,
-  LobbyJoined,
-  LobbyLeft,
-  MoveHistory,
-  SubscribeAcknowledged
-}
+import com.andy327.actor.core.GameManager.{LobbyCreated, LobbyJoined, LobbyLeft, MoveHistory, SubscribeAcknowledged}
 import com.andy327.actor.core.PlayerEvent
 import com.andy327.actor.game.{
   BattleshipState,
@@ -40,6 +33,7 @@ import com.andy327.model.connectfour.ConnectFour
 import com.andy327.model.core.GameType
 import com.andy327.model.tictactoe.TicTacToe
 import com.andy327.persistence.db.MoveRecord
+import com.andy327.server.http.model.{ErrorResponse, MessageResponse}
 
 /** Covers the codecs JsonProtocol owns: the API response types, the GridGameState view, and the write-only PlayerEvent
   * encoder. The reused value codecs (Player, GameType, GameLifecycleStatus, LobbyMetadata) are tested at their source
@@ -87,6 +81,16 @@ class SerializationSpec extends AnyWordSpec with Matchers {
     "round-trip serialize and deserialize" in {
       val error = ErrorResponse("Something went wrong")
       error.asJson.as[ErrorResponse] shouldBe Right(error)
+    }
+
+    "serialize to an object with a single `error` field" in {
+      ErrorResponse("nope").asJson shouldBe Json.obj("error" -> "nope".asJson)
+    }
+  }
+
+  "MessageResponse codec" should {
+    "serialize to an object with a single `message` field" in {
+      MessageResponse("done").asJson shouldBe Json.obj("message" -> "done".asJson)
     }
   }
 

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -33,6 +33,7 @@ import com.andy327.model.connectfour.ConnectFour
 import com.andy327.model.core.GameType
 import com.andy327.model.tictactoe.TicTacToe
 import com.andy327.persistence.db.MoveRecord
+import com.andy327.server.http.auth.TokenResponse
 import com.andy327.server.http.model.{ErrorResponse, MessageResponse}
 
 /** Covers the codecs JsonProtocol owns: the API response types, the GridGameState view, and the write-only PlayerEvent
@@ -91,6 +92,12 @@ class SerializationSpec extends AnyWordSpec with Matchers {
   "MessageResponse codec" should {
     "serialize to an object with a single `message` field" in {
       MessageResponse("done").asJson shouldBe Json.obj("message" -> "done".asJson)
+    }
+  }
+
+  "TokenResponse codec" should {
+    "serialize to an object with a single `token` field" in {
+      TokenResponse("jwt").asJson shouldBe Json.obj("token" -> "jwt".asJson)
     }
   }
 

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/PlayerRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/PlayerRoutesSpec.scala
@@ -25,8 +25,8 @@ import com.andy327.actor.persistence.PersistenceProtocol
 import com.andy327.model.core.{GameType, RoomId}
 import com.andy327.persistence.db.InMemoryPlayerHistoryRepository
 import com.andy327.persistence.db.PlayerHistoryRepository.GameResult
-import com.andy327.server.http.auth.PlayerHistory
 import com.andy327.server.http.json.JsonProtocol._
+import com.andy327.server.http.player.PlayerHistory
 import com.andy327.server.testutil.AuthTestHelper.createTestToken
 
 class PlayerRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {


### PR DESCRIPTION
### Summary

Replaces the ad-hoc `Map[String, String]` response bodies and the raw-string error completions across the HTTP layer with typed wire types and a single error envelope, so every endpoint answers in one predictable shape. The single-string bodies stay wire-compatible (a `Map("error" -> …)` and an `ErrorResponse("…")` serialize identically), so only the deliberate shape changes below move.

### What changed

- **New neutral `com.andy327.server.http.model` package**: `ErrorResponse(error)` is now the single body for every 4xx/5xx, and `MessageResponse(message)` carries advisory 2xx bodies.
- **Auth wire types**: a new `http.auth.AuthResponses` holds `TokenResponse(token)` and `WhoamiResponse` (moved out of its own file). The `POST /auth/register` and `/auth/token` bodies use `TokenResponse`; `JwtAuthenticator` and every `AuthRoutes` error path use `ErrorResponse`.
- **`http.player` package**: `PlayerGameSummary` and `PlayerHistory` move out of the misfiled `http.auth` into `http.player`, where `GET /players/me/history` serves them.
- **Layering fix**: `GameManager.ErrorResponse` and `LobbyErrorResponse` stay actor-internal and are translated to the HTTP `ErrorResponse` at the route boundary, so `JsonProtocol` no longer imports or marshals an actor error type. This removes the `ErrorResponse` name collision and collapses the two former error shapes (auth `{"error":…}` vs. game/lobby raw text) into one.
- **`JsonProtocol` tidy-up**: the codec block is grouped into labeled sections instead of a uniform blank-line-per-codec list, matching the tightly-packed unmarshaller block below it.

### Wire-format changes (intentional)

- Game and lobby error responses were `text/plain` strings; they are now the JSON `{"error": "…"}` envelope, so the whole API shares one error shape.
- The forgot-password and resend-verification advisory 2xx bodies drop the `"status"` key for `"message"` (`MessageResponse`).
- Token and single-string auth error bodies are unchanged on the wire.
