### PR TITLE
Retype the game views to domain types, splitting projection from serialization

### DIFF
--- a/game-service-actor/src/main/scala/com/andy327/actor/battleship/BattleshipActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/battleship/BattleshipActor.scala
@@ -4,17 +4,17 @@ import io.circe.Encoder
 import io.circe.generic.semiauto.deriveEncoder
 
 import com.andy327.actor.core.TurnBasedGameActor
-import com.andy327.actor.game.BattleshipState
+import com.andy327.actor.game.BattleshipView
 import com.andy327.model.battleship.{Battleship, Coord, Fire, Seat}
 
 /** [[core.GameActor]] binding for Battleship.
   *
   * All behavior lives in [[core.TurnBasedGameActor]]; the rules (firing, hit/sink detection, win when a fleet is sunk)
   * live in `model.battleship.Battleship`, and the fog-of-war projection lives in the per-viewer
-  * `GameStateView[Battleship, BattleshipState]`. Player1 is seated first; fleets are placed at random.
+  * `GameProjection[Battleship, BattleshipView]`. Player1 is seated first; fleets are placed at random.
   */
 object BattleshipActor
-    extends TurnBasedGameActor[Battleship, Fire, Seat, BattleshipState](
+    extends TurnBasedGameActor[Battleship, Fire, Seat, BattleshipView](
       players => Battleship.random(players(0), players(1)), {
         // Fire nests a Coord, so its encoder must be in scope to derive the move-log encoder
         implicit val coordEncoder: Encoder[Coord] = deriveEncoder[Coord]

--- a/game-service-actor/src/main/scala/com/andy327/actor/checkers/CheckersActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/checkers/CheckersActor.scala
@@ -4,7 +4,7 @@ import io.circe.syntax._
 import io.circe.{Encoder, Json}
 
 import com.andy327.actor.core.TurnBasedGameActor
-import com.andy327.actor.game.CheckersState
+import com.andy327.actor.game.CheckersView
 import com.andy327.model.checkers.{Checkers, Color, Move, Square}
 
 /** [[core.GameActor]] binding for Checkers.
@@ -16,7 +16,7 @@ import com.andy327.model.checkers.{Checkers, Color, Move, Square}
   * shape the HTTP move endpoint accepts.
   */
 object CheckersActor
-    extends TurnBasedGameActor[Checkers, Move, Color, CheckersState](
+    extends TurnBasedGameActor[Checkers, Move, Color, CheckersView](
       players => Checkers.empty(players(0), players(1)),
       Encoder.instance[Move] { move =>
         def square(sq: Square): Json = Json.obj("row" -> sq.row.asJson, "col" -> sq.col.asJson)

--- a/game-service-actor/src/main/scala/com/andy327/actor/connectfour/ConnectFourActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/connectfour/ConnectFourActor.scala
@@ -3,7 +3,7 @@ package com.andy327.actor.connectfour
 import io.circe.generic.semiauto.deriveEncoder
 
 import com.andy327.actor.core.TurnBasedGameActor
-import com.andy327.actor.game.GridGameState
+import com.andy327.actor.game.GridGameView
 import com.andy327.model.connectfour.{ConnectFour, Drop, Mark}
 
 /** [[core.GameActor]] binding for ConnectFour.
@@ -12,7 +12,7 @@ import com.andy327.model.connectfour.{ConnectFour, Drop, Mark}
   * order) live in `model.connectfour.ConnectFour`. Red is seated first and moves first, Yellow second.
   */
 object ConnectFourActor
-    extends TurnBasedGameActor[ConnectFour, Drop, Mark, GridGameState](
+    extends TurnBasedGameActor[ConnectFour, Drop, Mark, GridGameView](
       players => ConnectFour.empty(players(0), players(1)),
       deriveEncoder[Drop]
     )

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/GameActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/GameActor.scala
@@ -4,7 +4,7 @@ import org.apache.pekko.actor.typed.scaladsl.Behaviors
 import org.apache.pekko.actor.typed.{ActorRef, Behavior, Terminated}
 
 import com.andy327.actor.events.EventPublisher
-import com.andy327.actor.game.GameState
+import com.andy327.actor.game.GameView
 import com.andy327.actor.persistence.PersistenceProtocol
 import com.andy327.model.core.{Game, GameError, GameType, GameTypeTag, MatchId, PlayerId, RoomId}
 
@@ -85,7 +85,7 @@ trait GameActor[G <: Game[_, _, _, _, _]] {
 
   /** Produce the game-specific Subscribe command that registers `playerRef` (the session for `playerId`) for push
     * events. The `playerId` lets the actor render each subscriber's own view — full-information games ignore it,
-    * hidden-state games use it for per-viewer serialization.
+    * hidden-state games use it for per-viewer projection.
     */
   def subscribeCommand(playerRef: ActorRef[PlayerActor.Command], playerId: PlayerId): GameActor.GameCommand
 
@@ -102,7 +102,7 @@ trait GameActor[G <: Game[_, _, _, _, _]] {
     * replying to `replyTo` with the leaver's view of the resulting state or a `GameError` if the leave is rejected.
     * Lets GameManager trigger a forfeit without knowing the game's concrete move/command types.
     */
-  def forfeitCommand(playerId: PlayerId, replyTo: ActorRef[Either[GameError, GameState]]): GameActor.GameCommand
+  def forfeitCommand(playerId: PlayerId, replyTo: ActorRef[Either[GameError, GameView]]): GameActor.GameCommand
 
   /** Extract the snapshot-save result from `cmd` if it is a `SnapshotSaved` message, otherwise `None`.
     *
@@ -111,13 +111,13 @@ trait GameActor[G <: Game[_, _, _, _, _]] {
     */
   protected def snapshotSavedResult(cmd: Command): Option[Either[Throwable, Unit]]
 
-  /** Extract the `replyTo` ref from `cmd` if it is a command that expects a `GameError`/`GameState` reply (a move,
+  /** Extract the `replyTo` ref from `cmd` if it is a command that expects a `GameError`/`GameView` reply (a move,
     * a leave, or a state read), otherwise `None`.
     *
     * Used by [[terminating]] to answer a request that lands in the brief window between game completion and the
     * final snapshot being confirmed, rather than leaving the caller's `ask` to time out silently.
     */
-  protected def replyToInTerminating(cmd: Command): Option[ActorRef[Either[GameError, GameState]]]
+  protected def replyToInTerminating(cmd: Command): Option[ActorRef[Either[GameError, GameView]]]
 
   /** Waits for the final snapshot confirmation after a game ends, then stops the actor.
     *

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
@@ -14,7 +14,7 @@ import org.apache.pekko.util.Timeout
 
 import com.andy327.actor.chat.{ChatRepository, NoOpChatRepository}
 import com.andy327.actor.events.{EventPublisher, GameEvent, NoOpEventPublisher}
-import com.andy327.actor.game.{GameOperation, GameRegistry, GameState}
+import com.andy327.actor.game.{GameOperation, GameRegistry, GameView}
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyError, LobbyMetadata, LobbyRepository, Player}
 import com.andy327.actor.persistence.PersistenceProtocol
 import com.andy327.actor.tracing.{TraceCollector, TraceEvent, TracingConfig, TracingInterceptor}
@@ -195,15 +195,15 @@ object GameManager {
       subscribers: Map[PlayerId, ActorRef[PlayerActor.Command]] = Map.empty
   ) extends Command
 
-  /** Adapter wrapper — converts a game actor's `Either[GameError, GameState]` reply into a [[GameResponse]]. */
-  final private case class WrappedGameResponse(response: Either[GameError, GameState], replyTo: ActorRef[GameResponse])
+  /** Adapter wrapper — converts a game actor's `Either[GameError, GameView]` reply into a [[GameResponse]]. */
+  final private case class WrappedGameResponse(response: Either[GameError, GameView], replyTo: ActorRef[GameResponse])
       extends Command
 
   /** Adapter wrapper — converts a game actor's forfeit reply (from a `LeaveLobby` on an in-progress game) into a
     * [[GameForfeited]] on success or a [[MoveRejected]] if the model rejected the leave.
     */
   final private case class WrappedForfeitResponse(
-      response: Either[GameError, GameState],
+      response: Either[GameError, GameView],
       roomId: RoomId,
       replyTo: ActorRef[GameResponse]
   ) extends Command
@@ -311,10 +311,10 @@ object GameManager {
 
   // Game responses
   final case class GameStarted(roomId: RoomId) extends GameResponse
-  final case class GameStatus(state: GameState) extends GameResponse
+  final case class GameStatus(state: GameView) extends GameResponse
 
   /** A player left an in-progress game and thereby forfeited it; `state` is the leaver's view of the finished game. */
-  final case class GameForfeited(roomId: RoomId, state: GameState) extends GameResponse
+  final case class GameForfeited(roomId: RoomId, state: GameView) extends GameResponse
 
   /** The ordered move history for a game; `moves` is empty if the game has no recorded moves. */
   final case class MoveHistory(roomId: RoomId, moves: List[MoveRecord]) extends GameResponse
@@ -580,7 +580,7 @@ object GameManager {
             // game in progress: leaving it is a forfeit, handled by the game actor (which then self-completes and
             // triggers GameCompleted -> MarkCompleted, moving the lobby to Completed)
             case Some((gameType, _, gameActor)) =>
-              val adaptedRef: ActorRef[Either[GameError, GameState]] =
+              val adaptedRef: ActorRef[Either[GameError, GameView]] =
                 context.messageAdapter(response => WrappedForfeitResponse(response, roomId, replyTo))
               gameActor ! GameRegistry.forType(gameType).actor.forfeitCommand(player.id, adaptedRef)
             // pre-game (or unknown) lobby: ordinary leave / host-cancel handled by LobbyManager as before
@@ -838,7 +838,7 @@ object GameManager {
         case RunGameOperation(roomId, op, replyTo) =>
           activeGames.get(roomId) match {
             case Some((gameType, _, gameActor)) =>
-              val adaptedRef: ActorRef[Either[GameError, GameState]] =
+              val adaptedRef: ActorRef[Either[GameError, GameView]] =
                 context.messageAdapter(response => WrappedGameResponse(response, replyTo))
 
               GameRegistry.forType(gameType).module.toGameCommand(op, adaptedRef) match {
@@ -870,7 +870,7 @@ object GameManager {
         case CompletedGameLoaded(result, roomId, gameType, replyTo) =>
           result match {
             case Right(Some(game)) =>
-              replyTo ! GameStatus(GameRegistry.forType(gameType).serializeGame(game, None))
+              replyTo ! GameStatus(GameRegistry.forType(gameType).projectGame(game, None))
             case Right(None) =>
               context.log.warn(s"Completed game $roomId has no record in the database")
               replyTo ! GameNotFound(roomId)

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/PlayerEvent.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/PlayerEvent.scala
@@ -2,7 +2,7 @@ package com.andy327.actor.core
 
 import java.time.Instant
 
-import com.andy327.actor.game.GameState
+import com.andy327.actor.game.GameView
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyMetadata}
 import com.andy327.model.core.{PlayerId, RoomId}
 
@@ -28,7 +28,7 @@ object PlayerEvent {
     * @param state the full updated board state, rendered for the receiving subscriber
     * @param spectatorCount connected subscribers who are not one of the match's seated players
     */
-  final case class GameStateUpdated(roomId: RoomId, state: GameState, spectatorCount: Int) extends PlayerEvent
+  final case class GameStateUpdated(roomId: RoomId, state: GameView, spectatorCount: Int) extends PlayerEvent
 
   /** The game has ended.
     *

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/TurnBasedGameActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/TurnBasedGameActor.scala
@@ -8,7 +8,7 @@ import org.apache.pekko.actor.typed.scaladsl.{ActorContext, Behaviors, TimerSche
 import org.apache.pekko.actor.typed.{ActorRef, Behavior, Terminated}
 
 import com.andy327.actor.events.{EventPublisher, GameEvent}
-import com.andy327.actor.game.{GameState, GameStateView}
+import com.andy327.actor.game.{GameProjection, GameView}
 import com.andy327.actor.lobby.GameLifecycleStatus
 import com.andy327.actor.persistence.PersistenceProtocol
 import com.andy327.model.core.{
@@ -35,17 +35,17 @@ object TurnBasedGameActor {
   sealed trait Command[+M] extends GameActor.GameCommand
 
   /** Attempt to apply `move` on behalf of `playerId`. */
-  final case class MakeMove[M](playerId: PlayerId, move: M, replyTo: ActorRef[Either[GameError, GameState]])
+  final case class MakeMove[M](playerId: PlayerId, move: M, replyTo: ActorRef[Either[GameError, GameView]])
       extends Command[M]
 
   /** Apply the effect of `playerId` leaving the game (a forfeit for two-player games). Replies with the leaver's view
     * of the resulting state, or a `GameError` if the model rejects the leave (e.g. not a participant, or unsupported).
     */
-  final case class PlayerLeft(playerId: PlayerId, replyTo: ActorRef[Either[GameError, GameState]])
+  final case class PlayerLeft(playerId: PlayerId, replyTo: ActorRef[Either[GameError, GameView]])
       extends Command[Nothing]
 
-  /** Return the current serialized game state without mutating it. */
-  final case class GetState(replyTo: ActorRef[Either[GameError, GameState]]) extends Command[Nothing]
+  /** Return the current game state, projected for a spectator, without mutating it. */
+  final case class GetState(replyTo: ActorRef[Either[GameError, GameView]]) extends Command[Nothing]
 
   /** Register a PlayerActor (the session for `playerId`) to receive push events (state updates and game-end
     * notifications). `playerId` identifies the viewer so each subscriber can be sent their own rendering of the state.
@@ -99,12 +99,12 @@ object TurnBasedGameActor {
   *
   * Adding a new game type therefore requires no actor code beyond a binding:
   * {{{
-  *   object MyGameActor extends TurnBasedGameActor[MyGame, MyMove, MySeat, MyGameState](
+  *   object MyGameActor extends TurnBasedGameActor[MyGame, MyMove, MySeat, MyGameView](
   *     players => MyGame.empty(players(0), players(1)),
   *     deriveEncoder[MyMove]
   *   )
   * }}}
-  * given a `GameTypeTag[MyGame]` (model) and a `GameStateView[MyGame, MyGameState]` (http.json) instance.
+  * given a `GameTypeTag[MyGame]` (model) and a `GameProjection[MyGame, MyGameView]` (game package) instance.
   *
   * @param newGame factory producing the initial game model from the seated players; the player count has already been
   *                validated against the GameType's bounds by [[GameManager]]
@@ -112,13 +112,13 @@ object TurnBasedGameActor {
   * @tparam G the concrete game model type
   * @tparam M the game's move type
   * @tparam P the game's player-token (seat) type
-  * @tparam S the serializable view produced for HTTP/WebSocket delivery
+  * @tparam S the per-viewer view type fanned out to subscribers and returned to callers
   * @see [[GameActor]] for the full actor lifecycle and behavioral contract.
   */
-class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <: GameState](
+class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <: GameView](
     newGame: Seq[PlayerId] => G,
     moveEncoder: Encoder[M]
-)(implicit tag: GameTypeTag[G], view: GameStateView[G, S], ct: ClassTag[G])
+)(implicit tag: GameTypeTag[G], view: GameProjection[G, S], ct: ClassTag[G])
     extends GameActor[G] {
 
   import TurnBasedGameActor._
@@ -143,7 +143,7 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
 
   override def forfeitCommand(
       playerId: PlayerId,
-      replyTo: ActorRef[Either[GameError, GameState]]
+      replyTo: ActorRef[Either[GameError, GameView]]
   ): GameActor.GameCommand =
     PlayerLeft(playerId, replyTo)
 
@@ -152,7 +152,7 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
     case _                     => None
   }
 
-  override protected def replyToInTerminating(cmd: Command): Option[ActorRef[Either[GameError, GameState]]] =
+  override protected def replyToInTerminating(cmd: Command): Option[ActorRef[Either[GameError, GameView]]] =
     cmd match {
       case MakeMove(_, _, replyTo) => Some(replyTo)
       case PlayerLeft(_, replyTo)  => Some(replyTo)
@@ -268,7 +268,7 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
       subscribers: Map[ActorRef[PlayerActor.Command], PlayerId],
       publisher: EventPublisher,
       forfeit: Boolean,
-      replyTo: ActorRef[Either[GameError, GameState]],
+      replyTo: ActorRef[Either[GameError, GameView]],
       timers: TimerScheduler[Command],
       timeout: Option[FiniteDuration]
   )(appendMove: => Unit = ()): Behavior[Command] = {

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/GameRegistry.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/GameRegistry.scala
@@ -24,11 +24,11 @@ import com.andy327.model.core.{Game, GameType, PlayerId}
 
 /** Groups the [[com.andy327.actor.game.modules.GameModule]] and [[com.andy327.actor.core.GameActor]] implementations for a single game type.
   *
-  * The type parameter `G` ties module and actor together so that `module.serialize` and `actor.create`/`fromSnapshot`
-  * are guaranteed to work with the same concrete game model. The `serializeGame` method is the single place where the
+  * The type parameter `G` ties module and actor together so that `module.project` and `actor.create`/`fromSnapshot`
+  * are guaranteed to work with the same concrete game model. The `projectGame` method is the single place where the
   * existential `Game[_, _, _, _, _]` coming from the database is cast to `G`.
   *
-  * @param module the HTTP-layer plugin (move decoding, command mapping, serialization)
+  * @param module the HTTP-layer plugin (move decoding, command mapping, view projection)
   * @param actor the actor-layer plugin (game creation, snapshot recovery, subscribe)
   * @tparam G the concrete game model type shared by both plugins
   */
@@ -39,8 +39,8 @@ case class GameModuleBundle[G <: Game[_, _, _, _, _]](module: GameModule[G], act
     * The caller must ensure that `game` was loaded using this bundle's `GameType`; the cast is safe because
     * [[GameRegistry]] constructs each bundle with matching `G` types.
     */
-  def serializeGame(game: Game[_, _, _, _, _], viewer: Option[PlayerId]): GameState =
-    module.serialize(game.asInstanceOf[G], viewer)
+  def projectGame(game: Game[_, _, _, _, _], viewer: Option[PlayerId]): GameView =
+    module.project(game.asInstanceOf[G], viewer)
 }
 
 /** Maps each supported `GameType` to its [[GameModuleBundle]].

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
@@ -49,35 +49,37 @@ object GridGameState {
   }
 }
 
-/** Serializable view of a Checkers game.
+/** View of a Checkers game.
   *
-  * The board is full information — every viewer sees the same pieces (`r`/`b` pawns, `R`/`B` kings, `""` empty). Unlike
-  * the shared [[GridGameState]], it also carries `viewerSeat`: the requesting viewer's own color (`"R"`/`"B"`, or `None`
-  * for a spectator), so the client can tell a player which side they are and whether it is their turn.
+  * The board is full information — every viewer sees the same pieces — and cells carry the `Piece` itself, so a
+  * consumer reasoning about the position has the piece's color and crown in hand; the encoder renders them to the
+  * `r`/`b` pawn and `R`/`B` king tokens.
   *
-  * @param viewerSeat the color the viewer plays (`"R"`/`"B"`), or `None` for a spectator
+  * @param viewerSeat the color the viewer plays, or `None` for a spectator, letting a client tell a player which side
+  *                   they are and whether it is their turn
+  * @param legalMoves the moves `currentPlayer` may play right now, empty once the game is over. Captures being
+  *                   mandatory, this lists only jumps whenever any exist. Not part of the wire format, so the encoder
+  *                   omits it.
   */
 case class CheckersState(
-    board: Vector[Vector[String]],
-    currentPlayer: String,
-    winner: Option[String],
-    viewerSeat: Option[String]
+    board: Vector[Vector[Option[Piece]]],
+    currentPlayer: Color,
+    winner: Option[Color],
+    viewerSeat: Option[Color],
+    legalMoves: List[MovePayload]
 ) extends GameState
 
 object CheckersState {
 
   /** Builds the view of `game` for the given viewer color (`None` = spectator). The board is identical for everyone. */
-  def of(game: Checkers, viewerSeat: Option[Color]): CheckersState = {
-    val cells = game.board.map(_.map {
-      case Some(Piece(color, isKing)) => if (isKing) color.symbol else color.symbol.toLowerCase
-      case None                       => ""
-    })
-    val winner = game.gameStatus match {
-      case Won(color) => Some(color.symbol)
-      case _          => None
-    }
-    CheckersState(cells, game.currentPlayer.symbol, winner, viewerSeat.map(_.symbol))
-  }
+  def of(game: Checkers, viewerSeat: Option[Color]): CheckersState =
+    CheckersState(
+      board = game.board,
+      currentPlayer = game.currentPlayer,
+      winner = game.winner,
+      viewerSeat = viewerSeat,
+      legalMoves = game.legalMoves.map(move => MovePayload.CheckersMove(move.from, move.steps))
+    )
 }
 
 /** Serializable, per-viewer view of a Battleship game.

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
@@ -3,7 +3,7 @@ package com.andy327.actor.game
 import com.andy327.model.battleship.{Battleship, Coord, Player1, Player2, PlayerBoard, Seat}
 import com.andy327.model.checkers.{Checkers, Color, Piece}
 import com.andy327.model.connectfour.ConnectFour
-import com.andy327.model.core.{Draw, Game, GameStatus, Mark, PlayerId, Won}
+import com.andy327.model.core.{Draw, Game, GameStatus, InProgress, Mark, PlayerId, Won}
 import com.andy327.model.holdem.TexasHoldEm
 import com.andy327.model.liarsdice.{Bid, LiarsDice}
 import com.andy327.model.mastermind.{Codemaker, Mastermind, Role}
@@ -18,8 +18,8 @@ sealed trait GameState
 /** View of any grid-based game state, shared by every game whose state is a board of cells each holding an optional
   * mark.
   *
-  * Marks are kept as `Mark` rather than flattened to their symbols: rendering a mark to a string is the encoder's
-  * job, so a consumer that needs to reason about the board (rather than display it) does not have to parse it back.
+  * Cells carry the `Mark` itself, so a consumer reasoning about the board has the domain value in hand; rendering a
+  * mark to its symbol belongs to the encoder.
   *
   * @param legalMoves the moves `currentPlayer` may play right now, empty once the game is over. Carried for consumers
   *                   that choose or offer a move; not part of the wire format, so the encoder omits it.
@@ -123,30 +123,43 @@ object BattleshipState {
   }
 }
 
-/** Serializable view of a Pig game, pushed to all clients over WebSocket.
+/** View of a Pig game. Pig hides nothing, so every viewer sees the same state bar their own `viewerSeat`.
   *
-  * Scores are indexed in seat order: `"P1"` → index 0, `"P2"` → index 1, etc. `viewerSeat` identifies the viewer
-  * ("P1", "P2", …) or is `None` for a spectator. `lastRoll` is absent at the start of a turn (before any roll).
+  * Seats are zero-based indices — the token the model uses as its player type — and the encoder applies the
+  * `"P1"`/`"P2"` labels. `scores` is indexed in seat order, so `scores(0)` belongs to the seat that moved first.
+  *
+  * @param lastRoll the die value from the most recent roll, absent at the start of a turn
+  * @param legalMoves the moves `currentPlayer` may play right now, empty once the game is over. Not part of the wire
+  *                   format, so the encoder omits it.
   */
 case class PigState(
-    scores: Map[String, Int],
-    currentPlayer: String,
+    scores: Vector[Int],
+    currentPlayer: Int,
     turnScore: Int,
     lastRoll: Option[Int],
-    winner: Option[String],
-    viewerSeat: Option[String]
+    winner: Option[Int],
+    viewerSeat: Option[Int],
+    legalMoves: List[MovePayload]
 ) extends GameState
 
 object PigState {
 
+  /** Pig's move set is the same on every turn: a player may always roll, and may always hold — banking nothing when
+    * their turn score is zero is a legal pass. The die a `Roll` carries is supplied by `PigModule`, so these payloads
+    * name the action alone and the module rolls for it.
+    */
+  private val TurnMoves: List[MovePayload] =
+    List(MovePayload.PigAction("roll"), MovePayload.PigAction("hold"))
+
   def of(game: Pig, viewerSeat: Option[Int]): PigState =
     PigState(
-      scores = game.playerIds.indices.map(i => Pig.seatLabel(i) -> game.scores(i)).toMap,
-      currentPlayer = Pig.seatLabel(game.currentSeat),
+      scores = game.scores,
+      currentPlayer = game.currentSeat,
       turnScore = game.turnScore,
       lastRoll = game.lastRoll,
-      winner = game.winner.map(Pig.seatLabel),
-      viewerSeat = viewerSeat.map(Pig.seatLabel)
+      winner = game.winner,
+      viewerSeat = viewerSeat,
+      legalMoves = if (game.gameStatus == InProgress) TurnMoves else Nil
     )
 }
 

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
@@ -104,20 +104,51 @@ object CheckersState {
     )
 }
 
-/** Serializable, per-viewer view of a Battleship game.
+/** What one cell of a Battleship board looks like to a particular viewer.
   *
-  * `board1` and `board2` are each projected for the requesting viewer: the viewer's own board reveals their ships,
-  * while the opponent's board (and, for a spectator, both boards) is fog-of-war — only fired cells are shown, so ship
-  * positions are never leaked until hit. Each cell is one of `hit`, `miss`, `ship`, `water`, or `unknown`.
+  * A resolved shot shows as [[BattleshipCell.Hit]] or [[BattleshipCell.Miss]] to everyone. The rest of the board
+  * depends on whose waters it is: the viewer's own un-fired cells are [[BattleshipCell.Ship]] or
+  * [[BattleshipCell.Water]], while an opponent's (or, for a spectator, anyone's) un-fired cell is
+  * [[BattleshipCell.Unknown]] — the type has no way to say what lies beneath, which is what keeps a projected board
+  * leak-free by construction.
+  */
+sealed trait BattleshipCell
+
+object BattleshipCell {
+
+  /** A fired cell that struck a ship. */
+  case object Hit extends BattleshipCell
+
+  /** A fired cell that found only water. */
+  case object Miss extends BattleshipCell
+
+  /** An un-fired cell of the viewer's own fleet. */
+  case object Ship extends BattleshipCell
+
+  /** An un-fired, empty cell of the viewer's own waters. */
+  case object Water extends BattleshipCell
+
+  /** An un-fired cell of waters the viewer cannot see into. */
+  case object Unknown extends BattleshipCell
+}
+
+/** Per-viewer view of a Battleship game.
   *
-  * @param viewerSeat the seat the viewer occupies (`"P1"`/`"P2"`), or `None` for a spectator
+  * `board1` and `board2` are each projected for the requesting viewer — see [[BattleshipCell]] for what each cell can
+  * reveal. A viewer's legal shots are exactly the opponent cells still [[BattleshipCell.Unknown]] to them, so the view
+  * derives every field, `legalMoves` included, from what its viewer is entitled to know.
+  *
+  * @param viewerSeat the seat the viewer occupies, or `None` for a spectator
+  * @param legalMoves the moves the viewer may play right now: their own move set on their turn, empty otherwise. Not
+  *                   part of the wire format, so the encoder omits it.
   */
 case class BattleshipState(
-    board1: Vector[Vector[String]],
-    board2: Vector[Vector[String]],
-    currentPlayer: String,
-    winner: Option[String],
-    viewerSeat: Option[String]
+    board1: Vector[Vector[BattleshipCell]],
+    board2: Vector[Vector[BattleshipCell]],
+    currentPlayer: Seat,
+    winner: Option[Seat],
+    viewerSeat: Option[Seat],
+    legalMoves: List[MovePayload]
 ) extends GameState
 
 object BattleshipState {
@@ -127,22 +158,26 @@ object BattleshipState {
     BattleshipState(
       board1 = project(game.board1, revealShips = viewerSeat.contains(Player1)),
       board2 = project(game.board2, revealShips = viewerSeat.contains(Player2)),
-      currentPlayer = game.currentPlayer.symbol,
-      winner = game.winner.map(_.symbol),
-      viewerSeat = viewerSeat.map(_.symbol)
+      currentPlayer = game.currentPlayer,
+      winner = game.winner,
+      viewerSeat = viewerSeat,
+      legalMoves = GameState.movesFor(viewerSeat, game.currentPlayer)(
+        game.legalMoves.map(fire => MovePayload.BattleshipMove(fire.target.row, fire.target.col))
+      )
     )
 
-  /** Projects one player's board to cell tokens. When `revealShips` (the viewer's own board), un-hit ships show as
-    * `ship` and empty cells as `water`; otherwise un-fired cells are `unknown`, hiding ship positions until hit.
+  /** Projects one player's board for a viewer. When `revealShips` (the viewer's own board), un-hit ships show as
+    * [[BattleshipCell.Ship]] and empty cells as [[BattleshipCell.Water]]; otherwise every un-fired cell is
+    * [[BattleshipCell.Unknown]], hiding ship positions until hit.
     */
-  private def project(b: PlayerBoard, revealShips: Boolean): Vector[Vector[String]] = {
+  private def project(b: PlayerBoard, revealShips: Boolean): Vector[Vector[BattleshipCell]] = {
     val shipCells = b.shipCells
     Vector.tabulate(Battleship.Size, Battleship.Size) { (r, c) =>
       val coord = Coord(r, c)
       val isShip = shipCells.contains(coord)
-      if (b.shots.contains(coord)) if (isShip) "hit" else "miss"
-      else if (revealShips) if (isShip) "ship" else "water"
-      else "unknown"
+      if (b.shots.contains(coord)) if (isShip) BattleshipCell.Hit else BattleshipCell.Miss
+      else if (revealShips) if (isShip) BattleshipCell.Ship else BattleshipCell.Water
+      else BattleshipCell.Unknown
     }
   }
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
@@ -4,7 +4,7 @@ import com.andy327.model.battleship.{Battleship, Coord, Player1, Player2, Player
 import com.andy327.model.checkers.{Checkers, Color, Piece}
 import com.andy327.model.connectfour.ConnectFour
 import com.andy327.model.core.{Draw, Game, GameStatus, InProgress, Mark, PlayerId, Won}
-import com.andy327.model.holdem.TexasHoldEm
+import com.andy327.model.holdem.{Action, Card, HandResult, Street, TexasHoldEm}
 import com.andy327.model.liarsdice.{Bid, LiarsDice, Reveal}
 import com.andy327.model.mastermind.{Attempt, Codemaker, Mastermind, Peg, Role}
 import com.andy327.model.pig.Pig
@@ -18,13 +18,18 @@ sealed trait GameState
 object GameState {
 
   /** The moves the viewer occupying `viewerSeat` may play right now: their own move set while it is their turn, and
-    * nothing otherwise, since a viewer waiting on an opponent — or a spectator, holding no seat at all — has no move to
-    * make. `moves` is by-name, so a view rendered for anyone but the player to act never pays to enumerate.
+    * `whenNotToAct` otherwise, since a viewer waiting on an opponent — or a spectator, holding no seat at all — has no
+    * move to make. `moves` is by-name, so a view rendered for anyone but the player to act never pays to build it.
+    * `M` is whatever shape the game represents its move set in: most views list their moves, while a range of sizings
+    * (see [[BetSizing]]) gates its description here the same way.
     */
+  private[game] def movesFor[P, M](viewerSeat: Option[P], currentPlayer: P, whenNotToAct: M)(moves: => M): M =
+    if (viewerSeat.contains(currentPlayer)) moves else whenNotToAct
+
   private[game] def movesFor[P](viewerSeat: Option[P], currentPlayer: P)(
       moves: => List[MovePayload]
   ): List[MovePayload] =
-    if (viewerSeat.contains(currentPlayer)) moves else Nil
+    movesFor(viewerSeat, currentPlayer, List.empty[MovePayload])(moves)
 }
 
 /** View of any grid-based game state, shared by every game whose state is a board of cells each holding an optional
@@ -317,91 +322,92 @@ object LiarsDiceState {
 
 /** One seat's public state in a Texas Hold 'Em view: its chips, what it has committed this hand and this street, and
   * whether it has folded or is all-in. Hole cards are never here — a viewer sees only their own, in [[HoldEmState]].
+  * The seat's index is its position in the view's seat list.
   */
-case class HoldEmSeat(seat: String, stack: Int, committed: Int, bet: Int, folded: Boolean, allIn: Boolean)
+case class HoldEmSeat(stack: Int, committed: Int, bet: Int, folded: Boolean, allIn: Boolean)
 
-/** One pot awarded in a Texas Hold 'Em showdown view: chips, the winning seat labels, and the hand description (absent
-  * when the pot was taken uncontested).
+/** The range of bet or raise sizings open to a Texas Hold 'Em viewer on their turn.
+  *
+  * `action` names the move as the wire knows it — `"bet"` when nothing stands on the street, `"raise"` against a
+  * standing bet — and every street-contribution total from `min` to `max` is playable: `max` is the seat's all-in,
+  * and when the stack cannot reach the normal minimum the all-in alone remains, leaving `min == max`. The range is
+  * described rather than enumerated because it is one: sizings are contiguous chip totals, not discrete alternatives.
   */
-case class HoldEmPotAward(amount: Int, winners: List[String], description: Option[String])
+case class BetSizing(action: String, min: Int, max: Int)
 
-/** The public reveal of the most recently finished Texas Hold 'Em hand.
+/** Per-viewer view of a Texas Hold 'Em game.
   *
-  * Every seat that reached the showdown exposes its hole cards here (keyed by seat label); folded hands stay hidden.
-  * Safe to show everyone and retained into the next hand for reconnecting clients, mirroring Liar's Dice's reveal.
-  *
-  * @param board the community cards that were face-up when the hand ended
-  * @param shownHands the hole cards shown at the showdown, keyed by seat label ("P1", "P2", …)
-  * @param awards the pots awarded, main pot first
-  */
-case class HoldEmHandResult(board: List[String], shownHands: Map[String, List[String]], awards: List[HoldEmPotAward])
-
-/** Serializable, per-viewer view of a Texas Hold 'Em game.
-  *
-  * The viewer sees their own hole cards and every seat's public chips/bets, but never another seat's hole cards until a
-  * showdown, which surfaces through `handResult`. `board` holds only the community cards revealed on the current street.
-  * Cards are rendered as their compact text form ("As", "Td"); `street` is the street name.
+  * The viewer sees their own hole cards and every seat's public chips/bets, but never another seat's hole cards until
+  * a showdown, which surfaces through `handResult` — the model's own reveal, carried as-is. `board` holds only the
+  * community cards revealed on the current street. Seats are zero-based indices and cards are the model's own; the
+  * encoder applies the `"P1"`/`"P2"` labels and the compact card text.
   *
   * @param seats every seat's public state, in seat order
   * @param holeCards the viewer's own two hole cards, or `None` for a spectator
   * @param board the community cards revealed so far
-  * @param button the seat label holding the dealer button
-  * @param currentPlayer the seat label whose turn it is
+  * @param button the seat holding the dealer button
   * @param currentBet the amount to match on the current street
   * @param minRaise the smallest total a bet or raise may commit this street
   * @param pot the total chips committed to the pot this hand
   * @param toCall the chips the viewer must put in to call, or 0 for a spectator
-  * @param street the current street ("PreFlop", "Flop", "Turn", "River")
-  * @param winner the winning seat label once the sit-and-go is over, otherwise `None`
-  * @param viewerSeat the viewer's seat label, or `None` for a spectator
   * @param handResult the most recently finished hand's public reveal, or `None` before any hand ends
+  * @param legalMoves the chip-free moves the viewer may play right now: their own move set on their turn, empty
+  *                   otherwise. A bet or raise is a range, not a move, and lives in `betSizing`. Not part of the wire
+  *                   format, so the encoder omits it.
+  * @param betSizing the sizings open to the viewer on their turn, `None` otherwise or when no sizing action is open —
+  *                  see [[BetSizing]]. Not part of the wire format, so the encoder omits it.
   */
 case class HoldEmState(
     seats: List[HoldEmSeat],
-    holeCards: Option[List[String]],
-    board: List[String],
-    button: String,
-    currentPlayer: String,
+    holeCards: Option[List[Card]],
+    board: List[Card],
+    button: Int,
+    currentPlayer: Int,
     currentBet: Int,
     minRaise: Int,
     pot: Int,
     toCall: Int,
-    street: String,
-    winner: Option[String],
-    viewerSeat: Option[String],
-    handResult: Option[HoldEmHandResult]
+    street: Street,
+    winner: Option[Int],
+    viewerSeat: Option[Int],
+    handResult: Option[HandResult],
+    legalMoves: List[MovePayload],
+    betSizing: Option[BetSizing]
 ) extends GameState
 
 object HoldEmState {
 
   /** Builds the view of `game` for the given viewer seat (`None` = spectator, who sees no hole cards). */
-  def of(game: TexasHoldEm, viewerSeat: Option[Int]): HoldEmState = {
-    def label(seat: Int): String = TexasHoldEm.seatLabel(seat)
-    val minRaise = if (game.currentBet == 0) TexasHoldEm.BigBlind else game.currentBet + game.lastRaiseSize
+  def of(game: TexasHoldEm, viewerSeat: Option[Int]): HoldEmState =
     HoldEmState(
       seats = game.playerIds.indices.toList.map { i =>
-        HoldEmSeat(label(i), game.stacks(i), game.committed(i), game.streetContrib(i), game.folded(i), game.allIn(i))
+        HoldEmSeat(game.stacks(i), game.committed(i), game.streetContrib(i), game.folded(i), game.allIn(i))
       },
-      holeCards = viewerSeat.map(seat => game.holeCards(seat).map(_.toString)),
-      board = game.board.take(game.street.revealed).map(_.toString),
-      button = label(game.button),
-      currentPlayer = label(game.toAct),
+      holeCards = viewerSeat.map(game.holeCards),
+      board = game.board.take(game.street.revealed),
+      button = game.button,
+      currentPlayer = game.toAct,
       currentBet = game.currentBet,
-      minRaise = minRaise,
+      minRaise = if (game.currentBet == 0) TexasHoldEm.BigBlind else game.currentBet + game.lastRaiseSize,
       pot = game.pot,
       toCall = viewerSeat.map(game.toCall).getOrElse(0),
-      street = game.street.toString,
-      winner = game.winner.map(label),
-      viewerSeat = viewerSeat.map(label),
-      handResult = game.handResult.map { r =>
-        HoldEmHandResult(
-          board = r.board.map(_.toString),
-          shownHands = r.shownHands.map { case (seat, cs) => label(seat) -> cs.map(_.toString) },
-          awards = r.awards.map(a => HoldEmPotAward(a.amount, a.winners.map(label), a.description))
-        )
-      }
+      street = game.street,
+      winner = game.winner,
+      viewerSeat = viewerSeat,
+      handResult = game.handResult,
+      legalMoves = GameState.movesFor(viewerSeat, game.toAct)(
+        game.legalActions.collect {
+          case Action.Fold  => MovePayload.HoldEmAction("fold", None)
+          case Action.Check => MovePayload.HoldEmAction("check", None)
+          case Action.Call  => MovePayload.HoldEmAction("call", None)
+        }
+      ),
+      betSizing = GameState.movesFor(viewerSeat, game.toAct, Option.empty[BetSizing])(
+        game.betBounds.map { case (min, max) =>
+          BetSizing(if (game.currentBet == 0) "bet" else "raise", min, max)
+        }
+      )
     )
-  }
 }
 
 /** Type class for converting an internal game model into a serializable GameState.

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
@@ -5,7 +5,7 @@ import com.andy327.model.checkers.{Checkers, Color, Piece}
 import com.andy327.model.connectfour.ConnectFour
 import com.andy327.model.core.{Draw, Game, GameStatus, InProgress, Mark, PlayerId, Won}
 import com.andy327.model.holdem.TexasHoldEm
-import com.andy327.model.liarsdice.{Bid, LiarsDice}
+import com.andy327.model.liarsdice.{Bid, LiarsDice, Reveal}
 import com.andy327.model.mastermind.{Attempt, Codemaker, Mastermind, Peg, Role}
 import com.andy327.model.pig.Pig
 import com.andy327.model.tictactoe.TicTacToe
@@ -268,82 +268,51 @@ object MastermindState {
   }
 }
 
-/** One bid in a Liar's Dice view: a quantity plus either a numbered face (2–6) or `None` for a wild "ones" bid. */
-case class BidView(quantity: Int, face: Option[Int])
-
-/** The public reveal of the most recently resolved challenge in a Liar's Dice view.
-  *
-  * Every seat's dice are exposed here (keyed by seat label) because a challenge is the one moment all cups come up;
-  * this snapshot is safe to show everyone and persists into the next round for reconnecting clients.
-  *
-  * @param bid the bid that was challenged
-  * @param count the true number of dice counting toward `bid` (its face plus wild ones)
-  * @param dice every seat's dice at the challenge, keyed by seat label ("P1", "P2", …)
-  * @param challenger the seat that called "Liar"
-  * @param bidder the seat whose bid was challenged
-  * @param loser the seat that lost dice
-  * @param diceLost how many dice `loser` lost (0 when a challenger meets the bid exactly)
-  */
-case class RevealView(
-    bid: BidView,
-    count: Int,
-    dice: Map[String, List[Int]],
-    challenger: String,
-    bidder: String,
-    loser: String,
-    diceLost: Int
-)
-
-/** Serializable, per-viewer view of a Liar's Dice game.
+/** Per-viewer view of a Liar's Dice game.
   *
   * The viewer sees their own current dice and every seat's dice count, but never another seat's current dice — hidden
-  * information stays hidden. `lastReveal` is the exception: it captures all dice at the moment of the last challenge,
-  * which is public once the cups come up.
+  * information stays hidden. `lastReveal` is the exception: it carries the model's own `Reveal`, capturing all dice at
+  * the moment of the last challenge, which is public once the cups come up. Seats are zero-based indices and the bid
+  * and reveal are the model's own types; the encoder applies the `"P1"`/`"P2"` labels.
   *
-  * @param dice the viewer's own current dice, or `None` for a spectator
-  * @param diceCounts dice remaining per seat, keyed by seat label ("P1", "P2", …)
+  * @param dice the viewer's own current dice (empty if eliminated), or `None` for a spectator
+  * @param diceCounts dice remaining per seat, indexed in seat order
   * @param currentBid the standing bid, or `None` at the start of a round
-  * @param currentPlayer the seat label whose turn it is
-  * @param winner the winning seat label once the game is over, otherwise `None`
-  * @param viewerSeat the viewer's seat label, or `None` for a spectator
   * @param lastReveal the most recently resolved challenge, or `None` before any challenge
+  * @param legalMoves the moves the viewer may play right now: their own move set on their turn, empty otherwise —
+  *                   every useful raise (see `LiarsDice.legalBids` for the quantity cap) plus the challenge whenever a
+  *                   standing bid exists. Not part of the wire format, so the encoder omits it.
   */
 case class LiarsDiceState(
-    dice: Option[List[Int]],
-    diceCounts: Map[String, Int],
-    currentBid: Option[BidView],
-    currentPlayer: String,
-    winner: Option[String],
-    viewerSeat: Option[String],
-    lastReveal: Option[RevealView]
+    dice: Option[Vector[Int]],
+    diceCounts: Vector[Int],
+    currentBid: Option[Bid],
+    currentPlayer: Int,
+    winner: Option[Int],
+    viewerSeat: Option[Int],
+    lastReveal: Option[Reveal],
+    legalMoves: List[MovePayload]
 ) extends GameState
 
 object LiarsDiceState {
 
   /** Builds the view of `game` for the given viewer seat (`None` = spectator, who sees dice counts but no hand). */
-  def of(game: LiarsDice, viewerSeat: Option[Int]): LiarsDiceState = {
-    def label(seat: Int): String = LiarsDice.seatLabel(seat)
-    def bidView(bid: Bid): BidView = BidView(bid.quantity, bid.face)
+  def of(game: LiarsDice, viewerSeat: Option[Int]): LiarsDiceState =
     LiarsDiceState(
-      dice = viewerSeat.map(seat => game.dice(seat).toList),
-      diceCounts = game.playerIds.indices.map(i => label(i) -> game.diceCount(i)).toMap,
-      currentBid = game.standing.map(sb => bidView(sb.bid)),
-      currentPlayer = label(game.currentSeat),
-      winner = game.winner.map(label),
-      viewerSeat = viewerSeat.map(label),
-      lastReveal = game.lastReveal.map { r =>
-        RevealView(
-          bid = bidView(r.bid),
-          count = r.count,
-          dice = game.playerIds.indices.map(i => label(i) -> r.allDice(i).toList).toMap,
-          challenger = label(r.challengerSeat),
-          bidder = label(r.bidderSeat),
-          loser = label(r.loserSeat),
-          diceLost = r.diceLost
-        )
+      dice = viewerSeat.map(game.dice),
+      diceCounts = game.playerIds.indices.map(game.diceCount).toVector,
+      currentBid = game.standing.map(_.bid),
+      currentPlayer = game.currentSeat,
+      winner = game.winner,
+      viewerSeat = viewerSeat,
+      lastReveal = game.lastReveal,
+      legalMoves = GameState.movesFor(viewerSeat, game.currentSeat) {
+        // the challenge payload names the action alone: the fresh dice a challenge deals are rolled by the module
+        val challenge =
+          if (game.standing.isDefined) List(MovePayload.LiarsDiceAction("challenge", None, None)) else Nil
+        game.legalBids.map(bid => MovePayload.LiarsDiceAction("bid", Some(bid.quantity), bid.face)) ++ challenge
       }
     )
-  }
 }
 
 /** One seat's public state in a Texas Hold 'Em view: its chips, what it has committed this hand and this street, and

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
@@ -15,14 +15,26 @@ import com.andy327.model.tictactoe.TicTacToe
   */
 sealed trait GameState
 
+object GameState {
+
+  /** The moves the viewer occupying `viewerSeat` may play right now: their own move set while it is their turn, and
+    * nothing otherwise, since a viewer waiting on an opponent — or a spectator, holding no seat at all — has no move to
+    * make. `moves` is by-name, so a view rendered for anyone but the player to act never pays to enumerate.
+    */
+  private[game] def movesFor[P](viewerSeat: Option[P], currentPlayer: P)(
+      moves: => List[MovePayload]
+  ): List[MovePayload] =
+    if (viewerSeat.contains(currentPlayer)) moves else Nil
+}
+
 /** View of any grid-based game state, shared by every game whose state is a board of cells each holding an optional
   * mark.
   *
   * Cells carry the `Mark` itself, so a consumer reasoning about the board has the domain value in hand; rendering a
   * mark to its symbol belongs to the encoder.
   *
-  * @param legalMoves the moves `currentPlayer` may play right now, empty once the game is over. Carried for consumers
-  *                   that choose or offer a move; not part of the wire format, so the encoder omits it.
+  * @param legalMoves the moves the viewer may play right now: their own move set on their turn, empty otherwise. Carried
+  *                   for consumers that choose or offer a move; not part of the wire format, so the encoder omits it.
   */
 case class GridGameState(
     board: Vector[Vector[Option[Mark]]],
@@ -34,18 +46,26 @@ case class GridGameState(
 
 object GridGameState {
 
-  /** Builds the view from any board of optional marks plus the game's current player, status, and available moves. */
+  /** Builds the view from any board of optional marks plus the game's current player, status, and the move set to
+    * offer the viewer holding `viewerSeat`.
+    */
   def of(
       board: Vector[Vector[Option[Mark]]],
       currentPlayer: Mark,
       status: GameStatus[Mark],
-      legalMoves: List[MovePayload]
-  ): GridGameState = {
+      viewerSeat: Option[Mark]
+  )(legalMoves: => List[MovePayload]): GridGameState = {
     val winner = status match {
       case Won(mark) => Some(mark)
       case _         => None
     }
-    GridGameState(board, currentPlayer, winner, status == Draw, legalMoves)
+    GridGameState(
+      board,
+      currentPlayer,
+      winner,
+      status == Draw,
+      GameState.movesFor(viewerSeat, currentPlayer)(legalMoves)
+    )
   }
 }
 
@@ -57,9 +77,9 @@ object GridGameState {
   *
   * @param viewerSeat the color the viewer plays, or `None` for a spectator, letting a client tell a player which side
   *                   they are and whether it is their turn
-  * @param legalMoves the moves `currentPlayer` may play right now, empty once the game is over. Captures being
-  *                   mandatory, this lists only jumps whenever any exist. Not part of the wire format, so the encoder
-  *                   omits it.
+  * @param legalMoves the moves the viewer may play right now: their own move set on their turn, empty otherwise.
+  *                   Captures being mandatory, this lists only jumps whenever any exist. Not part of the wire format,
+  *                   so the encoder omits it.
   */
 case class CheckersState(
     board: Vector[Vector[Option[Piece]]],
@@ -78,7 +98,9 @@ object CheckersState {
       currentPlayer = game.currentPlayer,
       winner = game.winner,
       viewerSeat = viewerSeat,
-      legalMoves = game.legalMoves.map(move => MovePayload.CheckersMove(move.from, move.steps))
+      legalMoves = GameState.movesFor(viewerSeat, game.currentPlayer)(
+        game.legalMoves.map(move => MovePayload.CheckersMove(move.from, move.steps))
+      )
     )
 }
 
@@ -131,8 +153,8 @@ object BattleshipState {
   * `"P1"`/`"P2"` labels. `scores` is indexed in seat order, so `scores(0)` belongs to the seat that moved first.
   *
   * @param lastRoll the die value from the most recent roll, absent at the start of a turn
-  * @param legalMoves the moves `currentPlayer` may play right now, empty once the game is over. Not part of the wire
-  *                   format, so the encoder omits it.
+  * @param legalMoves the moves the viewer may play right now: their own move set on their turn, empty otherwise. Not
+  *                   part of the wire format, so the encoder omits it.
   */
 case class PigState(
     scores: Vector[Int],
@@ -161,7 +183,9 @@ object PigState {
       lastRoll = game.lastRoll,
       winner = game.winner,
       viewerSeat = viewerSeat,
-      legalMoves = if (game.gameStatus == InProgress) TurnMoves else Nil
+      legalMoves = GameState.movesFor(viewerSeat, game.currentSeat)(
+        if (game.gameStatus == InProgress) TurnMoves else Nil
+      )
     )
 }
 
@@ -390,21 +414,15 @@ object GameStateView {
 
   /** Type class instance for serializing a TicTacToe game into a GridGameState (same board for every viewer). */
   implicit val ticTacToeView: GameStateView[TicTacToe, GridGameState] =
-    (game, _) =>
-      GridGameState.of(
-        game.board,
-        game.currentPlayer,
-        game.gameStatus,
+    (game, viewer) =>
+      GridGameState.of(game.board, game.currentPlayer, game.gameStatus, viewer.flatMap(game.playerFor))(
         game.legalMoves.map(loc => MovePayload.TicTacToeMove(loc.row, loc.col))
       )
 
   /** Type class instance for serializing a ConnectFour game into a GridGameState (same board for every viewer). */
   implicit val connectFourView: GameStateView[ConnectFour, GridGameState] =
-    (game, _) =>
-      GridGameState.of(
-        game.board,
-        game.currentPlayer,
-        game.gameStatus,
+    (game, viewer) =>
+      GridGameState.of(game.board, game.currentPlayer, game.gameStatus, viewer.flatMap(game.playerFor))(
         game.legalMoves.map(drop => MovePayload.ConnectFourMove(drop.col))
       )
 

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
@@ -15,28 +15,37 @@ import com.andy327.model.tictactoe.TicTacToe
   */
 sealed trait GameState
 
-/** Serializable view of any grid-based game state, suitable for HTTP responses.
+/** View of any grid-based game state, shared by every game whose state is a board of cells each holding an optional
+  * mark.
   *
-  * Shared by every game whose state is a board of cells each holding an optional mark: cells carry the mark's symbol
-  * or `""` when empty, and the current player and winner are identified by their mark symbols.
+  * Marks are kept as `Mark` rather than flattened to their symbols: rendering a mark to a string is the encoder's
+  * job, so a consumer that needs to reason about the board (rather than display it) does not have to parse it back.
+  *
+  * @param legalMoves the moves `currentPlayer` may play right now, empty once the game is over. Carried for consumers
+  *                   that choose or offer a move; not part of the wire format, so the encoder omits it.
   */
 case class GridGameState(
-    board: Vector[Vector[String]],
-    currentPlayer: String,
-    winner: Option[String],
-    draw: Boolean
+    board: Vector[Vector[Option[Mark]]],
+    currentPlayer: Mark,
+    winner: Option[Mark],
+    draw: Boolean,
+    legalMoves: List[MovePayload]
 ) extends GameState
 
 object GridGameState {
 
-  /** Builds the view from any board of optional marks plus the game's current player and status. */
-  def of(board: Vector[Vector[Option[Mark]]], currentPlayer: Mark, status: GameStatus[Mark]): GridGameState = {
-    val cells = board.map(_.map(_.map(_.toString).getOrElse(""))) // string-based representation for JSON
+  /** Builds the view from any board of optional marks plus the game's current player, status, and available moves. */
+  def of(
+      board: Vector[Vector[Option[Mark]]],
+      currentPlayer: Mark,
+      status: GameStatus[Mark],
+      legalMoves: List[MovePayload]
+  ): GridGameState = {
     val winner = status match {
-      case Won(mark) => Some(mark.toString)
+      case Won(mark) => Some(mark)
       case _         => None
     }
-    GridGameState(cells, currentPlayer.toString, winner, status == Draw)
+    GridGameState(board, currentPlayer, winner, status == Draw, legalMoves)
   }
 }
 
@@ -366,11 +375,23 @@ object GameStateView {
 
   /** Type class instance for serializing a TicTacToe game into a GridGameState (same board for every viewer). */
   implicit val ticTacToeView: GameStateView[TicTacToe, GridGameState] =
-    (game, _) => GridGameState.of(game.board, game.currentPlayer, game.gameStatus)
+    (game, _) =>
+      GridGameState.of(
+        game.board,
+        game.currentPlayer,
+        game.gameStatus,
+        game.legalMoves.map(loc => MovePayload.TicTacToeMove(loc.row, loc.col))
+      )
 
   /** Type class instance for serializing a ConnectFour game into a GridGameState (same board for every viewer). */
   implicit val connectFourView: GameStateView[ConnectFour, GridGameState] =
-    (game, _) => GridGameState.of(game.board, game.currentPlayer, game.gameStatus)
+    (game, _) =>
+      GridGameState.of(
+        game.board,
+        game.currentPlayer,
+        game.gameStatus,
+        game.legalMoves.map(drop => MovePayload.ConnectFourMove(drop.col))
+      )
 
   /** Type class instance for serializing a Battleship game, projected per viewer (fog-of-war for hidden boards). */
   implicit val battleshipView: GameStateView[Battleship, BattleshipState] =

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/GameState.scala
@@ -6,7 +6,7 @@ import com.andy327.model.connectfour.ConnectFour
 import com.andy327.model.core.{Draw, Game, GameStatus, InProgress, Mark, PlayerId, Won}
 import com.andy327.model.holdem.TexasHoldEm
 import com.andy327.model.liarsdice.{Bid, LiarsDice}
-import com.andy327.model.mastermind.{Codemaker, Mastermind, Role}
+import com.andy327.model.mastermind.{Attempt, Codemaker, Mastermind, Peg, Role}
 import com.andy327.model.pig.Pig
 import com.andy327.model.tictactoe.TicTacToe
 
@@ -224,27 +224,30 @@ object PigState {
     )
 }
 
-/** One codebreaker guess in a Mastermind view: the guessed colors and its black/white peg feedback. */
-case class GuessResult(pegs: List[String], black: Int, white: Int)
-
-/** Serializable, per-viewer view of a Mastermind game.
+/** Per-viewer view of a Mastermind game.
   *
   * The `secret` is projected for the requesting viewer: the codemaker always sees their own code, and everyone
-  * (codebreaker and spectators) sees it once the game is over — but never before, so guessing stays honest. Guesses and
-  * their feedback are public. `currentPlayer` is `"codemaker"` while the code is unset and `"codebreaker"` afterwards.
+  * (codebreaker and spectators) sees it once the game is over — but never before, so guessing stays honest. Guesses
+  * and their feedback are public, carried as the model's own `Attempt`s; rendering pegs and roles to their names
+  * belongs to the encoder. `currentPlayer` is `Codemaker` while the code is unset and `Codebreaker` afterwards.
+  *
+  * The view carries no `legalMoves`: Mastermind's move space is the constant `Peg.all ^ Mastermind.CodeLength` —
+  * every code of `CodeLength` pegs, for the code-setting and every guess alike — so there is nothing per-state to
+  * enumerate or describe. A consumer choosing a move may act exactly when `viewerRole` matches `currentPlayer` and
+  * `winner` is empty, and builds its code from those two model constants.
   *
   * @param guesses the codebreaker's guesses with feedback, oldest first
-  * @param secret the revealed code (color names), or `None` while it is still hidden from this viewer
+  * @param secret the code, or `None` while it is still hidden from this viewer
   * @param guessesRemaining guesses the codebreaker has left before the codemaker wins by default
-  * @param viewerRole the viewer's role (`"codemaker"`/`"codebreaker"`), or `None` for a spectator
+  * @param viewerRole the viewer's role, or `None` for a spectator
   */
 case class MastermindState(
-    guesses: List[GuessResult],
-    secret: Option[List[String]],
-    currentPlayer: String,
-    winner: Option[String],
+    guesses: List[Attempt],
+    secret: Option[Vector[Peg]],
+    currentPlayer: Role,
+    winner: Option[Role],
     guessesRemaining: Int,
-    viewerRole: Option[String]
+    viewerRole: Option[Role]
 ) extends GameState
 
 object MastermindState {
@@ -255,12 +258,12 @@ object MastermindState {
   def of(game: Mastermind, viewerRole: Option[Role]): MastermindState = {
     val reveal = game.winner.isDefined || viewerRole.contains(Codemaker)
     MastermindState(
-      guesses = game.guesses.map(a => GuessResult(a.guess.map(_.name).toList, a.feedback.black, a.feedback.white)),
-      secret = if (reveal) game.secret.map(_.map(_.name).toList) else None,
-      currentPlayer = game.currentPlayer.label,
-      winner = game.winner.map(_.label),
+      guesses = game.guesses,
+      secret = if (reveal) game.secret else None,
+      currentPlayer = game.currentPlayer,
+      winner = game.winner,
       guessesRemaining = Mastermind.MaxGuesses - game.guesses.size,
-      viewerRole = viewerRole.map(_.label)
+      viewerRole = viewerRole
     )
   }
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/GameView.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/GameView.scala
@@ -10,12 +10,18 @@ import com.andy327.model.mastermind.{Attempt, Codemaker, Mastermind, Peg, Role}
 import com.andy327.model.pig.Pig
 import com.andy327.model.tictactoe.TicTacToe
 
-/** Super-type for all serializable “view” representations of game state that can be sent to the client as part of an
-  * HTTP response.
+/** Super-type for every per-viewer projection of a game's state.
+  *
+  * A view is what one viewer is entitled to see of a game — a seated player their own hand, a spectator the public
+  * table — expressed in the model's own domain types, plus the moves that viewer may play right now. It is produced
+  * by a [[GameProjection]] and consumed in two ways: rendered to JSON by an encoder in the server's `JsonProtocol`
+  * for delivery to clients, and read directly by in-process consumers that reason about the position. Redaction
+  * happens here, at projection time, so a view structurally cannot leak what its viewer must not know; the encoders
+  * are write-only because a projection is lossy by design and cannot be inverted.
   */
-sealed trait GameState
+sealed trait GameView
 
-object GameState {
+object GameView {
 
   /** The moves the viewer occupying `viewerSeat` may play right now: their own move set while it is their turn, and
     * `whenNotToAct` otherwise, since a viewer waiting on an opponent — or a spectator, holding no seat at all — has no
@@ -41,15 +47,15 @@ object GameState {
   * @param legalMoves the moves the viewer may play right now: their own move set on their turn, empty otherwise. Carried
   *                   for consumers that choose or offer a move; not part of the wire format, so the encoder omits it.
   */
-case class GridGameState(
+case class GridGameView(
     board: Vector[Vector[Option[Mark]]],
     currentPlayer: Mark,
     winner: Option[Mark],
     draw: Boolean,
     legalMoves: List[MovePayload]
-) extends GameState
+) extends GameView
 
-object GridGameState {
+object GridGameView {
 
   /** Builds the view from any board of optional marks plus the game's current player, status, and the move set to
     * offer the viewer holding `viewerSeat`.
@@ -59,17 +65,17 @@ object GridGameState {
       currentPlayer: Mark,
       status: GameStatus[Mark],
       viewerSeat: Option[Mark]
-  )(legalMoves: => List[MovePayload]): GridGameState = {
+  )(legalMoves: => List[MovePayload]): GridGameView = {
     val winner = status match {
       case Won(mark) => Some(mark)
       case _         => None
     }
-    GridGameState(
+    GridGameView(
       board,
       currentPlayer,
       winner,
       status == Draw,
-      GameState.movesFor(viewerSeat, currentPlayer)(legalMoves)
+      GameView.movesFor(viewerSeat, currentPlayer)(legalMoves)
     )
   }
 }
@@ -86,24 +92,24 @@ object GridGameState {
   *                   Captures being mandatory, this lists only jumps whenever any exist. Not part of the wire format,
   *                   so the encoder omits it.
   */
-case class CheckersState(
+case class CheckersView(
     board: Vector[Vector[Option[Piece]]],
     currentPlayer: Color,
     winner: Option[Color],
     viewerSeat: Option[Color],
     legalMoves: List[MovePayload]
-) extends GameState
+) extends GameView
 
-object CheckersState {
+object CheckersView {
 
   /** Builds the view of `game` for the given viewer color (`None` = spectator). The board is identical for everyone. */
-  def of(game: Checkers, viewerSeat: Option[Color]): CheckersState =
-    CheckersState(
+  def of(game: Checkers, viewerSeat: Option[Color]): CheckersView =
+    CheckersView(
       board = game.board,
       currentPlayer = game.currentPlayer,
       winner = game.winner,
       viewerSeat = viewerSeat,
-      legalMoves = GameState.movesFor(viewerSeat, game.currentPlayer)(
+      legalMoves = GameView.movesFor(viewerSeat, game.currentPlayer)(
         game.legalMoves.map(move => MovePayload.CheckersMove(move.from, move.steps))
       )
     )
@@ -147,26 +153,26 @@ object BattleshipCell {
   * @param legalMoves the moves the viewer may play right now: their own move set on their turn, empty otherwise. Not
   *                   part of the wire format, so the encoder omits it.
   */
-case class BattleshipState(
+case class BattleshipView(
     board1: Vector[Vector[BattleshipCell]],
     board2: Vector[Vector[BattleshipCell]],
     currentPlayer: Seat,
     winner: Option[Seat],
     viewerSeat: Option[Seat],
     legalMoves: List[MovePayload]
-) extends GameState
+) extends GameView
 
-object BattleshipState {
+object BattleshipView {
 
   /** Builds the view of `game` for the given viewer seat (`None` = spectator, who sees both boards fogged). */
-  def of(game: Battleship, viewerSeat: Option[Seat]): BattleshipState =
-    BattleshipState(
+  def of(game: Battleship, viewerSeat: Option[Seat]): BattleshipView =
+    BattleshipView(
       board1 = project(game.board1, revealShips = viewerSeat.contains(Player1)),
       board2 = project(game.board2, revealShips = viewerSeat.contains(Player2)),
       currentPlayer = game.currentPlayer,
       winner = game.winner,
       viewerSeat = viewerSeat,
-      legalMoves = GameState.movesFor(viewerSeat, game.currentPlayer)(
+      legalMoves = GameView.movesFor(viewerSeat, game.currentPlayer)(
         game.legalMoves.map(fire => MovePayload.BattleshipMove(fire.target.row, fire.target.col))
       )
     )
@@ -196,7 +202,7 @@ object BattleshipState {
   * @param legalMoves the moves the viewer may play right now: their own move set on their turn, empty otherwise. Not
   *                   part of the wire format, so the encoder omits it.
   */
-case class PigState(
+case class PigView(
     scores: Vector[Int],
     currentPlayer: Int,
     turnScore: Int,
@@ -204,9 +210,9 @@ case class PigState(
     winner: Option[Int],
     viewerSeat: Option[Int],
     legalMoves: List[MovePayload]
-) extends GameState
+) extends GameView
 
-object PigState {
+object PigView {
 
   /** Pig's move set is the same on every turn: a player may always roll, and may always hold — banking nothing when
     * their turn score is zero is a legal pass. The die a `Roll` carries is supplied by `PigModule`, so these payloads
@@ -215,15 +221,15 @@ object PigState {
   private val TurnMoves: List[MovePayload] =
     List(MovePayload.PigAction("roll"), MovePayload.PigAction("hold"))
 
-  def of(game: Pig, viewerSeat: Option[Int]): PigState =
-    PigState(
+  def of(game: Pig, viewerSeat: Option[Int]): PigView =
+    PigView(
       scores = game.scores,
       currentPlayer = game.currentSeat,
       turnScore = game.turnScore,
       lastRoll = game.lastRoll,
       winner = game.winner,
       viewerSeat = viewerSeat,
-      legalMoves = GameState.movesFor(viewerSeat, game.currentSeat)(
+      legalMoves = GameView.movesFor(viewerSeat, game.currentSeat)(
         if (game.gameStatus == InProgress) TurnMoves else Nil
       )
     )
@@ -246,23 +252,23 @@ object PigState {
   * @param guessesRemaining guesses the codebreaker has left before the codemaker wins by default
   * @param viewerRole the viewer's role, or `None` for a spectator
   */
-case class MastermindState(
+case class MastermindView(
     guesses: List[Attempt],
     secret: Option[Vector[Peg]],
     currentPlayer: Role,
     winner: Option[Role],
     guessesRemaining: Int,
     viewerRole: Option[Role]
-) extends GameState
+) extends GameView
 
-object MastermindState {
+object MastermindView {
 
   /** Builds the view of `game` for the given viewer role (`None` = spectator). The secret is included only for the
     * codemaker or once the game has ended.
     */
-  def of(game: Mastermind, viewerRole: Option[Role]): MastermindState = {
+  def of(game: Mastermind, viewerRole: Option[Role]): MastermindView = {
     val reveal = game.winner.isDefined || viewerRole.contains(Codemaker)
-    MastermindState(
+    MastermindView(
       guesses = game.guesses,
       secret = if (reveal) game.secret else None,
       currentPlayer = game.currentPlayer,
@@ -288,7 +294,7 @@ object MastermindState {
   *                   every useful raise (see `LiarsDice.legalBids` for the quantity cap) plus the challenge whenever a
   *                   standing bid exists. Not part of the wire format, so the encoder omits it.
   */
-case class LiarsDiceState(
+case class LiarsDiceView(
     dice: Option[Vector[Int]],
     diceCounts: Vector[Int],
     currentBid: Option[Bid],
@@ -297,13 +303,13 @@ case class LiarsDiceState(
     viewerSeat: Option[Int],
     lastReveal: Option[Reveal],
     legalMoves: List[MovePayload]
-) extends GameState
+) extends GameView
 
-object LiarsDiceState {
+object LiarsDiceView {
 
   /** Builds the view of `game` for the given viewer seat (`None` = spectator, who sees dice counts but no hand). */
-  def of(game: LiarsDice, viewerSeat: Option[Int]): LiarsDiceState =
-    LiarsDiceState(
+  def of(game: LiarsDice, viewerSeat: Option[Int]): LiarsDiceView =
+    LiarsDiceView(
       dice = viewerSeat.map(game.dice),
       diceCounts = game.playerIds.indices.map(game.diceCount).toVector,
       currentBid = game.standing.map(_.bid),
@@ -311,7 +317,7 @@ object LiarsDiceState {
       winner = game.winner,
       viewerSeat = viewerSeat,
       lastReveal = game.lastReveal,
-      legalMoves = GameState.movesFor(viewerSeat, game.currentSeat) {
+      legalMoves = GameView.movesFor(viewerSeat, game.currentSeat) {
         // the challenge payload names the action alone: the fresh dice a challenge deals are rolled by the module
         val challenge =
           if (game.standing.isDefined) List(MovePayload.LiarsDiceAction("challenge", None, None)) else Nil
@@ -321,7 +327,7 @@ object LiarsDiceState {
 }
 
 /** One seat's public state in a Texas Hold 'Em view: its chips, what it has committed this hand and this street, and
-  * whether it has folded or is all-in. Hole cards are never here — a viewer sees only their own, in [[HoldEmState]].
+  * whether it has folded or is all-in. Hole cards are never here — a viewer sees only their own, in [[HoldEmView]].
   * The seat's index is its position in the view's seat list.
   */
 case class HoldEmSeat(stack: Int, committed: Int, bet: Int, folded: Boolean, allIn: Boolean)
@@ -357,7 +363,7 @@ case class BetSizing(action: String, min: Int, max: Int)
   * @param betSizing the sizings open to the viewer on their turn, `None` otherwise or when no sizing action is open —
   *                  see [[BetSizing]]. Not part of the wire format, so the encoder omits it.
   */
-case class HoldEmState(
+case class HoldEmView(
     seats: List[HoldEmSeat],
     holeCards: Option[List[Card]],
     board: List[Card],
@@ -373,13 +379,13 @@ case class HoldEmState(
     handResult: Option[HandResult],
     legalMoves: List[MovePayload],
     betSizing: Option[BetSizing]
-) extends GameState
+) extends GameView
 
-object HoldEmState {
+object HoldEmView {
 
   /** Builds the view of `game` for the given viewer seat (`None` = spectator, who sees no hole cards). */
-  def of(game: TexasHoldEm, viewerSeat: Option[Int]): HoldEmState =
-    HoldEmState(
+  def of(game: TexasHoldEm, viewerSeat: Option[Int]): HoldEmView =
+    HoldEmView(
       seats = game.playerIds.indices.toList.map { i =>
         HoldEmSeat(game.stacks(i), game.committed(i), game.streetContrib(i), game.folded(i), game.allIn(i))
       },
@@ -395,14 +401,14 @@ object HoldEmState {
       winner = game.winner,
       viewerSeat = viewerSeat,
       handResult = game.handResult,
-      legalMoves = GameState.movesFor(viewerSeat, game.toAct)(
+      legalMoves = GameView.movesFor(viewerSeat, game.toAct)(
         game.legalActions.collect {
           case Action.Fold  => MovePayload.HoldEmAction("fold", None)
           case Action.Check => MovePayload.HoldEmAction("check", None)
           case Action.Call  => MovePayload.HoldEmAction("call", None)
         }
       ),
-      betSizing = GameState.movesFor(viewerSeat, game.toAct, Option.empty[BetSizing])(
+      betSizing = GameView.movesFor(viewerSeat, game.toAct, Option.empty[BetSizing])(
         game.betBounds.map { case (min, max) =>
           BetSizing(if (game.currentBet == 0) "bet" else "raise", min, max)
         }
@@ -410,75 +416,69 @@ object HoldEmState {
     )
 }
 
-/** Type class for converting an internal game model into a serializable GameState.
+/** Type class projecting a game model into its per-viewer [[GameView]].
   *
-  * Instances live in the companion object, which is always in implicit scope for `GameStateView[G, S]` searches, so
+  * Instances live in the companion object, which is always in implicit scope for `GameProjection[G, V]` searches, so
   * call sites need no imports beyond the types themselves.
   *
-  * `viewer` identifies who the view is being rendered for: `Some(playerId)` for that player's own view, or `None` for a
-  * public/spectator view. Full-information games (TicTacToe, ConnectFour) show everyone the same board and ignore it;
-  * hidden-state games (e.g. Battleship) use it to reveal only what that viewer is allowed to see.
+  * `viewer` identifies who the view is rendered for: `Some(playerId)` for that player's own view, or `None` for a
+  * public/spectator view. Full-information games (TicTacToe, ConnectFour) show everyone the same board and consult it
+  * only to scope the view's legal moves; hidden-state games (e.g. Battleship) also use it to reveal only what that
+  * viewer is allowed to see.
   */
-trait GameStateView[G <: Game[_, _, _, _, _], S <: GameState] {
-  def fromGame(game: G, viewer: Option[PlayerId]): S
+trait GameProjection[G <: Game[_, _, _, _, _], V <: GameView] {
+  def fromGame(game: G, viewer: Option[PlayerId]): V
 }
 
-object GameStateView {
+object GameProjection {
 
-  /** Type class instance for serializing a TicTacToe game into a GridGameState (same board for every viewer). */
-  implicit val ticTacToeView: GameStateView[TicTacToe, GridGameState] =
+  /** Type class instance for projecting a TicTacToe game into a GridGameView (same board for every viewer). */
+  implicit val ticTacToeView: GameProjection[TicTacToe, GridGameView] =
     (game, viewer) =>
-      GridGameState.of(game.board, game.currentPlayer, game.gameStatus, viewer.flatMap(game.playerFor))(
+      GridGameView.of(game.board, game.currentPlayer, game.gameStatus, viewer.flatMap(game.playerFor))(
         game.legalMoves.map(loc => MovePayload.TicTacToeMove(loc.row, loc.col))
       )
 
-  /** Type class instance for serializing a ConnectFour game into a GridGameState (same board for every viewer). */
-  implicit val connectFourView: GameStateView[ConnectFour, GridGameState] =
+  /** Type class instance for projecting a ConnectFour game into a GridGameView (same board for every viewer). */
+  implicit val connectFourView: GameProjection[ConnectFour, GridGameView] =
     (game, viewer) =>
-      GridGameState.of(game.board, game.currentPlayer, game.gameStatus, viewer.flatMap(game.playerFor))(
+      GridGameView.of(game.board, game.currentPlayer, game.gameStatus, viewer.flatMap(game.playerFor))(
         game.legalMoves.map(drop => MovePayload.ConnectFourMove(drop.col))
       )
 
-  /** Type class instance for serializing a Battleship game, projected per viewer (fog-of-war for hidden boards). */
-  implicit val battleshipView: GameStateView[Battleship, BattleshipState] =
-    (game, viewer) => BattleshipState.of(game, viewer.flatMap(game.playerFor))
+  /** Type class instance for projecting a Battleship game, projected per viewer (fog-of-war for hidden boards). */
+  implicit val battleshipView: GameProjection[Battleship, BattleshipView] =
+    (game, viewer) => BattleshipView.of(game, viewer.flatMap(game.playerFor))
 
-  /** Type class instance for serializing a Pig game (same state for every viewer; no hidden information). */
-  implicit val pigView: GameStateView[Pig, PigState] =
-    (game, viewer) => PigState.of(game, viewer.flatMap(game.playerFor))
+  /** Type class instance for projecting a Pig game (same state for every viewer; no hidden information). */
+  implicit val pigView: GameProjection[Pig, PigView] =
+    (game, viewer) => PigView.of(game, viewer.flatMap(game.playerFor))
 
-  /** Type class instance for serializing a Mastermind game, projected per viewer (the secret is hidden until reveal). */
-  implicit val mastermindView: GameStateView[Mastermind, MastermindState] =
-    (game, viewer) => MastermindState.of(game, viewer.flatMap(game.playerFor))
+  /** Type class instance for projecting a Mastermind game, projected per viewer (the secret is hidden until reveal). */
+  implicit val mastermindView: GameProjection[Mastermind, MastermindView] =
+    (game, viewer) => MastermindView.of(game, viewer.flatMap(game.playerFor))
 
-  /** Type class instance for serializing a Liar's Dice game, projected per viewer (only the viewer's own dice show). */
-  implicit val liarsDiceView: GameStateView[LiarsDice, LiarsDiceState] =
-    (game, viewer) => LiarsDiceState.of(game, viewer.flatMap(game.playerFor))
+  /** Type class instance for projecting a Liar's Dice game, projected per viewer (only the viewer's own dice show). */
+  implicit val liarsDiceView: GameProjection[LiarsDice, LiarsDiceView] =
+    (game, viewer) => LiarsDiceView.of(game, viewer.flatMap(game.playerFor))
 
-  /** Type class instance for serializing a Texas Hold 'Em game, projected per viewer (only the viewer's hole cards). */
-  implicit val texasHoldEmView: GameStateView[TexasHoldEm, HoldEmState] =
-    (game, viewer) => HoldEmState.of(game, viewer.flatMap(game.playerFor))
+  /** Type class instance for projecting a Texas Hold 'Em game, projected per viewer (only the viewer's hole cards). */
+  implicit val texasHoldEmView: GameProjection[TexasHoldEm, HoldEmView] =
+    (game, viewer) => HoldEmView.of(game, viewer.flatMap(game.playerFor))
 
-  /** Type class instance for serializing a Checkers game. The board is the same for every viewer; the view is tagged
+  /** Type class instance for projecting a Checkers game. The board is the same for every viewer; the view is tagged
     * with the viewer's own color so the client can show which side they are and whose turn it is.
     */
-  implicit val checkersView: GameStateView[Checkers, CheckersState] =
-    (game, viewer) => CheckersState.of(game, viewer.flatMap(game.playerFor))
-}
+  implicit val checkersView: GameProjection[Checkers, CheckersView] =
+    (game, viewer) => CheckersView.of(game, viewer.flatMap(game.playerFor))
 
-/** Utility for converting internal game models to HTTP-serializable GameState representations using the GameStateView
-  * type class.
-  */
-object GameStateConverters {
-
-  /** Converts a concrete game instance into a corresponding GameState, rendered for `viewer`.
+  /** Projects `game` into its view for `viewer`, resolved through the type class instance for `G`.
     *
-    * This uses a type class instance of GameStateView[G, S], which knows how to convert a specific game type G (e.g.,
-    * TicTacToe) into a specific GameState type S (e.g., GridGameState). `viewer` is `Some(playerId)` for that player's
-    * own view or `None` for a public/spectator view; full-information games ignore it.
+    * `viewer` is `Some(playerId)` for that player's own view or `None` for a public/spectator view; full-information
+    * games ignore it.
     */
-  def serializeGame[G <: Game[_, _, _, _, _], S <: GameState](game: G, viewer: Option[PlayerId])(implicit
-      view: GameStateView[G, S]
-  ): S =
-    view.fromGame(game, viewer)
+  def project[G <: Game[_, _, _, _, _], V <: GameView](game: G, viewer: Option[PlayerId])(implicit
+      projection: GameProjection[G, V]
+  ): V =
+    projection.fromGame(game, viewer)
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/modules/BattleshipModule.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/modules/BattleshipModule.scala
@@ -8,13 +8,13 @@ import org.apache.pekko.actor.typed.ActorRef
 
 import com.andy327.actor.core.{GameActor, TurnBasedGameActor}
 import com.andy327.actor.game.MovePayload.BattleshipMove
-import com.andy327.actor.game.{GameOperation, GameState, GameStateConverters, MovePayload}
+import com.andy327.actor.game.{GameOperation, GameProjection, GameView, MovePayload}
 import com.andy327.model.battleship.{Battleship, Coord, Fire}
 import com.andy327.model.core.{GameError, PlayerId}
 
 /** [[GameModule]] implementation for Battleship.
   *
-  * Provides move decoding, operation-to-command mapping, and per-viewer serialization for Battleship. Enables
+  * Provides move decoding, operation-to-command mapping, and per-viewer projection for Battleship. Enables
   * [[core.GameManager]] and the HTTP routes to handle Battleship games without any game-specific logic.
   */
 object BattleshipModule extends GameModule[Battleship] {
@@ -23,7 +23,7 @@ object BattleshipModule extends GameModule[Battleship] {
 
   override def toGameCommand(
       op: GameOperation,
-      replyTo: ActorRef[Either[GameError, GameState]]
+      replyTo: ActorRef[Either[GameError, GameView]]
   ): Either[GameError, GameActor.GameCommand] = op match {
     case GameOperation.MakeMove(playerId, MovePayload.BattleshipMove(row, col)) =>
       Right(TurnBasedGameActor.MakeMove(playerId, Fire(Coord(row, col)), replyTo))
@@ -36,6 +36,6 @@ object BattleshipModule extends GameModule[Battleship] {
       Right(TurnBasedGameActor.GetState(replyTo))
   }
 
-  override def serialize(game: Battleship, viewer: Option[PlayerId]): GameState =
-    GameStateConverters.serializeGame(game, viewer)
+  override def project(game: Battleship, viewer: Option[PlayerId]): GameView =
+    GameProjection.project(game, viewer)
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/modules/CheckersModule.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/modules/CheckersModule.scala
@@ -8,13 +8,13 @@ import org.apache.pekko.actor.typed.ActorRef
 
 import com.andy327.actor.core.{GameActor, TurnBasedGameActor}
 import com.andy327.actor.game.MovePayload.CheckersMove
-import com.andy327.actor.game.{GameOperation, GameState, GameStateConverters, MovePayload}
+import com.andy327.actor.game.{GameOperation, GameProjection, GameView, MovePayload}
 import com.andy327.model.checkers.{Checkers, Move}
 import com.andy327.model.core.{GameError, PlayerId}
 
 /** [[GameModule]] implementation for Checkers.
   *
-  * Provides move decoding, operation-to-command mapping, and game serialization for Checkers. Enables
+  * Provides move decoding, operation-to-command mapping, and view projection for Checkers. Enables
   * [[core.GameManager]] and the HTTP routes to handle Checkers games without any game-specific logic.
   */
 object CheckersModule extends GameModule[Checkers] {
@@ -23,7 +23,7 @@ object CheckersModule extends GameModule[Checkers] {
 
   override def toGameCommand(
       op: GameOperation,
-      replyTo: ActorRef[Either[GameError, GameState]]
+      replyTo: ActorRef[Either[GameError, GameView]]
   ): Either[GameError, GameActor.GameCommand] = op match {
     case GameOperation.MakeMove(playerId, MovePayload.CheckersMove(from, steps)) =>
       Right(TurnBasedGameActor.MakeMove(playerId, Move(from, steps), replyTo))
@@ -36,6 +36,6 @@ object CheckersModule extends GameModule[Checkers] {
       Right(TurnBasedGameActor.GetState(replyTo))
   }
 
-  override def serialize(game: Checkers, viewer: Option[PlayerId]): GameState =
-    GameStateConverters.serializeGame(game, viewer)
+  override def project(game: Checkers, viewer: Option[PlayerId]): GameView =
+    GameProjection.project(game, viewer)
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/modules/ConnectFourModule.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/modules/ConnectFourModule.scala
@@ -8,13 +8,13 @@ import org.apache.pekko.actor.typed.ActorRef
 
 import com.andy327.actor.core.{GameActor, TurnBasedGameActor}
 import com.andy327.actor.game.MovePayload.ConnectFourMove
-import com.andy327.actor.game.{GameOperation, GameState, GameStateConverters, MovePayload}
+import com.andy327.actor.game.{GameOperation, GameProjection, GameView, MovePayload}
 import com.andy327.model.connectfour.{ConnectFour, Drop}
 import com.andy327.model.core.{GameError, PlayerId}
 
 /** [[GameModule]] implementation for ConnectFour.
   *
-  * Provides move decoding, operation-to-command mapping, and game serialization for ConnectFour. Enables
+  * Provides move decoding, operation-to-command mapping, and view projection for ConnectFour. Enables
   * [[core.GameManager]] and the HTTP routes to handle ConnectFour games without any game-specific logic.
   */
 object ConnectFourModule extends GameModule[ConnectFour] {
@@ -23,7 +23,7 @@ object ConnectFourModule extends GameModule[ConnectFour] {
 
   override def toGameCommand(
       op: GameOperation,
-      replyTo: ActorRef[Either[GameError, GameState]]
+      replyTo: ActorRef[Either[GameError, GameView]]
   ): Either[GameError, GameActor.GameCommand] = op match {
     case GameOperation.MakeMove(playerId, MovePayload.ConnectFourMove(col)) =>
       Right(TurnBasedGameActor.MakeMove(playerId, Drop(col), replyTo))
@@ -36,6 +36,6 @@ object ConnectFourModule extends GameModule[ConnectFour] {
       Right(TurnBasedGameActor.GetState(replyTo))
   }
 
-  override def serialize(game: ConnectFour, viewer: Option[PlayerId]): GameState =
-    GameStateConverters.serializeGame(game, viewer)
+  override def project(game: ConnectFour, viewer: Option[PlayerId]): GameView =
+    GameProjection.project(game, viewer)
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/modules/GameModule.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/modules/GameModule.scala
@@ -4,13 +4,13 @@ import io.circe.Decoder
 import org.apache.pekko.actor.typed.ActorRef
 
 import com.andy327.actor.core.GameActor
-import com.andy327.actor.game.{GameOperation, GameState, MovePayload}
+import com.andy327.actor.game.{GameOperation, GameView, MovePayload}
 import com.andy327.model.core.{Game, GameError, PlayerId}
 
 /** Per-game-type plugin that bridges HTTP-layer concerns to the actor layer.
   *
-  * Parameterized on `G` so that `serialize` is type-safe: the compiler guarantees that the concrete game model passed
-  * to `serialize` matches the game type this module handles. The single cast lives in
+  * Parameterized on `G` so that `project` is type-safe: the compiler guarantees that the concrete game model passed
+  * to `project` matches the game type this module handles. The single cast lives in
   * [[com.andy327.actor.game.GameModuleBundle]] at the DB-deserialization boundary, not here.
   *
   * == Implementing a new game ==
@@ -29,7 +29,7 @@ import com.andy327.model.core.{Game, GameError, PlayerId}
   *     payload (constructing the game's move type), a wrong payload type (return `Left(GameError.Unknown(...))`),
   *     and `GetState`:
   *     {{{
-  *       override def toGameCommand(op: GameOperation, replyTo: ActorRef[Either[GameError, GameState]]) = op match {
+  *       override def toGameCommand(op: GameOperation, replyTo: ActorRef[Either[GameError, GameView]]) = op match {
   *         case GameOperation.MakeMove(playerId, MovePayload.MyGameMove(x, y)) =>
   *           Right(TurnBasedGameActor.MakeMove(playerId, MyMove(x, y), replyTo))
   *         case GameOperation.MakeMove(_, other) =>
@@ -40,12 +40,12 @@ import com.andy327.model.core.{Game, GameError, PlayerId}
   *       }
   *     }}}
   *
-  *  3. `serialize` — convert the game model to its HTTP view for `viewer`. Given a
-  *     [[com.andy327.actor.game.GameStateView]] instance in the `GameStateView` companion, this is always the
+  *  3. `project` — build the game's view for `viewer`. Given a
+  *     [[com.andy327.actor.game.GameProjection]] instance in the `GameProjection` companion, this is always the
   *     same one-liner:
   *     {{{
-  *       override def serialize(game: MyGame, viewer: Option[PlayerId]): GameState =
-  *         GameStateConverters.serializeGame(game, viewer)
+  *       override def project(game: MyGame, viewer: Option[PlayerId]): GameView =
+  *         GameProjection.project(game, viewer)
   *     }}}
   *
   * @tparam G the concrete game model type this module handles
@@ -58,20 +58,19 @@ trait GameModule[G <: Game[_, _, _, _, _]] {
   /** Convert a game-agnostic [[GameOperation]] into a game-specific actor command.
     *
     * @param op the operation to execute (MakeMove or GetState)
-    * @param replyTo the actor that should receive the `Either[GameError, GameState]` result
+    * @param replyTo the actor that should receive the `Either[GameError, GameView]` result
     * @return `Right(command)` ready to send to the game actor, or `Left(error)` if the operation is invalid
     */
   def toGameCommand(
       op: GameOperation,
-      replyTo: ActorRef[Either[GameError, GameState]]
+      replyTo: ActorRef[Either[GameError, GameView]]
   ): Either[GameError, GameActor.GameCommand]
 
-  /** Convert a concrete game model into its HTTP-serializable `GameState` representation, rendered for `viewer`.
+  /** Project a concrete game model into its [[GameView]] for `viewer`.
     *
-    * @param game the game to serialize; guaranteed by [[com.andy327.actor.game.GameModuleBundle]] to be of type `G`
-    * @param viewer `Some(playerId)` for that player's own view, or `None` for a public/spectator view; full-information
-    *               games ignore it
-    * @return the corresponding `GameState` for delivery over HTTP or WebSocket
+    * @param game the game to project; guaranteed by [[com.andy327.actor.game.GameModuleBundle]] to be of type `G`
+    * @param viewer `Some(playerId)` for that player's own view, or `None` for a public/spectator view
+    * @return the corresponding `GameView`, ready for an in-process consumer or the JSON encoders
     */
-  def serialize(game: G, viewer: Option[PlayerId]): GameState
+  def project(game: G, viewer: Option[PlayerId]): GameView
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/modules/LiarsDiceModule.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/modules/LiarsDiceModule.scala
@@ -10,13 +10,13 @@ import org.apache.pekko.actor.typed.ActorRef
 
 import com.andy327.actor.core.{GameActor, TurnBasedGameActor}
 import com.andy327.actor.game.MovePayload.LiarsDiceAction
-import com.andy327.actor.game.{GameOperation, GameState, GameStateConverters, MovePayload}
+import com.andy327.actor.game.{GameOperation, GameProjection, GameView, MovePayload}
 import com.andy327.model.core.{GameError, PlayerId}
 import com.andy327.model.liarsdice.{Bid, Challenge, LiarsDice, MakeBid}
 
 /** [[GameModule]] implementation for Liar's Dice.
   *
-  * Provides move decoding, operation-to-command mapping, and per-viewer serialization for Liar's Dice. Dice are rolled
+  * Provides move decoding, operation-to-command mapping, and per-viewer projection for Liar's Dice. Dice are rolled
   * server-side here — a challenge carries a fresh pool the pure model deals to the surviving hands for the next round —
   * so `LiarsDice.play` stays a pure function. Bid well-formedness (a positive quantity, a face of 2–6) is left to the
   * model, which rejects a malformed bid with its own `InvalidBid` error.
@@ -32,7 +32,7 @@ object LiarsDiceModule extends GameModule[LiarsDice] {
 
   override def toGameCommand(
       op: GameOperation,
-      replyTo: ActorRef[Either[GameError, GameState]]
+      replyTo: ActorRef[Either[GameError, GameView]]
   ): Either[GameError, GameActor.GameCommand] = op match {
     case GameOperation.MakeMove(playerId, LiarsDiceAction(action, quantity, face)) =>
       action.toLowerCase match {
@@ -53,6 +53,6 @@ object LiarsDiceModule extends GameModule[LiarsDice] {
       Right(TurnBasedGameActor.GetState(replyTo))
   }
 
-  override def serialize(game: LiarsDice, viewer: Option[PlayerId]): GameState =
-    GameStateConverters.serializeGame(game, viewer)
+  override def project(game: LiarsDice, viewer: Option[PlayerId]): GameView =
+    GameProjection.project(game, viewer)
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/modules/MastermindModule.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/modules/MastermindModule.scala
@@ -8,13 +8,13 @@ import org.apache.pekko.actor.typed.ActorRef
 
 import com.andy327.actor.core.{GameActor, TurnBasedGameActor}
 import com.andy327.actor.game.MovePayload.MastermindAction
-import com.andy327.actor.game.{GameOperation, GameState, GameStateConverters, MovePayload}
+import com.andy327.actor.game.{GameOperation, GameProjection, GameView, MovePayload}
 import com.andy327.model.core.{GameError, PlayerId}
 import com.andy327.model.mastermind.{Guess, Mastermind, Peg, SetCode}
 
 /** [[GameModule]] implementation for Mastermind.
   *
-  * Provides move decoding, operation-to-command mapping, and per-viewer serialization for Mastermind. The peg color
+  * Provides move decoding, operation-to-command mapping, and per-viewer projection for Mastermind. The peg color
   * names carried in the payload are resolved to `Peg` values here; an unrecognized color is rejected as an `Unknown`
   * error so it never reaches the model.
   */
@@ -24,7 +24,7 @@ object MastermindModule extends GameModule[Mastermind] {
 
   override def toGameCommand(
       op: GameOperation,
-      replyTo: ActorRef[Either[GameError, GameState]]
+      replyTo: ActorRef[Either[GameError, GameView]]
   ): Either[GameError, GameActor.GameCommand] = op match {
     case GameOperation.MakeMove(playerId, MastermindAction(action, pegs)) =>
       parsePegs(pegs).flatMap { parsed =>
@@ -52,6 +52,6 @@ object MastermindModule extends GameModule[Mastermind] {
       } yield peg :: rest
     }.map(_.toVector)
 
-  override def serialize(game: Mastermind, viewer: Option[PlayerId]): GameState =
-    GameStateConverters.serializeGame(game, viewer)
+  override def project(game: Mastermind, viewer: Option[PlayerId]): GameView =
+    GameProjection.project(game, viewer)
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/modules/PigModule.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/modules/PigModule.scala
@@ -10,13 +10,13 @@ import org.apache.pekko.actor.typed.ActorRef
 
 import com.andy327.actor.core.{GameActor, TurnBasedGameActor}
 import com.andy327.actor.game.MovePayload.PigAction
-import com.andy327.actor.game.{GameOperation, GameState, GameStateConverters, MovePayload}
+import com.andy327.actor.game.{GameOperation, GameProjection, GameView, MovePayload}
 import com.andy327.model.core.{GameError, PlayerId}
 import com.andy327.model.pig.{Hold, Pig, Roll}
 
 /** [[GameModule]] implementation for Pig.
   *
-  * Provides move decoding, operation-to-command mapping, and game serialization for Pig. Enables
+  * Provides move decoding, operation-to-command mapping, and view projection for Pig. Enables
   * [[core.GameManager]] and the HTTP routes to handle Pig games without any game-specific logic. The die is rolled
   * server-side here before dispatching to the model, keeping `Pig.play` a pure function.
   */
@@ -26,7 +26,7 @@ object PigModule extends GameModule[Pig] {
 
   override def toGameCommand(
       op: GameOperation,
-      replyTo: ActorRef[Either[GameError, GameState]]
+      replyTo: ActorRef[Either[GameError, GameView]]
   ): Either[GameError, GameActor.GameCommand] = op match {
     case GameOperation.MakeMove(playerId, PigAction("roll")) =>
       Right(TurnBasedGameActor.MakeMove(playerId, Roll(Random.between(1, 7)), replyTo))
@@ -45,6 +45,6 @@ object PigModule extends GameModule[Pig] {
       Right(TurnBasedGameActor.GetState(replyTo))
   }
 
-  override def serialize(game: Pig, viewer: Option[PlayerId]): GameState =
-    GameStateConverters.serializeGame(game, viewer)
+  override def project(game: Pig, viewer: Option[PlayerId]): GameView =
+    GameProjection.project(game, viewer)
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/modules/TexasHoldEmModule.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/modules/TexasHoldEmModule.scala
@@ -10,14 +10,14 @@ import org.apache.pekko.actor.typed.ActorRef
 
 import com.andy327.actor.core.{GameActor, TurnBasedGameActor}
 import com.andy327.actor.game.MovePayload.HoldEmAction
-import com.andy327.actor.game.{GameOperation, GameState, GameStateConverters, MovePayload}
+import com.andy327.actor.game.{GameOperation, GameProjection, GameView, MovePayload}
 import com.andy327.model.core.{GameError, PlayerId}
 import com.andy327.model.holdem.Action.{Bet, Call, Check, Fold, Raise}
 import com.andy327.model.holdem.{Action, Card, HoldEmMove, TexasHoldEm}
 
 /** [[GameModule]] implementation for Texas Hold 'Em.
   *
-  * Provides move decoding, operation-to-command mapping, and per-viewer serialization. Every action carries a freshly
+  * Provides move decoding, operation-to-command mapping, and per-viewer projection. Every action carries a freshly
   * shuffled deck produced here — server-side — because any action can end a hand and start the next one; the pure model
   * deals the next hand from it and ignores it otherwise, so `TexasHoldEm.play` stays a pure function. Bet and raise
   * sizing is validated by the model, which rejects an illegal amount with its own errors.
@@ -31,7 +31,7 @@ object TexasHoldEmModule extends GameModule[TexasHoldEm] {
 
   override def toGameCommand(
       op: GameOperation,
-      replyTo: ActorRef[Either[GameError, GameState]]
+      replyTo: ActorRef[Either[GameError, GameView]]
   ): Either[GameError, GameActor.GameCommand] = op match {
     case GameOperation.MakeMove(playerId, HoldEmAction(action, amount)) =>
       def command(a: Action): Either[GameError, GameActor.GameCommand] =
@@ -60,6 +60,6 @@ object TexasHoldEmModule extends GameModule[TexasHoldEm] {
       Right(TurnBasedGameActor.GetState(replyTo))
   }
 
-  override def serialize(game: TexasHoldEm, viewer: Option[PlayerId]): GameState =
-    GameStateConverters.serializeGame(game, viewer)
+  override def project(game: TexasHoldEm, viewer: Option[PlayerId]): GameView =
+    GameProjection.project(game, viewer)
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/game/modules/TicTacToeModule.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/game/modules/TicTacToeModule.scala
@@ -8,13 +8,13 @@ import org.apache.pekko.actor.typed.ActorRef
 
 import com.andy327.actor.core.{GameActor, TurnBasedGameActor}
 import com.andy327.actor.game.MovePayload.TicTacToeMove
-import com.andy327.actor.game.{GameOperation, GameState, GameStateConverters, MovePayload}
+import com.andy327.actor.game.{GameOperation, GameProjection, GameView, MovePayload}
 import com.andy327.model.core.{GameError, PlayerId}
 import com.andy327.model.tictactoe.{Location, TicTacToe}
 
 /** [[GameModule]] implementation for TicTacToe.
   *
-  * Provides move decoding, operation-to-command mapping, and game serialization for TicTacToe. Enables
+  * Provides move decoding, operation-to-command mapping, and view projection for TicTacToe. Enables
   * [[core.GameManager]] and the HTTP routes to handle TicTacToe games without any game-specific logic.
   */
 object TicTacToeModule extends GameModule[TicTacToe] {
@@ -23,7 +23,7 @@ object TicTacToeModule extends GameModule[TicTacToe] {
 
   override def toGameCommand(
       op: GameOperation,
-      replyTo: ActorRef[Either[GameError, GameState]]
+      replyTo: ActorRef[Either[GameError, GameView]]
   ): Either[GameError, GameActor.GameCommand] = op match {
     case GameOperation.MakeMove(playerId, MovePayload.TicTacToeMove(row, col)) =>
       Right(TurnBasedGameActor.MakeMove(playerId, Location(row, col), replyTo))
@@ -36,6 +36,6 @@ object TicTacToeModule extends GameModule[TicTacToe] {
       Right(TurnBasedGameActor.GetState(replyTo))
   }
 
-  override def serialize(game: TicTacToe, viewer: Option[PlayerId]): GameState =
-    GameStateConverters.serializeGame(game, viewer)
+  override def project(game: TicTacToe, viewer: Option[PlayerId]): GameView =
+    GameProjection.project(game, viewer)
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/liarsdice/LiarsDiceActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/liarsdice/LiarsDiceActor.scala
@@ -4,7 +4,7 @@ import io.circe.syntax._
 import io.circe.{Encoder, Json}
 
 import com.andy327.actor.core.TurnBasedGameActor
-import com.andy327.actor.game.LiarsDiceState
+import com.andy327.actor.game.LiarsDiceView
 import com.andy327.actor.game.modules.LiarsDiceModule
 import com.andy327.model.liarsdice.{Challenge, LiarsDice, LiarsDiceMove, MakeBid}
 
@@ -12,14 +12,14 @@ import com.andy327.model.liarsdice.{Challenge, LiarsDice, LiarsDiceMove, MakeBid
   *
   * All behavior lives in [[core.TurnBasedGameActor]]; the rules (bidding-track raises, wild-ones counting, per-round
   * elimination) live in `model.liarsdice.LiarsDice`, and the per-viewer projection that hides each player's dice lives
-  * in `GameStateView[LiarsDice, LiarsDiceState]`. The starting hands are rolled here — server-side — and dealt by the
+  * in `GameProjection[LiarsDice, LiarsDiceView]`. The starting hands are rolled here — server-side — and dealt by the
   * pure model, mirroring how Pig supplies its die result.
   *
   * The move-log encoder records a bid's quantity and face but omits a challenge's re-roll pool: that pool is internal
   * server randomness for the next round, not meaningful public history.
   */
 object LiarsDiceActor
-    extends TurnBasedGameActor[LiarsDice, LiarsDiceMove, Int, LiarsDiceState](
+    extends TurnBasedGameActor[LiarsDice, LiarsDiceMove, Int, LiarsDiceView](
       players => LiarsDice.newGame(players, LiarsDiceModule.rollPool()),
       Encoder.instance[LiarsDiceMove] {
         case MakeBid(bid) =>

--- a/game-service-actor/src/main/scala/com/andy327/actor/mastermind/MastermindActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/mastermind/MastermindActor.scala
@@ -4,20 +4,20 @@ import io.circe.syntax._
 import io.circe.{Encoder, Json}
 
 import com.andy327.actor.core.TurnBasedGameActor
-import com.andy327.actor.game.MastermindState
+import com.andy327.actor.game.MastermindView
 import com.andy327.model.mastermind.{Guess, Mastermind, MastermindMove, Role, SetCode}
 
 /** [[core.GameActor]] binding for Mastermind.
   *
   * All behavior lives in [[core.TurnBasedGameActor]]; the rules (setting the code, scoring guesses, winning by cracking
   * or exhausting guesses) live in `model.mastermind.Mastermind`, and the per-viewer projection that hides the secret
-  * lives in `GameStateView[Mastermind, MastermindState]`. The codemaker (seat 0) sets the code first.
+  * lives in `GameProjection[Mastermind, MastermindView]`. The codemaker (seat 0) sets the code first.
   *
   * The move-log encoder deliberately redacts the code from a `SetCode`: the history log is served publicly via
   * `GET /{gameType}/{roomId}/history`, so logging the pegs would let the codebreaker read the answer mid-game.
   */
 object MastermindActor
-    extends TurnBasedGameActor[Mastermind, MastermindMove, Role, MastermindState](
+    extends TurnBasedGameActor[Mastermind, MastermindMove, Role, MastermindView](
       players => Mastermind.newGame(players),
       Encoder.instance[MastermindMove] {
         case SetCode(_)  => Json.obj("action" -> "setcode".asJson) // pegs redacted: never leak the secret to /history

--- a/game-service-actor/src/main/scala/com/andy327/actor/pig/PigActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/pig/PigActor.scala
@@ -5,7 +5,7 @@ import io.circe.syntax._
 
 import com.andy327.actor.core.TurnBasedGameActor
 import com.andy327.actor.core.TurnBasedGameActor.TimeoutAction
-import com.andy327.actor.game.PigState
+import com.andy327.actor.game.PigView
 import com.andy327.model.pig.{Hold, Pig, PigMove, Roll}
 
 /** [[core.GameActor]] binding for Pig.
@@ -17,7 +17,7 @@ import com.andy327.model.pig.{Hold, Pig, PigMove, Roll}
   * idle seat simply passes its turn and the game keeps moving.
   */
 object PigActor
-    extends TurnBasedGameActor[Pig, PigMove, Int, PigState](
+    extends TurnBasedGameActor[Pig, PigMove, Int, PigView](
       players => Pig.newGame(players),
       Encoder.instance[PigMove] {
         case Roll(result) => Map("action" -> "roll", "result" -> result.toString).asJson

--- a/game-service-actor/src/main/scala/com/andy327/actor/texasholdem/TexasHoldEmActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/texasholdem/TexasHoldEmActor.scala
@@ -5,7 +5,7 @@ import io.circe.{Encoder, Json}
 
 import com.andy327.actor.core.TurnBasedGameActor
 import com.andy327.actor.core.TurnBasedGameActor.TimeoutAction
-import com.andy327.actor.game.HoldEmState
+import com.andy327.actor.game.HoldEmView
 import com.andy327.actor.game.modules.TexasHoldEmModule
 import com.andy327.model.holdem.Action.{Bet, Call, Check, Fold, Raise}
 import com.andy327.model.holdem.{HoldEmMove, TexasHoldEm}
@@ -14,7 +14,7 @@ import com.andy327.model.holdem.{HoldEmMove, TexasHoldEm}
   *
   * All behavior lives in [[core.TurnBasedGameActor]]; the rules (betting, streets, side pots, sit-and-go win) live in
   * `model.holdem.TexasHoldEm`, and the per-viewer projection that hides each player's hole cards lives in
-  * `GameStateView[TexasHoldEm, HoldEmState]`. The opening deal is shuffled here — server-side — and dealt by the pure
+  * `GameProjection[TexasHoldEm, HoldEmView]`. The opening deal is shuffled here — server-side — and dealt by the pure
   * model.
   *
   * The move-log encoder records a bet's or raise's amount but omits the deck each move carries: that deck is internal
@@ -26,7 +26,7 @@ import com.andy327.model.holdem.{HoldEmMove, TexasHoldEm}
   * folding can end the hand and deal the next.
   */
 object TexasHoldEmActor
-    extends TurnBasedGameActor[TexasHoldEm, HoldEmMove, Int, HoldEmState](
+    extends TurnBasedGameActor[TexasHoldEm, HoldEmMove, Int, HoldEmView](
       players => TexasHoldEm.newGame(players, TexasHoldEmModule.shuffledDeck()),
       Encoder.instance[HoldEmMove] { move =>
         move.action match {

--- a/game-service-actor/src/main/scala/com/andy327/actor/tictactoe/TicTacToeActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/tictactoe/TicTacToeActor.scala
@@ -3,7 +3,7 @@ package com.andy327.actor.tictactoe
 import io.circe.generic.semiauto.deriveEncoder
 
 import com.andy327.actor.core.TurnBasedGameActor
-import com.andy327.actor.game.GridGameState
+import com.andy327.actor.game.GridGameView
 import com.andy327.model.tictactoe.{Location, Mark, TicTacToe}
 
 /** [[core.GameActor]] binding for TicTacToe.
@@ -12,7 +12,7 @@ import com.andy327.model.tictactoe.{Location, Mark, TicTacToe}
   * `model.tictactoe.TicTacToe`. X is seated first, O second.
   */
 object TicTacToeActor
-    extends TurnBasedGameActor[TicTacToe, Location, Mark, GridGameState](
+    extends TurnBasedGameActor[TicTacToe, Location, Mark, GridGameView](
       players => TicTacToe.empty(players(0), players(1)),
       deriveEncoder[Location]
     )

--- a/game-service-actor/src/test/scala/com/andy327/actor/battleship/BattleshipActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/battleship/BattleshipActorSpec.scala
@@ -9,9 +9,9 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.actor.core.{GameManager, PlayerActor, PlayerEvent, TurnBasedGameActor}
 import com.andy327.actor.events.NoOpEventPublisher
-import com.andy327.actor.game.{BattleshipState, GameState}
+import com.andy327.actor.game.{BattleshipCell, BattleshipState, GameState}
 import com.andy327.actor.persistence.PersistenceProtocol
-import com.andy327.model.battleship.{Coord, Fire}
+import com.andy327.model.battleship.{Coord, Fire, Player1, Player2}
 import com.andy327.model.core.{GameError, PlayerId}
 
 class BattleshipActorSpec extends AnyWordSpecLike with Matchers {
@@ -53,9 +53,9 @@ class BattleshipActorSpec extends AnyWordSpecLike with Matchers {
 
       val Right(state: BattleshipState) = replyProbe.receiveMessage()
       state.viewerSeat shouldBe None
-      state.board1.flatten should not contain "ship"
-      state.board2.flatten should not contain "ship"
-      state.board1.flatten should contain("unknown")
+      state.board1.flatten should not contain BattleshipCell.Ship
+      state.board2.flatten should not contain BattleshipCell.Ship
+      state.board1.flatten should contain(BattleshipCell.Unknown)
     }
 
     "reveal only the subscriber's own fleet on subscribe" in {
@@ -66,21 +66,21 @@ class BattleshipActorSpec extends AnyWordSpecLike with Matchers {
 
       actor ! TurnBasedGameActor.Subscribe(p1.ref, alice)
       val s1 = stateFrom(p1)
-      s1.viewerSeat shouldBe Some("P1")
-      s1.board1.flatten should contain("ship") // own fleet revealed
-      s1.board2.flatten.toSet shouldBe Set("unknown") // opponent fogged, no shots yet
+      s1.viewerSeat shouldBe Some(Player1)
+      s1.board1.flatten should contain(BattleshipCell.Ship) // own fleet revealed
+      s1.board2.flatten.toSet shouldBe Set[BattleshipCell](BattleshipCell.Unknown) // opponent fogged, no shots yet
 
       actor ! TurnBasedGameActor.Subscribe(p2.ref, bob)
       val s2 = stateFrom(p2)
-      s2.viewerSeat shouldBe Some("P2")
-      s2.board2.flatten should contain("ship")
-      s2.board1.flatten.toSet shouldBe Set("unknown")
+      s2.viewerSeat shouldBe Some(Player2)
+      s2.board2.flatten should contain(BattleshipCell.Ship)
+      s2.board1.flatten.toSet shouldBe Set[BattleshipCell](BattleshipCell.Unknown)
 
       actor ! TurnBasedGameActor.Subscribe(spectator.ref, UUID.randomUUID())
       val ss = stateFrom(spectator)
       ss.viewerSeat shouldBe None
-      ss.board1.flatten should not contain "ship"
-      ss.board2.flatten should not contain "ship"
+      ss.board1.flatten should not contain BattleshipCell.Ship
+      ss.board2.flatten should not contain BattleshipCell.Ship
     }
 
     "push a per-viewer state update to each subscriber after a shot" in {
@@ -101,12 +101,12 @@ class BattleshipActorSpec extends AnyWordSpecLike with Matchers {
       val s2 = stateFrom(p2)
 
       // P1 fired at P2's waters (board2): cell (0,0) is now resolved for both viewers
-      s1.board2(0)(0) should (be("hit").or(be("miss")))
-      s2.board2(0)(0) should (be("hit").or(be("miss")))
+      s1.board2(0)(0) should (be(BattleshipCell.Hit).or(be(BattleshipCell.Miss)))
+      s2.board2(0)(0) should (be(BattleshipCell.Hit).or(be(BattleshipCell.Miss)))
 
       // each viewer still sees only their own fleet
-      s1.board1.flatten should contain("ship")
-      s2.board1.flatten should not contain "ship"
+      s1.board1.flatten should contain(BattleshipCell.Ship)
+      s2.board1.flatten should not contain BattleshipCell.Ship
 
       // the two viewers receive different projections of the same game
       s1 should not be s2

--- a/game-service-actor/src/test/scala/com/andy327/actor/battleship/BattleshipActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/battleship/BattleshipActorSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.actor.core.{GameManager, PlayerActor, PlayerEvent, TurnBasedGameActor}
 import com.andy327.actor.events.NoOpEventPublisher
-import com.andy327.actor.game.{BattleshipCell, BattleshipState, GameState}
+import com.andy327.actor.game.{BattleshipCell, BattleshipView, GameView}
 import com.andy327.actor.persistence.PersistenceProtocol
 import com.andy327.model.battleship.{Coord, Fire, Player1, Player2}
 import com.andy327.model.core.{GameError, PlayerId}
@@ -37,21 +37,21 @@ class BattleshipActorSpec extends AnyWordSpecLike with Matchers {
     (spawn(behavior), persistProbe)
   }
 
-  /** Receives the next pushed event and asserts it is a GameStateUpdated carrying a BattleshipState. */
-  private def stateFrom(probe: TestProbe[PlayerActor.Command]): BattleshipState =
+  /** Receives the next pushed event and asserts it is a GameStateUpdated carrying a BattleshipView. */
+  private def stateFrom(probe: TestProbe[PlayerActor.Command]): BattleshipView =
     probe.expectMessageType[PlayerActor.SendEvent].event match {
-      case PlayerEvent.GameStateUpdated(_, s: BattleshipState, _) => s
-      case other => fail(s"expected GameStateUpdated(BattleshipState), got $other")
+      case PlayerEvent.GameStateUpdated(_, s: BattleshipView, _) => s
+      case other => fail(s"expected GameStateUpdated(BattleshipView), got $other")
     }
 
   "BattleshipActor" should {
     "return a fog-of-war view on GetState (no viewer)" in {
       val (actor, _) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
 
-      val Right(state: BattleshipState) = replyProbe.receiveMessage()
+      val Right(state: BattleshipView) = replyProbe.receiveMessage()
       state.viewerSeat shouldBe None
       state.board1.flatten should not contain BattleshipCell.Ship
       state.board2.flatten should not contain BattleshipCell.Ship
@@ -93,7 +93,7 @@ class BattleshipActorSpec extends AnyWordSpecLike with Matchers {
       actor ! TurnBasedGameActor.Subscribe(p2.ref, bob)
       stateFrom(p2) // initial push
 
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
       actor ! TurnBasedGameActor.MakeMove(alice, Fire(Coord(0, 0)), replyProbe.ref)
       replyProbe.receiveMessage() // mover reply
 

--- a/game-service-actor/src/test/scala/com/andy327/actor/checkers/CheckersActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/checkers/CheckersActorSpec.scala
@@ -50,13 +50,13 @@ class CheckersActorSpec extends AnyWordSpecLike with Matchers {
 
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
 
-      val Right(CheckersState(board, current, winner, viewerSeat)) = replyProbe.receiveMessage()
+      val Right(CheckersState(board, current, winner, viewerSeat, _)) = replyProbe.receiveMessage()
       board should have size 8
       board.head should have size 8
-      board(5)(0) shouldBe "r" // Red pawn in its home rows
-      board(2)(1) shouldBe "b" // Black pawn in its home rows
-      board(3)(4) shouldBe "" // empty middle rank
-      current shouldBe "R"
+      board(5)(0) shouldBe Some(Piece(Red, isKing = false)) // Red pawn in its home rows
+      board(2)(1) shouldBe Some(Piece(Black, isKing = false)) // Black pawn in its home rows
+      board(3)(4) shouldBe None // empty middle rank
+      current shouldBe Red
       winner shouldBe None
       viewerSeat shouldBe None // GetState renders the public view (no specific viewer)
     }
@@ -67,11 +67,11 @@ class CheckersActorSpec extends AnyWordSpecLike with Matchers {
 
       actor ! TurnBasedGameActor.MakeMove(alice, Move(Square(5, 0), List(Square(4, 1))), replyProbe.ref)
 
-      val Right(CheckersState(board, current, _, viewerSeat)) = replyProbe.receiveMessage()
-      board(4)(1) shouldBe "r"
-      board(5)(0) shouldBe ""
-      current shouldBe "B"
-      viewerSeat shouldBe Some("R") // the move reply is rendered for the acting player (Red)
+      val Right(CheckersState(board, current, _, viewerSeat, _)) = replyProbe.receiveMessage()
+      board(4)(1) shouldBe Some(Piece(Red, isKing = false))
+      board(5)(0) shouldBe None
+      current shouldBe Black
+      viewerSeat shouldBe Some(Red) // the move reply is rendered for the acting player (Red)
     }
 
     "append an applied move to history as its {from, steps} JSON" in {
@@ -127,9 +127,9 @@ class CheckersActorSpec extends AnyWordSpecLike with Matchers {
       val replyProbe = createTestProbe[Either[GameError, GameState]]()
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
 
-      val Right(CheckersState(board, current, _, _)) = replyProbe.receiveMessage()
-      board(5)(2) shouldBe "r"
-      current shouldBe "R"
+      val Right(CheckersState(board, current, _, _, _)) = replyProbe.receiveMessage()
+      board(5)(2) shouldBe Some(Piece(Red, isKing = false))
+      current shouldBe Red
     }
 
     "notify GameManager and stop when restored from a completed snapshot" in {
@@ -187,9 +187,9 @@ class CheckersActorSpec extends AnyWordSpecLike with Matchers {
       val replyProbe = createTestProbe[Either[GameError, GameState]]()
       actor ! TurnBasedGameActor.MakeMove(alice, Move(Square(5, 2), List(Square(3, 4))), replyProbe.ref)
 
-      val Right(CheckersState(_, _, winner, viewerSeat)) = replyProbe.receiveMessage()
-      winner shouldBe Some("R")
-      viewerSeat shouldBe Some("R") // rendered for the acting player (Red)
+      val Right(CheckersState(_, _, winner, viewerSeat, _)) = replyProbe.receiveMessage()
+      winner shouldBe Some(Red)
+      viewerSeat shouldBe Some(Red) // rendered for the acting player (Red)
 
       subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe a[PlayerEvent.GameStateUpdated]
       subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe

--- a/game-service-actor/src/test/scala/com/andy327/actor/checkers/CheckersActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/checkers/CheckersActorSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.actor.core.{GameManager, PlayerActor, PlayerEvent, TurnBasedGameActor}
 import com.andy327.actor.events.NoOpEventPublisher
-import com.andy327.actor.game.{CheckersState, GameState}
+import com.andy327.actor.game.{CheckersView, GameView}
 import com.andy327.actor.lobby.GameLifecycleStatus
 import com.andy327.actor.persistence.PersistenceProtocol
 import com.andy327.model.checkers.{Black, Checkers, Move, Piece, Red, Square}
@@ -46,11 +46,11 @@ class CheckersActorSpec extends AnyWordSpecLike with Matchers {
   "CheckersActor" should {
     "return the standard 8×8 opening board on GetState" in {
       val (actor, _) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
 
-      val Right(CheckersState(board, current, winner, viewerSeat, _)) = replyProbe.receiveMessage()
+      val Right(CheckersView(board, current, winner, viewerSeat, _)) = replyProbe.receiveMessage()
       board should have size 8
       board.head should have size 8
       board(5)(0) shouldBe Some(Piece(Red, isKing = false)) // Red pawn in its home rows
@@ -63,11 +63,11 @@ class CheckersActorSpec extends AnyWordSpecLike with Matchers {
 
     "apply a valid move and switch currentPlayer" in {
       val (actor, _) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.MakeMove(alice, Move(Square(5, 0), List(Square(4, 1))), replyProbe.ref)
 
-      val Right(CheckersState(board, current, _, viewerSeat, _)) = replyProbe.receiveMessage()
+      val Right(CheckersView(board, current, _, viewerSeat, _)) = replyProbe.receiveMessage()
       board(4)(1) shouldBe Some(Piece(Red, isKing = false))
       board(5)(0) shouldBe None
       current shouldBe Black
@@ -76,7 +76,7 @@ class CheckersActorSpec extends AnyWordSpecLike with Matchers {
 
     "append an applied move to history as its {from, steps} JSON" in {
       val (actor, persistProbe) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.MakeMove(alice, Move(Square(5, 0), List(Square(4, 1))), replyProbe.ref)
       replyProbe.receiveMessage()
@@ -93,7 +93,7 @@ class CheckersActorSpec extends AnyWordSpecLike with Matchers {
 
     "reject a move when it is not the player's turn" in {
       val (actor, _) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.MakeMove(bob, Move(Square(2, 1), List(Square(3, 0))), replyProbe.ref)
       replyProbe.receiveMessage() shouldBe Left(GameError.InvalidTurn)
@@ -102,7 +102,7 @@ class CheckersActorSpec extends AnyWordSpecLike with Matchers {
     "reject a move from a player not in the game" in {
       val eve: PlayerId = UUID.randomUUID()
       val (actor, _) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.MakeMove(eve, Move(Square(5, 0), List(Square(4, 1))), replyProbe.ref)
       replyProbe.receiveMessage() shouldBe Left(GameError.InvalidPlayer(eve))
@@ -124,10 +124,10 @@ class CheckersActorSpec extends AnyWordSpecLike with Matchers {
         )
       )
 
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
 
-      val Right(CheckersState(board, current, _, _, _)) = replyProbe.receiveMessage()
+      val Right(CheckersView(board, current, _, _, _)) = replyProbe.receiveMessage()
       board(5)(2) shouldBe Some(Piece(Red, isKing = false))
       current shouldBe Red
     }
@@ -184,10 +184,10 @@ class CheckersActorSpec extends AnyWordSpecLike with Matchers {
       actor ! TurnBasedGameActor.Subscribe(subscriberProbe.ref, alice)
       subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial state push on subscribe
 
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
       actor ! TurnBasedGameActor.MakeMove(alice, Move(Square(5, 2), List(Square(3, 4))), replyProbe.ref)
 
-      val Right(CheckersState(_, _, winner, viewerSeat, _)) = replyProbe.receiveMessage()
+      val Right(CheckersView(_, _, winner, viewerSeat, _)) = replyProbe.receiveMessage()
       winner shouldBe Some(Red)
       viewerSeat shouldBe Some(Red) // rendered for the acting player (Red)
 

--- a/game-service-actor/src/test/scala/com/andy327/actor/connectfour/ConnectFourActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/connectfour/ConnectFourActorSpec.scala
@@ -74,11 +74,11 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
 
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
 
-      val Right(GridGameState(board, current, winner, draw)) = replyProbe.receiveMessage()
+      val Right(GridGameState(board, current, winner, draw, _)) = replyProbe.receiveMessage()
       board should have size 6
       board.head should have size 7
-      board.flatten should contain only ""
-      current shouldBe "R"
+      board.flatten should contain only None
+      current shouldBe Red
       winner shouldBe None
       draw shouldBe false
     }
@@ -100,9 +100,9 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
       val replyProbe = createTestProbe[Either[GameError, GameState]]()
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
 
-      val Right(GridGameState(board, current, winner, draw)) = replyProbe.receiveMessage()
-      board(5)(3) shouldBe "R" // Red dropped into col 3 — piece falls to bottom row
-      current shouldBe "Y"
+      val Right(GridGameState(board, current, winner, draw, _)) = replyProbe.receiveMessage()
+      board(5)(3) shouldBe Some(Red) // Red dropped into col 3 — piece falls to bottom row
+      current shouldBe Yellow
       winner shouldBe None
       draw shouldBe false
     }
@@ -159,15 +159,15 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
       val replyProbe = createTestProbe[Either[GameError, GameState]]()
 
       actor ! TurnBasedGameActor.MakeMove(alice, Drop(0), replyProbe.ref)
-      val Right(GridGameState(board1, current1, _, _)) = replyProbe.receiveMessage()
-      board1(5)(0) shouldBe "R" // piece falls to bottom row
-      current1 shouldBe "Y"
+      val Right(GridGameState(board1, current1, _, _, _)) = replyProbe.receiveMessage()
+      board1(5)(0) shouldBe Some(Red) // piece falls to bottom row
+      current1 shouldBe Yellow
 
       actor ! TurnBasedGameActor.MakeMove(bob, Drop(1), replyProbe.ref)
-      val Right(GridGameState(board2, current2, _, _)) = replyProbe.receiveMessage()
-      board2(5)(0) shouldBe "R"
-      board2(5)(1) shouldBe "Y"
-      current2 shouldBe "R"
+      val Right(GridGameState(board2, current2, _, _, _)) = replyProbe.receiveMessage()
+      board2(5)(0) shouldBe Some(Red)
+      board2(5)(1) shouldBe Some(Yellow)
+      current2 shouldBe Red
     }
 
     "append each applied move to history with an incrementing seq and the move payload" in {

--- a/game-service-actor/src/test/scala/com/andy327/actor/connectfour/ConnectFourActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/connectfour/ConnectFourActorSpec.scala
@@ -13,7 +13,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.actor.core.{GameManager, PlayerActor, PlayerEvent, TurnBasedGameActor}
 import com.andy327.actor.events.NoOpEventPublisher
-import com.andy327.actor.game.{GameState, GridGameState}
+import com.andy327.actor.game.{GameView, GridGameView}
 import com.andy327.actor.lobby.GameLifecycleStatus
 import com.andy327.actor.persistence.PersistenceProtocol
 import com.andy327.model.connectfour.{ConnectFour, Drop, InvalidColumn, Red, Yellow}
@@ -70,11 +70,11 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
   "ConnectFourActor" should {
     "return an empty 6×7 board on GetState" in {
       val (actor, _) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
 
-      val Right(GridGameState(board, current, winner, draw, _)) = replyProbe.receiveMessage()
+      val Right(GridGameView(board, current, winner, draw, _)) = replyProbe.receiveMessage()
       board should have size 6
       board.head should have size 7
       board.flatten should contain only None
@@ -97,10 +97,10 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
       )
       val actor = spawn(behavior)
 
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
 
-      val Right(GridGameState(board, current, winner, draw, _)) = replyProbe.receiveMessage()
+      val Right(GridGameView(board, current, winner, draw, _)) = replyProbe.receiveMessage()
       board(5)(3) shouldBe Some(Red) // Red dropped into col 3 — piece falls to bottom row
       current shouldBe Yellow
       winner shouldBe None
@@ -156,15 +156,15 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
 
     "apply a valid move and switch currentPlayer" in {
       val (actor, _) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.MakeMove(alice, Drop(0), replyProbe.ref)
-      val Right(GridGameState(board1, current1, _, _, _)) = replyProbe.receiveMessage()
+      val Right(GridGameView(board1, current1, _, _, _)) = replyProbe.receiveMessage()
       board1(5)(0) shouldBe Some(Red) // piece falls to bottom row
       current1 shouldBe Yellow
 
       actor ! TurnBasedGameActor.MakeMove(bob, Drop(1), replyProbe.ref)
-      val Right(GridGameState(board2, current2, _, _, _)) = replyProbe.receiveMessage()
+      val Right(GridGameView(board2, current2, _, _, _)) = replyProbe.receiveMessage()
       board2(5)(0) shouldBe Some(Red)
       board2(5)(1) shouldBe Some(Yellow)
       current2 shouldBe Red
@@ -172,7 +172,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
 
     "append each applied move to history with an incrementing seq and the move payload" in {
       val (actor, persistProbe) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.MakeMove(alice, Drop(0), replyProbe.ref)
       replyProbe.receiveMessage()
@@ -193,7 +193,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
 
     "reject a move when it is not the player's turn" in {
       val (actor, _) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.MakeMove(bob, Drop(0), replyProbe.ref)
       replyProbe.receiveMessage() shouldBe Left(GameError.InvalidTurn)
@@ -202,7 +202,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
     "reject a move from a player not in the game" in {
       val eve: PlayerId = UUID.randomUUID()
       val (actor, _) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.MakeMove(eve, Drop(0), replyProbe.ref)
       replyProbe.receiveMessage() shouldBe Left(GameError.InvalidPlayer(eve))
@@ -210,7 +210,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
 
     "reject a move to an out-of-bounds column" in {
       val (actor, _) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.MakeMove(alice, Drop(7), replyProbe.ref)
       replyProbe.receiveMessage() shouldBe Left(InvalidColumn)
@@ -218,7 +218,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
 
     "log success and continue when SnapshotSaved succeeds" in {
       val (actor, persistProbe) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.MakeMove(alice, Drop(0), replyProbe.ref)
       val _ = replyProbe.receiveMessage()
@@ -236,7 +236,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
 
       actor ! TurnBasedGameActor.SnapshotSaved(Left(ex))
 
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
       replyProbe.receiveMessage() shouldBe a[Right[_, _]]
     }
@@ -248,7 +248,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
       actor ! TurnBasedGameActor.Subscribe(subscriberProbe.ref, alice)
       subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial state push on subscribe
 
-      actor ! TurnBasedGameActor.MakeMove(alice, Drop(0), createTestProbe[Either[GameError, GameState]]().ref)
+      actor ! TurnBasedGameActor.MakeMove(alice, Drop(0), createTestProbe[Either[GameError, GameView]]().ref)
 
       subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe a[PlayerEvent.GameStateUpdated]
     }
@@ -257,7 +257,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
       val gameManagerProbe = createTestProbe[GameManager.Command]()
       val (actor, persistProbe) = newActor(gmRef = gameManagerProbe.ref)
       val subscriberProbe = createTestProbe[PlayerActor.Command]()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.Subscribe(subscriberProbe.ref, alice)
       subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial state push on subscribe
@@ -280,14 +280,14 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
       actor ! TurnBasedGameActor.Subscribe(subscriberProbe.ref, alice)
       subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial state push on subscribe
       actor ! TurnBasedGameActor.Unsubscribe(subscriberProbe.ref)
-      actor ! TurnBasedGameActor.MakeMove(alice, Drop(0), createTestProbe[Either[GameError, GameState]]().ref)
+      actor ! TurnBasedGameActor.MakeMove(alice, Drop(0), createTestProbe[Either[GameError, GameView]]().ref)
 
       subscriberProbe.expectNoMessage()
     }
 
     "stop after receiving SnapshotSaved(Right) in terminating state" in {
       val (actor, persistProbe) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       redWinsMoves.foreach { case (playerId, col) =>
         actor ! TurnBasedGameActor.MakeMove(playerId, Drop(col), replyProbe.ref)
@@ -301,7 +301,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
 
     "stop after receiving SnapshotSaved(Left) in terminating state" in {
       val (actor, persistProbe) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
       val ex = new RuntimeException("snapshot failure") with NoStackTrace
 
       redWinsMoves.foreach { case (playerId, col) =>
@@ -316,7 +316,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
 
     "reject a GetState landing in terminating state with GameOver instead of dropping it" in {
       val (actor, persistProbe) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       redWinsMoves.foreach { case (playerId, col) =>
         actor ! TurnBasedGameActor.MakeMove(playerId, Drop(col), replyProbe.ref)
@@ -337,7 +337,7 @@ class ConnectFourActorSpec extends AnyWordSpecLike with Matchers {
       val gameManagerProbe = createTestProbe[GameManager.Command]()
       val matchId: MatchId = UUID.randomUUID()
       val (actor, persistProbe) = newActor(gmRef = gameManagerProbe.ref, matchId = matchId)
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       redWinsMoves.foreach { case (playerId, col) =>
         actor ! TurnBasedGameActor.MakeMove(playerId, Drop(col), replyProbe.ref)

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
@@ -26,7 +26,7 @@ import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyError, LobbyMetadata, 
 import com.andy327.actor.persistence.PersistenceProtocol
 import com.andy327.actor.tracing.{TraceCollector, TracingConfig}
 import com.andy327.model.core.{Game, GameType, MatchId, PlayerId, RoomId}
-import com.andy327.model.tictactoe.TicTacToe
+import com.andy327.model.tictactoe.{O, TicTacToe, X}
 import com.andy327.persistence.db.{GameRepository, MoveHistoryRepository, MoveRecord}
 
 /** In-memory GameRepository for unit tests */
@@ -797,7 +797,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       // Bob (O) leaves the in-progress game — Alice (X) wins by forfeit
       gm ! GameManager.LeaveLobby(roomId, bob, responseProbe.ref)
       val forfeited = responseProbe.expectMessageType[GameManager.GameForfeited]
-      forfeited.state.asInstanceOf[GridGameState].winner shouldBe Some("X")
+      forfeited.state.asInstanceOf[GridGameState].winner shouldBe Some(X)
 
       // the room has moved to Finished (post-game) via the GameCompleted -> MatchEnded flow
       eventually {
@@ -872,8 +872,8 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       val updatedState = responseProbe.expectMessageType[GameManager.GameStatus]
 
       val view = updatedState.state.asInstanceOf[GridGameState]
-      view.board(0)(0) shouldBe "X"
-      view.currentPlayer shouldBe "O"
+      view.board(0)(0) shouldBe Some(X)
+      view.currentPlayer shouldBe O
     }
 
     "return an error when forwarding an invalid move to a game" in {

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerSpec.scala
@@ -21,7 +21,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import com.andy327.actor.chat.ChatRepository
 import com.andy327.actor.core.{PlayerActor, PlayerEvent}
 import com.andy327.actor.events.{EventPublisher, GameEvent}
-import com.andy327.actor.game.{GameOperation, GameStateConverters, GridGameState, MovePayload}
+import com.andy327.actor.game.{GameOperation, GameProjection, GridGameView, MovePayload}
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyError, LobbyMetadata, LobbyRepository, Player}
 import com.andy327.actor.persistence.PersistenceProtocol
 import com.andy327.actor.tracing.{TraceCollector, TracingConfig}
@@ -140,7 +140,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       gm ! GameManager.RunGameOperation(roomId, GameOperation.GetState, gameResponseProbe.ref)
       val response = gameResponseProbe.expectMessageType[GameManager.GameResponse]
-      response shouldBe GameManager.GameStatus(GameStateConverters.serializeGame(restoredGame, None))
+      response shouldBe GameManager.GameStatus(GameProjection.project(restoredGame, None))
     }
 
     "ignore RestoreGames messages in running state" in {
@@ -619,7 +619,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       gm ! GameManager.RunGameOperation(roomId, GameOperation.GetState, responseProbe.ref)
       val response = responseProbe.expectMessageType[GameManager.GameStatus]
-      response.state shouldBe GameStateConverters.serializeGame(game, None)
+      response.state shouldBe GameProjection.project(game, None)
     }
 
     "drop the completedMatch entry on RoomClosed, so a later operation reports GameNotFound" in {
@@ -797,7 +797,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
       // Bob (O) leaves the in-progress game — Alice (X) wins by forfeit
       gm ! GameManager.LeaveLobby(roomId, bob, responseProbe.ref)
       val forfeited = responseProbe.expectMessageType[GameManager.GameForfeited]
-      forfeited.state.asInstanceOf[GridGameState].winner shouldBe Some(X)
+      forfeited.state.asInstanceOf[GridGameView].winner shouldBe Some(X)
 
       // the room has moved to Finished (post-game) via the GameCompleted -> MatchEnded flow
       eventually {
@@ -871,7 +871,7 @@ class GameManagerSpec extends AnyWordSpecLike with Matchers with Eventually {
 
       val updatedState = responseProbe.expectMessageType[GameManager.GameStatus]
 
-      val view = updatedState.state.asInstanceOf[GridGameState]
+      val view = updatedState.state.asInstanceOf[GridGameView]
       view.board(0)(0) shouldBe Some(X)
       view.currentPlayer shouldBe O
     }

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/PlayerActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/PlayerActorSpec.scala
@@ -6,7 +6,7 @@ import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
-import com.andy327.actor.game.GridGameState
+import com.andy327.actor.game.GridGameView
 import com.andy327.actor.lobby.Player
 import com.andy327.model.core.Mark
 import com.andy327.model.tictactoe.X
@@ -21,7 +21,7 @@ class PlayerActorSpec extends AnyWordSpecLike with Matchers {
       val sessionProbe = TestProbe[PlayerActor.SessionOutput]()
       val actor = spawn(PlayerActor(alice, sessionProbe.ref))
 
-      val dummyState = GridGameState(
+      val dummyState = GridGameView(
         board = Vector.fill(3)(Vector.fill(3)(Option.empty[Mark])),
         currentPlayer = X,
         winner = None,

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/PlayerActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/PlayerActorSpec.scala
@@ -8,6 +8,8 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.actor.game.GridGameState
 import com.andy327.actor.lobby.Player
+import com.andy327.model.core.Mark
+import com.andy327.model.tictactoe.X
 
 class PlayerActorSpec extends AnyWordSpecLike with Matchers {
   private val testKit = ActorTestKit()
@@ -20,10 +22,11 @@ class PlayerActorSpec extends AnyWordSpecLike with Matchers {
       val actor = spawn(PlayerActor(alice, sessionProbe.ref))
 
       val dummyState = GridGameState(
-        board = Vector.fill(3)(Vector.fill(3)("")),
-        currentPlayer = "X",
+        board = Vector.fill(3)(Vector.fill(3)(Option.empty[Mark])),
+        currentPlayer = X,
         winner = None,
-        draw = false
+        draw = false,
+        legalMoves = Nil
       )
       val event = PlayerEvent.GameStateUpdated(UUID.randomUUID(), dummyState, spectatorCount = 0)
 

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/TurnBasedGameActorTimeoutSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/TurnBasedGameActorTimeoutSpec.scala
@@ -17,7 +17,7 @@ import com.andy327.actor.lobby.GameLifecycleStatus
 import com.andy327.actor.persistence.PersistenceProtocol
 import com.andy327.actor.tictactoe.TicTacToeActor
 import com.andy327.model.core.{GameError, GameType, MatchId, PlayerId}
-import com.andy327.model.tictactoe.{Location, Mark, TicTacToe}
+import com.andy327.model.tictactoe.{Location, Mark, O, TicTacToe, X}
 import com.andy327.persistence.db.PlayerHistoryRepository.GameResult
 
 /** Shared per-turn timeout behavior of [[TurnBasedGameActor]], exercised through Tic-Tac-Toe (whose default policy is
@@ -136,8 +136,8 @@ class TurnBasedGameActorTimeoutSpec extends AnyWordSpecLike with Matchers {
 
       // the game is still in progress with Bob to move
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
-      val Right(GridGameState(_, current, winner, _)) = replyProbe.receiveMessage()
-      current shouldBe "O"
+      val Right(GridGameState(_, current, winner, _, _)) = replyProbe.receiveMessage()
+      current shouldBe O
       winner shouldBe None
     }
 
@@ -165,9 +165,9 @@ class TurnBasedGameActorTimeoutSpec extends AnyWordSpecLike with Matchers {
 
       // the board advanced: X is placed and it is now O's turn
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
-      val Right(GridGameState(board, current, winner, _)) = replyProbe.receiveMessage()
-      board(0)(0) shouldBe "X"
-      current shouldBe "O"
+      val Right(GridGameState(board, current, winner, _, _)) = replyProbe.receiveMessage()
+      board(0)(0) shouldBe Some(X)
+      current shouldBe O
       winner shouldBe None
     }
 
@@ -182,9 +182,9 @@ class TurnBasedGameActorTimeoutSpec extends AnyWordSpecLike with Matchers {
 
       // still a fresh game with Alice (X) to move
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
-      val Right(GridGameState(board, current, winner, _)) = replyProbe.receiveMessage()
-      board.flatten should contain only ""
-      current shouldBe "X"
+      val Right(GridGameState(board, current, winner, _, _)) = replyProbe.receiveMessage()
+      board.flatten should contain only None
+      current shouldBe X
       winner shouldBe None
     }
 

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/TurnBasedGameActorTimeoutSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/TurnBasedGameActorTimeoutSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.actor.core.TurnBasedGameActor.TimeoutAction
 import com.andy327.actor.events.NoOpEventPublisher
-import com.andy327.actor.game.{GameState, GridGameState}
+import com.andy327.actor.game.{GameView, GridGameView}
 import com.andy327.actor.lobby.GameLifecycleStatus
 import com.andy327.actor.persistence.PersistenceProtocol
 import com.andy327.actor.tictactoe.TicTacToeActor
@@ -55,7 +55,7 @@ class TurnBasedGameActorTimeoutSpec extends AnyWordSpecLike with Matchers {
     * its success and its move-rejected guard) independently of any real game's rules.
     */
   private class AutoMovePolicyActor(move: Location)
-      extends TurnBasedGameActor[TicTacToe, Location, Mark, GridGameState](
+      extends TurnBasedGameActor[TicTacToe, Location, Mark, GridGameView](
         players => TicTacToe.empty(players(0), players(1)),
         deriveEncoder[Location]
       ) {
@@ -115,14 +115,14 @@ class TurnBasedGameActorTimeoutSpec extends AnyWordSpecLike with Matchers {
       val gameManagerProbe = testKit.createTestProbe[GameManager.Command]()
       val (actor, persistProbe) = newActor(testKit, gameManagerProbe.ref)
       val subscriberProbe = testKit.createTestProbe[PlayerActor.Command]()
-      val replyProbe = testKit.createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = testKit.createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.Subscribe(subscriberProbe.ref, alice)
       subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial state push on subscribe
 
       // Alice actually moves before her clock would fire: moveCount advances 0 → 1 and it becomes Bob's turn
       actor ! TurnBasedGameActor.MakeMove(alice, Location(0, 0), replyProbe.ref)
-      replyProbe.expectMessageType[Right[GameError, GameState]]
+      replyProbe.expectMessageType[Right[GameError, GameView]]
       persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
       persistProbe.expectMessageType[PersistenceProtocol.AppendMove]
       subscriberProbe.expectMessageType[PlayerActor.SendEvent] // GameStateUpdated for the move
@@ -136,7 +136,7 @@ class TurnBasedGameActorTimeoutSpec extends AnyWordSpecLike with Matchers {
 
       // the game is still in progress with Bob to move
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
-      val Right(GridGameState(_, current, winner, _, _)) = replyProbe.receiveMessage()
+      val Right(GridGameView(_, current, winner, _, _)) = replyProbe.receiveMessage()
       current shouldBe O
       winner shouldBe None
     }
@@ -155,7 +155,7 @@ class TurnBasedGameActorTimeoutSpec extends AnyWordSpecLike with Matchers {
     "apply the auto-move and record it when the policy returns AutoMove" in {
       // policy auto-plays the empty top-left cell; Alice (X) is to move at turn 0
       val (actor, persistProbe) = newAutoMoveActor(Location(0, 0))
-      val replyProbe = testKit.createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = testKit.createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.TurnTimeout(alice, 0)
 
@@ -165,7 +165,7 @@ class TurnBasedGameActorTimeoutSpec extends AnyWordSpecLike with Matchers {
 
       // the board advanced: X is placed and it is now O's turn
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
-      val Right(GridGameState(board, current, winner, _, _)) = replyProbe.receiveMessage()
+      val Right(GridGameView(board, current, winner, _, _)) = replyProbe.receiveMessage()
       board(0)(0) shouldBe Some(X)
       current shouldBe O
       winner shouldBe None
@@ -174,7 +174,7 @@ class TurnBasedGameActorTimeoutSpec extends AnyWordSpecLike with Matchers {
     "leave the game untouched when the policy's AutoMove is rejected by the model" in {
       // policy auto-plays an out-of-bounds cell, which TicTacToe.play rejects → the guard logs and no-ops
       val (actor, persistProbe) = newAutoMoveActor(Location(9, 9))
-      val replyProbe = testKit.createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = testKit.createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.TurnTimeout(alice, 0)
 
@@ -182,7 +182,7 @@ class TurnBasedGameActorTimeoutSpec extends AnyWordSpecLike with Matchers {
 
       // still a fresh game with Alice (X) to move
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
-      val Right(GridGameState(board, current, winner, _, _)) = replyProbe.receiveMessage()
+      val Right(GridGameView(board, current, winner, _, _)) = replyProbe.receiveMessage()
       board.flatten should contain only None
       current shouldBe X
       winner shouldBe None

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/LiarsDiceStateSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/LiarsDiceStateSpec.scala
@@ -27,18 +27,18 @@ class LiarsDiceStateSpec extends AnyWordSpec with Matchers with OptionValues {
   "LiarsDiceState.of for a seated player" should {
     "reveal only that player's own dice, plus every seat's count" in {
       val p1 = LiarsDiceState.of(game, Some(0))
-      p1.viewerSeat shouldBe Some("P1")
-      p1.dice shouldBe Some(List(2, 3, 4))
-      p1.diceCounts shouldBe Map("P1" -> 3, "P2" -> 3)
+      p1.viewerSeat shouldBe Some(0)
+      p1.dice shouldBe Some(Vector(2, 3, 4))
+      p1.diceCounts shouldBe Vector(3, 3)
 
       val p2 = LiarsDiceState.of(game, Some(1))
-      p2.dice shouldBe Some(List(5, 6, 1)) // its own hand, not seat 0's
+      p2.dice shouldBe Some(Vector(5, 6, 1)) // its own hand, not seat 0's
     }
 
     "expose the standing bid and whose turn it is" in {
       val view = LiarsDiceState.of(game, Some(0))
-      view.currentBid shouldBe Some(BidView(2, Some(4)))
-      view.currentPlayer shouldBe "P1"
+      view.currentBid shouldBe Some(Bid(2, Some(4)))
+      view.currentPlayer shouldBe 0
       view.winner shouldBe None
     }
   }
@@ -48,7 +48,7 @@ class LiarsDiceStateSpec extends AnyWordSpec with Matchers with OptionValues {
       val view = LiarsDiceState.of(game, None)
       view.viewerSeat shouldBe None
       view.dice shouldBe None
-      view.diceCounts shouldBe Map("P1" -> 3, "P2" -> 3)
+      view.diceCounts shouldBe Vector(3, 3)
     }
   }
 
@@ -66,23 +66,40 @@ class LiarsDiceStateSpec extends AnyWordSpec with Matchers with OptionValues {
       // the challenger (seat 1) lost both dice, so their current hand is empty, but the reveal still shows what it held
       val ended = game.copy(dice = Vector(Vector(4, 4, 4), Vector.empty), lastReveal = Some(reveal), winner = Some(0))
       val view = LiarsDiceState.of(ended, Some(1))
-      val shown = view.lastReveal.value
-      shown.bid shouldBe BidView(3, Some(4))
-      shown.count shouldBe 5
-      shown.dice shouldBe Map("P1" -> List(4, 4, 4), "P2" -> List(4, 1))
-      shown.challenger shouldBe "P2"
-      shown.bidder shouldBe "P1"
-      shown.loser shouldBe "P2"
-      shown.diceLost shouldBe 2
-      view.winner shouldBe Some("P1")
-      view.diceCounts shouldBe Map("P1" -> 3, "P2" -> 0)
+      view.lastReveal.value shouldBe reveal // the model's public snapshot travels as-is
+      view.winner shouldBe Some(0)
+      view.diceCounts shouldBe Vector(3, 0)
     }
   }
 
   "LiarsDiceState.of for a wild ones bid" should {
     "represent a faceless bid with no face" in {
       val onesGame = game.copy(standing = Some(StandingBid(Bid(2, None), 1)))
-      LiarsDiceState.of(onesGame, Some(0)).currentBid shouldBe Some(BidView(2, None))
+      LiarsDiceState.of(onesGame, Some(0)).currentBid shouldBe Some(Bid(2, None))
+    }
+  }
+
+  "LiarsDiceState.of legal moves" should {
+    "offer the player to act every useful raise plus the challenge, and nobody else anything" in {
+      val view = LiarsDiceState.of(game, Some(0))
+      view.legalMoves should contain(MovePayload.LiarsDiceAction("challenge", None, None))
+      // the standing bid is 2×4s over 6 table dice: a higher quantity may keep the face, but never lower it, and
+      // the same quantity needs a strictly higher face
+      view.legalMoves should contain(MovePayload.LiarsDiceAction("bid", Some(3), Some(4)))
+      view.legalMoves should not contain MovePayload.LiarsDiceAction("bid", Some(3), Some(2))
+      view.legalMoves should not contain MovePayload.LiarsDiceAction("bid", Some(2), Some(3))
+      // no bid claims more dice than the table holds
+      view.legalMoves.collect { case MovePayload.LiarsDiceAction("bid", Some(q), _) => q }.max shouldBe 6
+
+      LiarsDiceState.of(game, Some(1)).legalMoves shouldBe empty // waiting on seat 0
+      LiarsDiceState.of(game, None).legalMoves shouldBe empty // spectator
+    }
+
+    "not offer the challenge before any bid stands" in {
+      val opening = game.copy(standing = None)
+      val moves = LiarsDiceState.of(opening, Some(0)).legalMoves
+      moves should not contain MovePayload.LiarsDiceAction("challenge", None, None)
+      moves should not be empty // every opening bid is available
     }
   }
 }

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/LiarsDiceViewSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/LiarsDiceViewSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import com.andy327.model.core.PlayerId
 import com.andy327.model.liarsdice.{Bid, LiarsDice, Reveal, StandingBid}
 
-class LiarsDiceStateSpec extends AnyWordSpec with Matchers with OptionValues {
+class LiarsDiceViewSpec extends AnyWordSpec with Matchers with OptionValues {
   val alice: PlayerId = UUID.randomUUID() // seat 0
   val bob: PlayerId = UUID.randomUUID() // seat 1
 
@@ -24,35 +24,35 @@ class LiarsDiceStateSpec extends AnyWordSpec with Matchers with OptionValues {
       moveCount = 3
     )
 
-  "LiarsDiceState.of for a seated player" should {
+  "LiarsDiceView.of for a seated player" should {
     "reveal only that player's own dice, plus every seat's count" in {
-      val p1 = LiarsDiceState.of(game, Some(0))
+      val p1 = LiarsDiceView.of(game, Some(0))
       p1.viewerSeat shouldBe Some(0)
       p1.dice shouldBe Some(Vector(2, 3, 4))
       p1.diceCounts shouldBe Vector(3, 3)
 
-      val p2 = LiarsDiceState.of(game, Some(1))
+      val p2 = LiarsDiceView.of(game, Some(1))
       p2.dice shouldBe Some(Vector(5, 6, 1)) // its own hand, not seat 0's
     }
 
     "expose the standing bid and whose turn it is" in {
-      val view = LiarsDiceState.of(game, Some(0))
+      val view = LiarsDiceView.of(game, Some(0))
       view.currentBid shouldBe Some(Bid(2, Some(4)))
       view.currentPlayer shouldBe 0
       view.winner shouldBe None
     }
   }
 
-  "LiarsDiceState.of for a spectator" should {
+  "LiarsDiceView.of for a spectator" should {
     "hide every hand while still reporting the counts" in {
-      val view = LiarsDiceState.of(game, None)
+      val view = LiarsDiceView.of(game, None)
       view.viewerSeat shouldBe None
       view.dice shouldBe None
       view.diceCounts shouldBe Vector(3, 3)
     }
   }
 
-  "LiarsDiceState.of with a resolved challenge" should {
+  "LiarsDiceView.of with a resolved challenge" should {
     "expose every seat's dice in the reveal — the one public moment" in {
       val reveal = Reveal(
         bid = Bid(3, Some(4)),
@@ -65,23 +65,23 @@ class LiarsDiceStateSpec extends AnyWordSpec with Matchers with OptionValues {
       )
       // the challenger (seat 1) lost both dice, so their current hand is empty, but the reveal still shows what it held
       val ended = game.copy(dice = Vector(Vector(4, 4, 4), Vector.empty), lastReveal = Some(reveal), winner = Some(0))
-      val view = LiarsDiceState.of(ended, Some(1))
+      val view = LiarsDiceView.of(ended, Some(1))
       view.lastReveal.value shouldBe reveal // the model's public snapshot travels as-is
       view.winner shouldBe Some(0)
       view.diceCounts shouldBe Vector(3, 0)
     }
   }
 
-  "LiarsDiceState.of for a wild ones bid" should {
+  "LiarsDiceView.of for a wild ones bid" should {
     "represent a faceless bid with no face" in {
       val onesGame = game.copy(standing = Some(StandingBid(Bid(2, None), 1)))
-      LiarsDiceState.of(onesGame, Some(0)).currentBid shouldBe Some(Bid(2, None))
+      LiarsDiceView.of(onesGame, Some(0)).currentBid shouldBe Some(Bid(2, None))
     }
   }
 
-  "LiarsDiceState.of legal moves" should {
+  "LiarsDiceView.of legal moves" should {
     "offer the player to act every useful raise plus the challenge, and nobody else anything" in {
-      val view = LiarsDiceState.of(game, Some(0))
+      val view = LiarsDiceView.of(game, Some(0))
       view.legalMoves should contain(MovePayload.LiarsDiceAction("challenge", None, None))
       // the standing bid is 2×4s over 6 table dice: a higher quantity may keep the face, but never lower it, and
       // the same quantity needs a strictly higher face
@@ -91,13 +91,13 @@ class LiarsDiceStateSpec extends AnyWordSpec with Matchers with OptionValues {
       // no bid claims more dice than the table holds
       view.legalMoves.collect { case MovePayload.LiarsDiceAction("bid", Some(q), _) => q }.max shouldBe 6
 
-      LiarsDiceState.of(game, Some(1)).legalMoves shouldBe empty // waiting on seat 0
-      LiarsDiceState.of(game, None).legalMoves shouldBe empty // spectator
+      LiarsDiceView.of(game, Some(1)).legalMoves shouldBe empty // waiting on seat 0
+      LiarsDiceView.of(game, None).legalMoves shouldBe empty // spectator
     }
 
     "not offer the challenge before any bid stands" in {
       val opening = game.copy(standing = None)
-      val moves = LiarsDiceState.of(opening, Some(0)).legalMoves
+      val moves = LiarsDiceView.of(opening, Some(0)).legalMoves
       moves should not contain MovePayload.LiarsDiceAction("challenge", None, None)
       moves should not be empty // every opening bid is available
     }

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/TexasHoldEmStateSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/TexasHoldEmStateSpec.scala
@@ -41,29 +41,29 @@ class TexasHoldEmStateSpec extends AnyWordSpec with Matchers with OptionValues {
   "HoldEmState.of for a seated player" should {
     "reveal only that player's own hole cards, plus every seat's public state" in {
       val p1 = HoldEmState.of(game, Some(0))
-      p1.viewerSeat shouldBe Some("P1")
-      p1.holeCards shouldBe Some(List("AS", "AH"))
+      p1.viewerSeat shouldBe Some(0)
+      p1.holeCards shouldBe Some(cards("AS", "AH"))
       p1.seats shouldBe List(
-        HoldEmSeat("P1", 900, 100, 0, folded = false, allIn = false),
-        HoldEmSeat("P2", 800, 150, 50, folded = false, allIn = false),
-        HoldEmSeat("P3", 1000, 100, 0, folded = false, allIn = false)
+        HoldEmSeat(900, 100, 0, folded = false, allIn = false),
+        HoldEmSeat(800, 150, 50, folded = false, allIn = false),
+        HoldEmSeat(1000, 100, 0, folded = false, allIn = false)
       )
 
       val p2 = HoldEmState.of(game, Some(1))
-      p2.holeCards shouldBe Some(List("KS", "KH")) // its own hand, not seat 0's
+      p2.holeCards shouldBe Some(cards("KS", "KH")) // its own hand, not seat 0's
     }
 
     "reveal only the community cards dealt on the current street" in {
-      HoldEmState.of(game, Some(0)).board shouldBe List("2C", "7D", "9S") // the flop, not the turn or river
+      HoldEmState.of(game, Some(0)).board shouldBe cards("2C", "7D", "9S") // the flop, not the turn or river
       HoldEmState.of(game.copy(street = Street.PreFlop), Some(0)).board shouldBe Nil
       HoldEmState.of(game.copy(street = Street.River), Some(0)).board shouldBe
-        List("2C", "7D", "9S", "JD", "4H")
+        cards("2C", "7D", "9S", "JD", "4H")
     }
 
     "expose the betting state and each player's amount to call" in {
       val p1 = HoldEmState.of(game, Some(0))
-      p1.button shouldBe "P1"
-      p1.currentPlayer shouldBe "P2"
+      p1.button shouldBe 0
+      p1.currentPlayer shouldBe 1
       p1.currentBet shouldBe 50
       p1.minRaise shouldBe 100 // current bet plus the last raise size
       p1.pot shouldBe 350
@@ -96,12 +96,52 @@ class TexasHoldEmStateSpec extends AnyWordSpec with Matchers with OptionValues {
         awards = List(PotAward(350, List(0), Some("one pair, As")))
       )
       val ended = game.copy(handResult = Some(result), winner = Some(0), street = Street.River)
-      val shown = HoldEmState.of(ended, Some(1)).handResult.value
+      val view = HoldEmState.of(ended, Some(1))
+      view.handResult.value shouldBe result // the model's public reveal travels as-is
+      view.winner shouldBe Some(0)
+    }
+  }
 
-      shown.board shouldBe List("2C", "7D", "9S", "JD", "4H")
-      shown.shownHands shouldBe Map("P1" -> List("AS", "AH"), "P3" -> List("QS", "QH"))
-      shown.awards shouldBe List(HoldEmPotAward(350, List("P1"), Some("one pair, As")))
-      HoldEmState.of(ended, Some(1)).winner shouldBe Some("P1")
+  "HoldEmState.of legal moves" should {
+    "offer the player to act their chip-free actions and sizing range, and nobody else anything" in {
+      // seat 1 has matched the bet, so it may check or fold, and raise anywhere from a min-raise to its all-in
+      val toAct = HoldEmState.of(game, Some(1))
+      toAct.legalMoves shouldBe List(
+        MovePayload.HoldEmAction("fold", None),
+        MovePayload.HoldEmAction("check", None)
+      )
+      toAct.betSizing shouldBe Some(BetSizing("raise", min = 100, max = 850)) // 50+50 up to 50+800 all-in
+
+      val waiting = HoldEmState.of(game, Some(0))
+      waiting.legalMoves shouldBe empty
+      waiting.betSizing shouldBe None
+
+      HoldEmState.of(game, None).legalMoves shouldBe empty // spectator
+      HoldEmState.of(game, None).betSizing shouldBe None
+    }
+
+    "offer call rather than check when chips are owed, and name the sizing a bet when nothing stands" in {
+      val noBet = game.copy(currentBet = 0, streetContrib = Vector(0, 0, 0))
+      val opening = HoldEmState.of(noBet, Some(1))
+      opening.legalMoves should contain(MovePayload.HoldEmAction("check", None))
+      opening.betSizing shouldBe Some(BetSizing("bet", min = TexasHoldEm.BigBlind, max = 800))
+
+      val owing = game.copy(streetContrib = Vector(0, 0, 0)) // the 50 bet stands and seat 1 has nothing in
+      val view = HoldEmState.of(owing, Some(1))
+      view.legalMoves shouldBe List(
+        MovePayload.HoldEmAction("fold", None),
+        MovePayload.HoldEmAction("call", None)
+      )
+    }
+
+    "collapse the sizing to the all-in for a short stack, dropping it when the bet cannot be exceeded at all" in {
+      val shortRaise = game.copy(stacks = Vector(900, 60, 1000), streetContrib = Vector(0, 0, 0))
+      HoldEmState.of(shortRaise, Some(1)).betSizing shouldBe Some(BetSizing("raise", min = 60, max = 60))
+
+      val tooShort = game.copy(stacks = Vector(900, 30, 1000), streetContrib = Vector(0, 0, 0))
+      val view = HoldEmState.of(tooShort, Some(1))
+      view.betSizing shouldBe None
+      view.legalMoves should contain(MovePayload.HoldEmAction("call", None)) // the short all-in call remains
     }
   }
 }

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/TexasHoldEmViewSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/TexasHoldEmViewSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import com.andy327.model.core.PlayerId
 import com.andy327.model.holdem.{Card, HandResult, PotAward, Street, TexasHoldEm}
 
-class TexasHoldEmStateSpec extends AnyWordSpec with Matchers with OptionValues {
+class TexasHoldEmViewSpec extends AnyWordSpec with Matchers with OptionValues {
   private val alice: PlayerId = UUID.randomUUID() // seat 0
   private val bob: PlayerId = UUID.randomUUID() // seat 1
   private val carol: PlayerId = UUID.randomUUID() // seat 2
@@ -38,9 +38,9 @@ class TexasHoldEmStateSpec extends AnyWordSpec with Matchers with OptionValues {
       moveCount = 5
     )
 
-  "HoldEmState.of for a seated player" should {
+  "HoldEmView.of for a seated player" should {
     "reveal only that player's own hole cards, plus every seat's public state" in {
-      val p1 = HoldEmState.of(game, Some(0))
+      val p1 = HoldEmView.of(game, Some(0))
       p1.viewerSeat shouldBe Some(0)
       p1.holeCards shouldBe Some(cards("AS", "AH"))
       p1.seats shouldBe List(
@@ -49,19 +49,19 @@ class TexasHoldEmStateSpec extends AnyWordSpec with Matchers with OptionValues {
         HoldEmSeat(1000, 100, 0, folded = false, allIn = false)
       )
 
-      val p2 = HoldEmState.of(game, Some(1))
+      val p2 = HoldEmView.of(game, Some(1))
       p2.holeCards shouldBe Some(cards("KS", "KH")) // its own hand, not seat 0's
     }
 
     "reveal only the community cards dealt on the current street" in {
-      HoldEmState.of(game, Some(0)).board shouldBe cards("2C", "7D", "9S") // the flop, not the turn or river
-      HoldEmState.of(game.copy(street = Street.PreFlop), Some(0)).board shouldBe Nil
-      HoldEmState.of(game.copy(street = Street.River), Some(0)).board shouldBe
+      HoldEmView.of(game, Some(0)).board shouldBe cards("2C", "7D", "9S") // the flop, not the turn or river
+      HoldEmView.of(game.copy(street = Street.PreFlop), Some(0)).board shouldBe Nil
+      HoldEmView.of(game.copy(street = Street.River), Some(0)).board shouldBe
         cards("2C", "7D", "9S", "JD", "4H")
     }
 
     "expose the betting state and each player's amount to call" in {
-      val p1 = HoldEmState.of(game, Some(0))
+      val p1 = HoldEmView.of(game, Some(0))
       p1.button shouldBe 0
       p1.currentPlayer shouldBe 1
       p1.currentBet shouldBe 50
@@ -69,18 +69,18 @@ class TexasHoldEmStateSpec extends AnyWordSpec with Matchers with OptionValues {
       p1.pot shouldBe 350
       p1.toCall shouldBe 50 // seat 0 has nothing in this street yet
 
-      HoldEmState.of(game, Some(1)).toCall shouldBe 0 // seat 1 has already matched the bet
+      HoldEmView.of(game, Some(1)).toCall shouldBe 0 // seat 1 has already matched the bet
     }
 
     "report the minimum raise as the big blind when there is no bet yet on the street" in {
       val noBet = game.copy(currentBet = 0, streetContrib = Vector(0, 0, 0))
-      HoldEmState.of(noBet, Some(0)).minRaise shouldBe TexasHoldEm.BigBlind
+      HoldEmView.of(noBet, Some(0)).minRaise shouldBe TexasHoldEm.BigBlind
     }
   }
 
-  "HoldEmState.of for a spectator" should {
+  "HoldEmView.of for a spectator" should {
     "hide every hole card while still reporting the public state" in {
-      val view = HoldEmState.of(game, None)
+      val view = HoldEmView.of(game, None)
       view.viewerSeat shouldBe None
       view.holeCards shouldBe None
       view.toCall shouldBe 0
@@ -88,7 +88,7 @@ class TexasHoldEmStateSpec extends AnyWordSpec with Matchers with OptionValues {
     }
   }
 
-  "HoldEmState.of with a finished hand" should {
+  "HoldEmView.of with a finished hand" should {
     "expose the showdown reveal — hole cards of the seats that reached it" in {
       val result = HandResult(
         board = cards("2C", "7D", "9S", "JD", "4H"),
@@ -96,38 +96,38 @@ class TexasHoldEmStateSpec extends AnyWordSpec with Matchers with OptionValues {
         awards = List(PotAward(350, List(0), Some("one pair, As")))
       )
       val ended = game.copy(handResult = Some(result), winner = Some(0), street = Street.River)
-      val view = HoldEmState.of(ended, Some(1))
+      val view = HoldEmView.of(ended, Some(1))
       view.handResult.value shouldBe result // the model's public reveal travels as-is
       view.winner shouldBe Some(0)
     }
   }
 
-  "HoldEmState.of legal moves" should {
+  "HoldEmView.of legal moves" should {
     "offer the player to act their chip-free actions and sizing range, and nobody else anything" in {
       // seat 1 has matched the bet, so it may check or fold, and raise anywhere from a min-raise to its all-in
-      val toAct = HoldEmState.of(game, Some(1))
+      val toAct = HoldEmView.of(game, Some(1))
       toAct.legalMoves shouldBe List(
         MovePayload.HoldEmAction("fold", None),
         MovePayload.HoldEmAction("check", None)
       )
       toAct.betSizing shouldBe Some(BetSizing("raise", min = 100, max = 850)) // 50+50 up to 50+800 all-in
 
-      val waiting = HoldEmState.of(game, Some(0))
+      val waiting = HoldEmView.of(game, Some(0))
       waiting.legalMoves shouldBe empty
       waiting.betSizing shouldBe None
 
-      HoldEmState.of(game, None).legalMoves shouldBe empty // spectator
-      HoldEmState.of(game, None).betSizing shouldBe None
+      HoldEmView.of(game, None).legalMoves shouldBe empty // spectator
+      HoldEmView.of(game, None).betSizing shouldBe None
     }
 
     "offer call rather than check when chips are owed, and name the sizing a bet when nothing stands" in {
       val noBet = game.copy(currentBet = 0, streetContrib = Vector(0, 0, 0))
-      val opening = HoldEmState.of(noBet, Some(1))
+      val opening = HoldEmView.of(noBet, Some(1))
       opening.legalMoves should contain(MovePayload.HoldEmAction("check", None))
       opening.betSizing shouldBe Some(BetSizing("bet", min = TexasHoldEm.BigBlind, max = 800))
 
       val owing = game.copy(streetContrib = Vector(0, 0, 0)) // the 50 bet stands and seat 1 has nothing in
-      val view = HoldEmState.of(owing, Some(1))
+      val view = HoldEmView.of(owing, Some(1))
       view.legalMoves shouldBe List(
         MovePayload.HoldEmAction("fold", None),
         MovePayload.HoldEmAction("call", None)
@@ -136,10 +136,10 @@ class TexasHoldEmStateSpec extends AnyWordSpec with Matchers with OptionValues {
 
     "collapse the sizing to the all-in for a short stack, dropping it when the bet cannot be exceeded at all" in {
       val shortRaise = game.copy(stacks = Vector(900, 60, 1000), streetContrib = Vector(0, 0, 0))
-      HoldEmState.of(shortRaise, Some(1)).betSizing shouldBe Some(BetSizing("raise", min = 60, max = 60))
+      HoldEmView.of(shortRaise, Some(1)).betSizing shouldBe Some(BetSizing("raise", min = 60, max = 60))
 
       val tooShort = game.copy(stacks = Vector(900, 30, 1000), streetContrib = Vector(0, 0, 0))
-      val view = HoldEmState.of(tooShort, Some(1))
+      val view = HoldEmView.of(tooShort, Some(1))
       view.betSizing shouldBe None
       view.legalMoves should contain(MovePayload.HoldEmAction("call", None)) // the short all-in call remains
     }

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/BattleshipModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/BattleshipModuleSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.actor.battleship.BattleshipActor
 import com.andy327.actor.core.{PlayerActor, TurnBasedGameActor}
-import com.andy327.actor.game.{BattleshipState, GameOperation, GameState, MovePayload}
+import com.andy327.actor.game.{BattleshipView, GameOperation, GameView, MovePayload}
 import com.andy327.actor.lobby.Player
 import com.andy327.model.battleship.{Battleship, Coord, Fire}
 import com.andy327.model.core.GameError
@@ -33,7 +33,7 @@ class BattleshipModuleSpec extends AnyWordSpecLike with Matchers {
 
     "convert a valid GameOperation.MakeMove to a Fire GameCommand" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
       val move = MovePayload.BattleshipMove(3, 4)
 
       val result = BattleshipModule.toGameCommand(GameOperation.MakeMove(alice.id, move), replyProbe.ref)
@@ -49,7 +49,7 @@ class BattleshipModuleSpec extends AnyWordSpecLike with Matchers {
     }
 
     "convert GetState to a GetState GameCommand" in {
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
 
       val result = BattleshipModule.toGameCommand(GameOperation.GetState, replyProbe.ref)
 
@@ -65,14 +65,14 @@ class BattleshipModuleSpec extends AnyWordSpecLike with Matchers {
       result shouldBe TurnBasedGameActor.Subscribe(playerProbe.ref, playerId)
     }
 
-    "serialize a Battleship game to BattleshipState" in {
+    "serialize a Battleship game to BattleshipView" in {
       val game = Battleship.random(Player("alice").id, Player("bob").id, new Random(0))
-      BattleshipModule.serialize(game, None) shouldBe a[BattleshipState]
+      BattleshipModule.project(game, None) shouldBe a[BattleshipView]
     }
 
     "return error when passing unsupported MovePayload to toGameCommand" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
       val unsupportedMove = null.asInstanceOf[MovePayload] // simulate invalid move type
 
       val result = BattleshipModule.toGameCommand(

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/CheckersModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/CheckersModuleSpec.scala
@@ -64,7 +64,7 @@ class CheckersModuleSpec extends AnyWordSpecLike with Matchers {
       result shouldBe TurnBasedGameActor.Subscribe(playerProbe.ref, playerId)
     }
 
-    "serialize a Checkers game to CheckersState, rendering kings uppercase and pawns lowercase" in {
+    "serialize a Checkers game to CheckersState, carrying each square's piece" in {
       val alice = Player("alice")
       val bob = Player("bob")
       val empty = Vector.fill(Checkers.Size, Checkers.Size)(Option.empty[Piece])
@@ -75,9 +75,21 @@ class CheckersModuleSpec extends AnyWordSpecLike with Matchers {
       val state = CheckersModule.serialize(game, None)
       state shouldBe a[CheckersState]
       val view = state.asInstanceOf[CheckersState]
-      view.board(0)(1) shouldBe Some(Piece(Red, isKing = true)) // red king → uppercase
-      view.board(5)(0) shouldBe Some(Piece(Black, isKing = false)) // black pawn → lowercase
+      view.board(0)(1) shouldBe Some(Piece(Red, isKing = true))
+      view.board(5)(0) shouldBe Some(Piece(Black, isKing = false))
       view.board(4)(4) shouldBe None // empty square
+    }
+
+    "offer the player to act their own moves, and nobody else any" in {
+      val alice = Player("alice") // seated Red, and Red leads
+      val bob = Player("bob")
+      val game = Checkers.empty(alice.id, bob.id)
+
+      val toAct = CheckersModule.serialize(game, Some(alice.id)).asInstanceOf[CheckersState]
+      toAct.legalMoves should not be empty
+
+      CheckersModule.serialize(game, Some(bob.id)).asInstanceOf[CheckersState].legalMoves shouldBe empty
+      CheckersModule.serialize(game, None).asInstanceOf[CheckersState].legalMoves shouldBe empty // spectator
     }
 
     "tag the serialized view with the requesting player's own color" in {

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/CheckersModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/CheckersModuleSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.actor.checkers.CheckersActor
 import com.andy327.actor.core.{PlayerActor, TurnBasedGameActor}
-import com.andy327.actor.game.{CheckersState, GameOperation, GameRegistry, GameState, MovePayload}
+import com.andy327.actor.game.{CheckersView, GameOperation, GameRegistry, GameView, MovePayload}
 import com.andy327.actor.lobby.Player
 import com.andy327.model.checkers.{Black, Checkers, Move, Piece, Red, Square}
 import com.andy327.model.core.{GameError, GameType}
@@ -32,7 +32,7 @@ class CheckersModuleSpec extends AnyWordSpecLike with Matchers {
 
     "convert a valid GameOperation.MakeMove to a GameCommand" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
       val move = MovePayload.CheckersMove(Square(5, 2), List(Square(4, 1)))
 
       val result = CheckersModule.toGameCommand(GameOperation.MakeMove(alice.id, move), replyProbe.ref)
@@ -48,7 +48,7 @@ class CheckersModuleSpec extends AnyWordSpecLike with Matchers {
     }
 
     "convert GetState to a GetState GameCommand" in {
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
 
       val result = CheckersModule.toGameCommand(GameOperation.GetState, replyProbe.ref)
 
@@ -64,7 +64,7 @@ class CheckersModuleSpec extends AnyWordSpecLike with Matchers {
       result shouldBe TurnBasedGameActor.Subscribe(playerProbe.ref, playerId)
     }
 
-    "serialize a Checkers game to CheckersState, carrying each square's piece" in {
+    "serialize a Checkers game to CheckersView, carrying each square's piece" in {
       val alice = Player("alice")
       val bob = Player("bob")
       val empty = Vector.fill(Checkers.Size, Checkers.Size)(Option.empty[Piece])
@@ -72,9 +72,9 @@ class CheckersModuleSpec extends AnyWordSpecLike with Matchers {
       val board = withRedKing.updated(5, withRedKing(5).updated(0, Some(Piece(Black, isKing = false))))
       val game = Checkers(alice.id, bob.id, board, Red, None, moveCount = 0)
 
-      val state = CheckersModule.serialize(game, None)
-      state shouldBe a[CheckersState]
-      val view = state.asInstanceOf[CheckersState]
+      val state = CheckersModule.project(game, None)
+      state shouldBe a[CheckersView]
+      val view = state.asInstanceOf[CheckersView]
       view.board(0)(1) shouldBe Some(Piece(Red, isKing = true))
       view.board(5)(0) shouldBe Some(Piece(Black, isKing = false))
       view.board(4)(4) shouldBe None // empty square
@@ -85,11 +85,11 @@ class CheckersModuleSpec extends AnyWordSpecLike with Matchers {
       val bob = Player("bob")
       val game = Checkers.empty(alice.id, bob.id)
 
-      val toAct = CheckersModule.serialize(game, Some(alice.id)).asInstanceOf[CheckersState]
+      val toAct = CheckersModule.project(game, Some(alice.id)).asInstanceOf[CheckersView]
       toAct.legalMoves should not be empty
 
-      CheckersModule.serialize(game, Some(bob.id)).asInstanceOf[CheckersState].legalMoves shouldBe empty
-      CheckersModule.serialize(game, None).asInstanceOf[CheckersState].legalMoves shouldBe empty // spectator
+      CheckersModule.project(game, Some(bob.id)).asInstanceOf[CheckersView].legalMoves shouldBe empty
+      CheckersModule.project(game, None).asInstanceOf[CheckersView].legalMoves shouldBe empty // spectator
     }
 
     "tag the serialized view with the requesting player's own color" in {
@@ -97,9 +97,9 @@ class CheckersModuleSpec extends AnyWordSpecLike with Matchers {
       val bob = Player("bob") // seated Black (second)
       val game = Checkers.empty(alice.id, bob.id)
 
-      CheckersModule.serialize(game, Some(alice.id)).asInstanceOf[CheckersState].viewerSeat shouldBe Some(Red)
-      CheckersModule.serialize(game, Some(bob.id)).asInstanceOf[CheckersState].viewerSeat shouldBe Some(Black)
-      CheckersModule.serialize(game, None).asInstanceOf[CheckersState].viewerSeat shouldBe None // spectator
+      CheckersModule.project(game, Some(alice.id)).asInstanceOf[CheckersView].viewerSeat shouldBe Some(Red)
+      CheckersModule.project(game, Some(bob.id)).asInstanceOf[CheckersView].viewerSeat shouldBe Some(Black)
+      CheckersModule.project(game, None).asInstanceOf[CheckersView].viewerSeat shouldBe None // spectator
     }
 
     "expose the Checkers bundle through the GameRegistry" in {
@@ -110,7 +110,7 @@ class CheckersModuleSpec extends AnyWordSpecLike with Matchers {
 
     "return error when passing unsupported MovePayload to toGameCommand" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
       val unsupportedMove = null.asInstanceOf[MovePayload]
 
       val result = CheckersModule.toGameCommand(

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/CheckersModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/CheckersModuleSpec.scala
@@ -75,9 +75,9 @@ class CheckersModuleSpec extends AnyWordSpecLike with Matchers {
       val state = CheckersModule.serialize(game, None)
       state shouldBe a[CheckersState]
       val view = state.asInstanceOf[CheckersState]
-      view.board(0)(1) shouldBe "R" // red king → uppercase
-      view.board(5)(0) shouldBe "b" // black pawn → lowercase
-      view.board(4)(4) shouldBe "" // empty square
+      view.board(0)(1) shouldBe Some(Piece(Red, isKing = true)) // red king → uppercase
+      view.board(5)(0) shouldBe Some(Piece(Black, isKing = false)) // black pawn → lowercase
+      view.board(4)(4) shouldBe None // empty square
     }
 
     "tag the serialized view with the requesting player's own color" in {
@@ -85,8 +85,8 @@ class CheckersModuleSpec extends AnyWordSpecLike with Matchers {
       val bob = Player("bob") // seated Black (second)
       val game = Checkers.empty(alice.id, bob.id)
 
-      CheckersModule.serialize(game, Some(alice.id)).asInstanceOf[CheckersState].viewerSeat shouldBe Some("R")
-      CheckersModule.serialize(game, Some(bob.id)).asInstanceOf[CheckersState].viewerSeat shouldBe Some("B")
+      CheckersModule.serialize(game, Some(alice.id)).asInstanceOf[CheckersState].viewerSeat shouldBe Some(Red)
+      CheckersModule.serialize(game, Some(bob.id)).asInstanceOf[CheckersState].viewerSeat shouldBe Some(Black)
       CheckersModule.serialize(game, None).asInstanceOf[CheckersState].viewerSeat shouldBe None // spectator
     }
 

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/ConnectFourModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/ConnectFourModuleSpec.scala
@@ -70,6 +70,18 @@ class ConnectFourModuleSpec extends AnyWordSpecLike with Matchers {
       ConnectFourModule.serialize(game, None) shouldBe a[GridGameState]
     }
 
+    "offer the player to act their own moves, and nobody else any" in {
+      val alice = Player("alice")
+      val bob = Player("bob")
+      val game = ConnectFour.empty(alice.id, bob.id) // Red (alice) leads
+
+      val toAct = ConnectFourModule.serialize(game, Some(alice.id)).asInstanceOf[GridGameState]
+      toAct.legalMoves should have size ConnectFour.Cols.toLong
+
+      ConnectFourModule.serialize(game, Some(bob.id)).asInstanceOf[GridGameState].legalMoves shouldBe empty
+      ConnectFourModule.serialize(game, None).asInstanceOf[GridGameState].legalMoves shouldBe empty // spectator
+    }
+
     "return error when passing unsupported MovePayload to toGameCommand" in {
       val alice = Player("alice")
       val replyProbe = TestProbe[Either[GameError, GameState]]()

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/ConnectFourModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/ConnectFourModuleSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.actor.connectfour.ConnectFourActor
 import com.andy327.actor.core.{PlayerActor, TurnBasedGameActor}
-import com.andy327.actor.game.{GameOperation, GameState, GridGameState, MovePayload}
+import com.andy327.actor.game.{GameOperation, GameView, GridGameView, MovePayload}
 import com.andy327.actor.lobby.Player
 import com.andy327.model.connectfour.{ConnectFour, Drop}
 import com.andy327.model.core.GameError
@@ -31,7 +31,7 @@ class ConnectFourModuleSpec extends AnyWordSpecLike with Matchers {
 
     "convert a valid GameOperation.MakeMove to a GameCommand" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
       val move = MovePayload.ConnectFourMove(3)
 
       val result = ConnectFourModule.toGameCommand(GameOperation.MakeMove(alice.id, move), replyProbe.ref)
@@ -47,7 +47,7 @@ class ConnectFourModuleSpec extends AnyWordSpecLike with Matchers {
     }
 
     "convert GetState to a GetState GameCommand" in {
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
 
       val result = ConnectFourModule.toGameCommand(GameOperation.GetState, replyProbe.ref)
 
@@ -63,11 +63,11 @@ class ConnectFourModuleSpec extends AnyWordSpecLike with Matchers {
       result shouldBe TurnBasedGameActor.Subscribe(playerProbe.ref, playerId)
     }
 
-    "serialize a ConnectFour game to GridGameState" in {
+    "serialize a ConnectFour game to GridGameView" in {
       val alice = Player("alice")
       val bob = Player("bob")
       val game = ConnectFour.empty(alice.id, bob.id)
-      ConnectFourModule.serialize(game, None) shouldBe a[GridGameState]
+      ConnectFourModule.project(game, None) shouldBe a[GridGameView]
     }
 
     "offer the player to act their own moves, and nobody else any" in {
@@ -75,16 +75,16 @@ class ConnectFourModuleSpec extends AnyWordSpecLike with Matchers {
       val bob = Player("bob")
       val game = ConnectFour.empty(alice.id, bob.id) // Red (alice) leads
 
-      val toAct = ConnectFourModule.serialize(game, Some(alice.id)).asInstanceOf[GridGameState]
+      val toAct = ConnectFourModule.project(game, Some(alice.id)).asInstanceOf[GridGameView]
       toAct.legalMoves should have size ConnectFour.Cols.toLong
 
-      ConnectFourModule.serialize(game, Some(bob.id)).asInstanceOf[GridGameState].legalMoves shouldBe empty
-      ConnectFourModule.serialize(game, None).asInstanceOf[GridGameState].legalMoves shouldBe empty // spectator
+      ConnectFourModule.project(game, Some(bob.id)).asInstanceOf[GridGameView].legalMoves shouldBe empty
+      ConnectFourModule.project(game, None).asInstanceOf[GridGameView].legalMoves shouldBe empty // spectator
     }
 
     "return error when passing unsupported MovePayload to toGameCommand" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
       val unsupportedMove = null.asInstanceOf[MovePayload]
 
       val result = ConnectFourModule.toGameCommand(

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/LiarsDiceModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/LiarsDiceModuleSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.actor.core.{PlayerActor, TurnBasedGameActor}
-import com.andy327.actor.game.{GameOperation, GameRegistry, GameState, LiarsDiceState, MovePayload}
+import com.andy327.actor.game.{GameOperation, GameRegistry, GameView, LiarsDiceView, MovePayload}
 import com.andy327.actor.liarsdice.LiarsDiceActor
 import com.andy327.actor.lobby.Player
 import com.andy327.model.core.{GameError, GameType}
@@ -43,7 +43,7 @@ class LiarsDiceModuleSpec extends AnyWordSpecLike with Matchers {
 
     "convert a numbered bid MakeMove to a MakeBid GameCommand" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
 
       val result = LiarsDiceModule.toGameCommand(
         GameOperation.MakeMove(alice.id, MovePayload.LiarsDiceAction("bid", Some(3), Some(4))),
@@ -55,7 +55,7 @@ class LiarsDiceModuleSpec extends AnyWordSpecLike with Matchers {
 
     "convert a wild ones bid MakeMove to a MakeBid GameCommand with no face" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
 
       val result = LiarsDiceModule.toGameCommand(
         GameOperation.MakeMove(alice.id, MovePayload.LiarsDiceAction("bid", Some(2), None)),
@@ -67,7 +67,7 @@ class LiarsDiceModuleSpec extends AnyWordSpecLike with Matchers {
 
     "reject a bid with no quantity" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
 
       val Left(err) = LiarsDiceModule.toGameCommand(
         GameOperation.MakeMove(alice.id, MovePayload.LiarsDiceAction("bid", None, None)),
@@ -79,7 +79,7 @@ class LiarsDiceModuleSpec extends AnyWordSpecLike with Matchers {
 
     "convert a challenge MakeMove to a Challenge GameCommand carrying a full server-rolled pool" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
 
       val result = LiarsDiceModule.toGameCommand(
         GameOperation.MakeMove(alice.id, MovePayload.LiarsDiceAction("challenge", None, None)),
@@ -99,7 +99,7 @@ class LiarsDiceModuleSpec extends AnyWordSpecLike with Matchers {
 
     "return an error for an unknown action string" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
 
       val Left(err) = LiarsDiceModule.toGameCommand(
         GameOperation.MakeMove(alice.id, MovePayload.LiarsDiceAction("bad", None, None)),
@@ -111,7 +111,7 @@ class LiarsDiceModuleSpec extends AnyWordSpecLike with Matchers {
 
     "return error when passing an unsupported MovePayload to toGameCommand" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
 
       val Left(err) = LiarsDiceModule.toGameCommand(
         GameOperation.MakeMove(alice.id, null.asInstanceOf[MovePayload]),
@@ -122,7 +122,7 @@ class LiarsDiceModuleSpec extends AnyWordSpecLike with Matchers {
     }
 
     "convert GetState to a GetState GameCommand" in {
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
       LiarsDiceModule.toGameCommand(GameOperation.GetState, replyProbe.ref) shouldBe
         Right(TurnBasedGameActor.GetState(replyProbe.ref))
     }
@@ -134,11 +134,11 @@ class LiarsDiceModuleSpec extends AnyWordSpecLike with Matchers {
         TurnBasedGameActor.Subscribe(playerProbe.ref, playerId)
     }
 
-    "serialize a Liar's Dice game to a LiarsDiceState for the requesting player" in {
+    "serialize a Liar's Dice game to a LiarsDiceView for the requesting player" in {
       val alice = Player("alice")
       val bob = Player("bob")
       val game = LiarsDice.newGame(Seq(alice.id, bob.id), List.fill(LiarsDice.MaxTotalDice)(4))
-      val state = LiarsDiceModule.serialize(game, Some(alice.id)).asInstanceOf[LiarsDiceState]
+      val state = LiarsDiceModule.project(game, Some(alice.id)).asInstanceOf[LiarsDiceView]
       state.viewerSeat shouldBe Some(0)
       state.dice shouldBe Some(Vector.fill(5)(4))
       state.diceCounts shouldBe Vector(5, 5)

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/LiarsDiceModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/LiarsDiceModuleSpec.scala
@@ -139,10 +139,10 @@ class LiarsDiceModuleSpec extends AnyWordSpecLike with Matchers {
       val bob = Player("bob")
       val game = LiarsDice.newGame(Seq(alice.id, bob.id), List.fill(LiarsDice.MaxTotalDice)(4))
       val state = LiarsDiceModule.serialize(game, Some(alice.id)).asInstanceOf[LiarsDiceState]
-      state.viewerSeat shouldBe Some("P1")
-      state.dice shouldBe Some(List.fill(5)(4))
-      state.diceCounts shouldBe Map("P1" -> 5, "P2" -> 5)
-      state.currentPlayer shouldBe "P1"
+      state.viewerSeat shouldBe Some(0)
+      state.dice shouldBe Some(Vector.fill(5)(4))
+      state.diceCounts shouldBe Vector(5, 5)
+      state.currentPlayer shouldBe 0
       state.currentBid shouldBe None
     }
 

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/MastermindModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/MastermindModuleSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.actor.core.{PlayerActor, TurnBasedGameActor}
-import com.andy327.actor.game.{GameOperation, GameRegistry, GameState, GuessResult, MastermindState, MovePayload}
+import com.andy327.actor.game.{GameOperation, GameRegistry, GameState, MastermindState, MovePayload}
 import com.andy327.actor.lobby.Player
 import com.andy327.actor.mastermind.MastermindActor
 import com.andy327.model.core.{GameError, GameType}
@@ -105,7 +105,7 @@ class MastermindModuleSpec extends AnyWordSpecLike with Matchers {
 
       MastermindModule.serialize(game, Some(codebreaker)).asInstanceOf[MastermindState].secret shouldBe None
       MastermindModule.serialize(game, Some(codemaker)).asInstanceOf[MastermindState].secret shouldBe
-        Some(List("red", "green", "yellow", "blue"))
+        Some(Vector(Peg.Red, Peg.Green, Peg.Yellow, Peg.Blue))
     }
 
     "render guesses and the winner, and reveal the secret to everyone, once the game is over" in {
@@ -120,9 +120,9 @@ class MastermindModuleSpec extends AnyWordSpecLike with Matchers {
         )
 
       val state = MastermindModule.serialize(finished, None).asInstanceOf[MastermindState]
-      state.guesses shouldBe List(GuessResult(List("red", "green", "yellow", "blue"), 4, 0))
-      state.winner shouldBe Some("codebreaker")
-      state.secret shouldBe Some(List("red", "green", "yellow", "blue")) // revealed to all (a spectator here) once over
+      state.guesses shouldBe List(Attempt(secret, Feedback(4, 0)))
+      state.winner shouldBe Some(Codebreaker)
+      state.secret shouldBe Some(secret) // revealed to all (a spectator here) once over
     }
 
     "expose the Mastermind bundle through the GameRegistry" in {

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/MastermindModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/MastermindModuleSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.actor.core.{PlayerActor, TurnBasedGameActor}
-import com.andy327.actor.game.{GameOperation, GameRegistry, GameState, MastermindState, MovePayload}
+import com.andy327.actor.game.{GameOperation, GameRegistry, GameView, MastermindView, MovePayload}
 import com.andy327.actor.lobby.Player
 import com.andy327.actor.mastermind.MastermindActor
 import com.andy327.model.core.{GameError, GameType}
@@ -31,7 +31,7 @@ class MastermindModuleSpec extends AnyWordSpecLike with Matchers {
 
     "convert a setcode operation to a SetCode GameCommand" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
       val move = MovePayload.MastermindAction("setcode", List("red", "green", "yellow", "blue"))
 
       MastermindModule.toGameCommand(GameOperation.MakeMove(alice.id, move), replyProbe.ref) match {
@@ -45,7 +45,7 @@ class MastermindModuleSpec extends AnyWordSpecLike with Matchers {
 
     "convert a guess operation to a Guess GameCommand" in {
       val bob = Player("bob")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
       val move = MovePayload.MastermindAction("guess", List("red", "red", "blue", "green"))
 
       MastermindModule.toGameCommand(GameOperation.MakeMove(bob.id, move), replyProbe.ref) match {
@@ -56,7 +56,7 @@ class MastermindModuleSpec extends AnyWordSpecLike with Matchers {
     }
 
     "reject a move naming a color that is not in the palette" in {
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
       val move = MovePayload.MastermindAction("guess", List("red", "chartreuse", "blue", "green"))
 
       val Left(err) = MastermindModule.toGameCommand(GameOperation.MakeMove(UUID.randomUUID(), move), replyProbe.ref)
@@ -64,7 +64,7 @@ class MastermindModuleSpec extends AnyWordSpecLike with Matchers {
     }
 
     "reject an unknown Mastermind action" in {
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
       val move = MovePayload.MastermindAction("peek", List("red", "green", "yellow", "blue"))
 
       val Left(err) = MastermindModule.toGameCommand(GameOperation.MakeMove(UUID.randomUUID(), move), replyProbe.ref)
@@ -72,13 +72,13 @@ class MastermindModuleSpec extends AnyWordSpecLike with Matchers {
     }
 
     "convert GetState to a GetState GameCommand" in {
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
       MastermindModule.toGameCommand(GameOperation.GetState, replyProbe.ref) shouldBe
         Right(TurnBasedGameActor.GetState(replyProbe.ref))
     }
 
     "return error when passing unsupported MovePayload to toGameCommand" in {
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
       val unsupportedMove = null.asInstanceOf[MovePayload]
 
       val Left(err) =
@@ -93,9 +93,9 @@ class MastermindModuleSpec extends AnyWordSpecLike with Matchers {
         TurnBasedGameActor.Subscribe(playerProbe.ref, playerId)
     }
 
-    "serialize a Mastermind game to MastermindState" in {
-      MastermindModule.serialize(Mastermind.newGame(Seq(UUID.randomUUID(), UUID.randomUUID())), None) shouldBe
-        a[MastermindState]
+    "serialize a Mastermind game to MastermindView" in {
+      MastermindModule.project(Mastermind.newGame(Seq(UUID.randomUUID(), UUID.randomUUID())), None) shouldBe
+        a[MastermindView]
     }
 
     "keep the codebreaker's view free of the secret while play is ongoing" in {
@@ -103,8 +103,8 @@ class MastermindModuleSpec extends AnyWordSpecLike with Matchers {
       val codebreaker = UUID.randomUUID()
       val game = Mastermind(codemaker, codebreaker, Some(Vector(Peg.Red, Peg.Green, Peg.Yellow, Peg.Blue)), Nil, None)
 
-      MastermindModule.serialize(game, Some(codebreaker)).asInstanceOf[MastermindState].secret shouldBe None
-      MastermindModule.serialize(game, Some(codemaker)).asInstanceOf[MastermindState].secret shouldBe
+      MastermindModule.project(game, Some(codebreaker)).asInstanceOf[MastermindView].secret shouldBe None
+      MastermindModule.project(game, Some(codemaker)).asInstanceOf[MastermindView].secret shouldBe
         Some(Vector(Peg.Red, Peg.Green, Peg.Yellow, Peg.Blue))
     }
 
@@ -119,7 +119,7 @@ class MastermindModuleSpec extends AnyWordSpecLike with Matchers {
           Some(Codebreaker)
         )
 
-      val state = MastermindModule.serialize(finished, None).asInstanceOf[MastermindState]
+      val state = MastermindModule.project(finished, None).asInstanceOf[MastermindView]
       state.guesses shouldBe List(Attempt(secret, Feedback(4, 0)))
       state.winner shouldBe Some(Codebreaker)
       state.secret shouldBe Some(secret) // revealed to all (a spectator here) once over

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/PigModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/PigModuleSpec.scala
@@ -112,16 +112,31 @@ class PigModuleSpec extends AnyWordSpecLike with Matchers {
         lastRoll = None,
         winner = None,
         viewerSeat = None,
-        legalMoves = List(MovePayload.PigAction("roll"), MovePayload.PigAction("hold"))
+        legalMoves = Nil // a spectator holds no seat, so has no move to make
       )
+    }
+
+    "offer roll and hold to the player whose turn it is" in {
+      val alice = Player("alice")
+      val bob = Player("bob")
+      val game = Pig.newGame(Seq(alice.id, bob.id)) // seat 0 (alice) leads
+      val state = PigModule.serialize(game, Some(alice.id)).asInstanceOf[PigState]
+      state.legalMoves shouldBe List(MovePayload.PigAction("roll"), MovePayload.PigAction("hold"))
+    }
+
+    "offer no moves to a player waiting on their opponent" in {
+      val alice = Player("alice")
+      val bob = Player("bob")
+      val game = Pig.newGame(Seq(alice.id, bob.id)) // seat 0 (alice) leads, so bob is waiting
+      PigModule.serialize(game, Some(bob.id)).asInstanceOf[PigState].legalMoves shouldBe empty
     }
 
     "offer no moves in PigState once the game has ended" in {
       val alice = Player("alice")
       val bob = Player("bob")
       val game = Pig.newGame(Seq(alice.id, bob.id))
-      val won = game.copy(winner = Some(0))
-      PigModule.serialize(won, None).asInstanceOf[PigState].legalMoves shouldBe empty
+      val won = game.copy(winner = Some(0)) // alice won, and it is still nominally her seat to act
+      PigModule.serialize(won, Some(alice.id)).asInstanceOf[PigState].legalMoves shouldBe empty
     }
 
     "set winner in PigState when the game has ended" in {

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/PigModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/PigModuleSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.actor.core.{PlayerActor, TurnBasedGameActor}
-import com.andy327.actor.game.{GameOperation, GameState, MovePayload, PigState}
+import com.andy327.actor.game.{GameOperation, GameView, MovePayload, PigView}
 import com.andy327.actor.lobby.Player
 import com.andy327.actor.pig.PigActor
 import com.andy327.model.core.GameError
@@ -36,7 +36,7 @@ class PigModuleSpec extends AnyWordSpecLike with Matchers {
 
     "convert a roll GameOperation.MakeMove to a Roll GameCommand with a valid die value" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
 
       val result = PigModule.toGameCommand(
         GameOperation.MakeMove(alice.id, MovePayload.PigAction("roll")),
@@ -55,7 +55,7 @@ class PigModuleSpec extends AnyWordSpecLike with Matchers {
 
     "convert a hold GameOperation.MakeMove to a Hold GameCommand" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
 
       val result = PigModule.toGameCommand(
         GameOperation.MakeMove(alice.id, MovePayload.PigAction("hold")),
@@ -73,7 +73,7 @@ class PigModuleSpec extends AnyWordSpecLike with Matchers {
 
     "return an error for an unknown action string" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
 
       val Left(err) = PigModule.toGameCommand(
         GameOperation.MakeMove(alice.id, MovePayload.PigAction("bad")),
@@ -84,7 +84,7 @@ class PigModuleSpec extends AnyWordSpecLike with Matchers {
     }
 
     "convert GetState to a GetState GameCommand" in {
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
 
       val result = PigModule.toGameCommand(GameOperation.GetState, replyProbe.ref)
 
@@ -100,12 +100,12 @@ class PigModuleSpec extends AnyWordSpecLike with Matchers {
       result shouldBe TurnBasedGameActor.Subscribe(playerProbe.ref, playerId)
     }
 
-    "serialize a Pig game to PigState with correct initial field values" in {
+    "serialize a Pig game to PigView with correct initial field values" in {
       val alice = Player("alice")
       val bob = Player("bob")
       val game = Pig.newGame(Seq(alice.id, bob.id))
-      val state = PigModule.serialize(game, None)
-      state shouldBe PigState(
+      val state = PigModule.project(game, None)
+      state shouldBe PigView(
         scores = Vector(0, 0),
         currentPlayer = 0,
         turnScore = 0,
@@ -120,7 +120,7 @@ class PigModuleSpec extends AnyWordSpecLike with Matchers {
       val alice = Player("alice")
       val bob = Player("bob")
       val game = Pig.newGame(Seq(alice.id, bob.id)) // seat 0 (alice) leads
-      val state = PigModule.serialize(game, Some(alice.id)).asInstanceOf[PigState]
+      val state = PigModule.project(game, Some(alice.id)).asInstanceOf[PigView]
       state.legalMoves shouldBe List(MovePayload.PigAction("roll"), MovePayload.PigAction("hold"))
     }
 
@@ -128,23 +128,23 @@ class PigModuleSpec extends AnyWordSpecLike with Matchers {
       val alice = Player("alice")
       val bob = Player("bob")
       val game = Pig.newGame(Seq(alice.id, bob.id)) // seat 0 (alice) leads, so bob is waiting
-      PigModule.serialize(game, Some(bob.id)).asInstanceOf[PigState].legalMoves shouldBe empty
+      PigModule.project(game, Some(bob.id)).asInstanceOf[PigView].legalMoves shouldBe empty
     }
 
-    "offer no moves in PigState once the game has ended" in {
+    "offer no moves in PigView once the game has ended" in {
       val alice = Player("alice")
       val bob = Player("bob")
       val game = Pig.newGame(Seq(alice.id, bob.id))
       val won = game.copy(winner = Some(0)) // alice won, and it is still nominally her seat to act
-      PigModule.serialize(won, Some(alice.id)).asInstanceOf[PigState].legalMoves shouldBe empty
+      PigModule.project(won, Some(alice.id)).asInstanceOf[PigView].legalMoves shouldBe empty
     }
 
-    "set winner in PigState when the game has ended" in {
+    "set winner in PigView when the game has ended" in {
       val alice = Player("alice")
       val bob = Player("bob")
       val game = Pig.newGame(Seq(alice.id, bob.id))
       val won = game.copy(winner = Some(0))
-      val state = PigModule.serialize(won, None).asInstanceOf[PigState]
+      val state = PigModule.project(won, None).asInstanceOf[PigView]
       state.winner shouldBe Some(0)
     }
 
@@ -152,13 +152,13 @@ class PigModuleSpec extends AnyWordSpecLike with Matchers {
       val alice = Player("alice")
       val bob = Player("bob")
       val game = Pig.newGame(Seq(alice.id, bob.id))
-      val state = PigModule.serialize(game, Some(alice.id)).asInstanceOf[PigState]
+      val state = PigModule.project(game, Some(alice.id)).asInstanceOf[PigView]
       state.viewerSeat shouldBe Some(0)
     }
 
     "return error when passing unsupported MovePayload to toGameCommand" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
       val unsupportedMove = null.asInstanceOf[MovePayload]
 
       val Left(err) = PigModule.toGameCommand(

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/PigModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/PigModuleSpec.scala
@@ -106,13 +106,22 @@ class PigModuleSpec extends AnyWordSpecLike with Matchers {
       val game = Pig.newGame(Seq(alice.id, bob.id))
       val state = PigModule.serialize(game, None)
       state shouldBe PigState(
-        scores = Map("P1" -> 0, "P2" -> 0),
-        currentPlayer = "P1",
+        scores = Vector(0, 0),
+        currentPlayer = 0,
         turnScore = 0,
         lastRoll = None,
         winner = None,
-        viewerSeat = None
+        viewerSeat = None,
+        legalMoves = List(MovePayload.PigAction("roll"), MovePayload.PigAction("hold"))
       )
+    }
+
+    "offer no moves in PigState once the game has ended" in {
+      val alice = Player("alice")
+      val bob = Player("bob")
+      val game = Pig.newGame(Seq(alice.id, bob.id))
+      val won = game.copy(winner = Some(0))
+      PigModule.serialize(won, None).asInstanceOf[PigState].legalMoves shouldBe empty
     }
 
     "set winner in PigState when the game has ended" in {
@@ -121,7 +130,7 @@ class PigModuleSpec extends AnyWordSpecLike with Matchers {
       val game = Pig.newGame(Seq(alice.id, bob.id))
       val won = game.copy(winner = Some(0))
       val state = PigModule.serialize(won, None).asInstanceOf[PigState]
-      state.winner shouldBe Some("P1")
+      state.winner shouldBe Some(0)
     }
 
     "set viewerSeat when serializing for a known player" in {
@@ -129,7 +138,7 @@ class PigModuleSpec extends AnyWordSpecLike with Matchers {
       val bob = Player("bob")
       val game = Pig.newGame(Seq(alice.id, bob.id))
       val state = PigModule.serialize(game, Some(alice.id)).asInstanceOf[PigState]
-      state.viewerSeat shouldBe Some("P1")
+      state.viewerSeat shouldBe Some(0)
     }
 
     "return error when passing unsupported MovePayload to toGameCommand" in {

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/TexasHoldEmModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/TexasHoldEmModuleSpec.scala
@@ -129,10 +129,10 @@ class TexasHoldEmModuleSpec extends AnyWordSpecLike with Matchers {
       val bob = Player("bob")
       val game = TexasHoldEm.newGame(Seq(alice.id, bob.id), Card.deck)
       val state = TexasHoldEmModule.serialize(game, Some(alice.id)).asInstanceOf[HoldEmState]
-      state.viewerSeat shouldBe Some("P1")
+      state.viewerSeat shouldBe Some(0)
       state.holeCards.map(_.size) shouldBe Some(2)
-      state.seats.map(_.seat) shouldBe List("P1", "P2")
-      state.currentPlayer shouldBe "P1"
+      state.seats should have size 2
+      state.currentPlayer shouldBe 0
       state.pot shouldBe 15
     }
 

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/TexasHoldEmModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/TexasHoldEmModuleSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.actor.core.{PlayerActor, TurnBasedGameActor}
-import com.andy327.actor.game.{GameOperation, GameRegistry, GameState, HoldEmState, MovePayload}
+import com.andy327.actor.game.{GameOperation, GameRegistry, GameView, HoldEmView, MovePayload}
 import com.andy327.actor.lobby.Player
 import com.andy327.actor.texasholdem.TexasHoldEmActor
 import com.andy327.model.core.{GameError, GameType}
@@ -36,7 +36,7 @@ class TexasHoldEmModuleSpec extends AnyWordSpecLike with Matchers {
 
     "convert a fold MakeMove to a Fold GameCommand carrying a full shuffled deck" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
 
       TexasHoldEmModule.toGameCommand(
         GameOperation.MakeMove(alice.id, MovePayload.HoldEmAction("fold", None)),
@@ -54,7 +54,7 @@ class TexasHoldEmModuleSpec extends AnyWordSpecLike with Matchers {
 
     "convert a bet MakeMove to a Bet GameCommand with the amount" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
 
       TexasHoldEmModule.toGameCommand(
         GameOperation.MakeMove(alice.id, MovePayload.HoldEmAction("bet", Some(75))),
@@ -67,7 +67,7 @@ class TexasHoldEmModuleSpec extends AnyWordSpecLike with Matchers {
 
     "convert check, call, and raise actions to their moves" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
       def action(payload: MovePayload.HoldEmAction): Action =
         TexasHoldEmModule.toGameCommand(GameOperation.MakeMove(alice.id, payload), replyProbe.ref) match {
           case Right(TurnBasedGameActor.MakeMove(_, HoldEmMove(a, _), _)) => a
@@ -80,7 +80,7 @@ class TexasHoldEmModuleSpec extends AnyWordSpecLike with Matchers {
 
     "reject a bet with no amount" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
 
       val Left(err) = TexasHoldEmModule.toGameCommand(
         GameOperation.MakeMove(alice.id, MovePayload.HoldEmAction("bet", None)),
@@ -91,7 +91,7 @@ class TexasHoldEmModuleSpec extends AnyWordSpecLike with Matchers {
 
     "return an error for an unknown action string" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
 
       val Left(err) = TexasHoldEmModule.toGameCommand(
         GameOperation.MakeMove(alice.id, MovePayload.HoldEmAction("bad", None)),
@@ -102,7 +102,7 @@ class TexasHoldEmModuleSpec extends AnyWordSpecLike with Matchers {
 
     "return error when passing an unsupported MovePayload to toGameCommand" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
 
       val Left(err) = TexasHoldEmModule.toGameCommand(
         GameOperation.MakeMove(alice.id, null.asInstanceOf[MovePayload]),
@@ -112,7 +112,7 @@ class TexasHoldEmModuleSpec extends AnyWordSpecLike with Matchers {
     }
 
     "convert GetState to a GetState GameCommand" in {
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
       TexasHoldEmModule.toGameCommand(GameOperation.GetState, replyProbe.ref) shouldBe
         Right(TurnBasedGameActor.GetState(replyProbe.ref))
     }
@@ -124,11 +124,11 @@ class TexasHoldEmModuleSpec extends AnyWordSpecLike with Matchers {
         TurnBasedGameActor.Subscribe(playerProbe.ref, playerId)
     }
 
-    "serialize a Texas Hold 'Em game to a HoldEmState for the requesting player" in {
+    "serialize a Texas Hold 'Em game to a HoldEmView for the requesting player" in {
       val alice = Player("alice")
       val bob = Player("bob")
       val game = TexasHoldEm.newGame(Seq(alice.id, bob.id), Card.deck)
-      val state = TexasHoldEmModule.serialize(game, Some(alice.id)).asInstanceOf[HoldEmState]
+      val state = TexasHoldEmModule.project(game, Some(alice.id)).asInstanceOf[HoldEmView]
       state.viewerSeat shouldBe Some(0)
       state.holeCards.map(_.size) shouldBe Some(2)
       state.seats should have size 2

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/TicTacToeModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/TicTacToeModuleSpec.scala
@@ -63,6 +63,18 @@ class TicTacToeModuleSpec extends AnyWordSpecLike with Matchers {
       result shouldBe TurnBasedGameActor.Subscribe(playerProbe.ref, playerId)
     }
 
+    "offer the player to act their own moves, and nobody else any" in {
+      val alice = Player("alice")
+      val bob = Player("bob")
+      val game = TicTacToe.empty(alice.id, bob.id) // X (alice) leads
+
+      val toAct = TicTacToeModule.serialize(game, Some(alice.id)).asInstanceOf[GridGameState]
+      toAct.legalMoves should have size 9
+
+      TicTacToeModule.serialize(game, Some(bob.id)).asInstanceOf[GridGameState].legalMoves shouldBe empty
+      TicTacToeModule.serialize(game, None).asInstanceOf[GridGameState].legalMoves shouldBe empty // spectator
+    }
+
     "serialize a TicTacToe game to GridGameState" in {
       val alice = Player("alice")
       val bob = Player("bob")

--- a/game-service-actor/src/test/scala/com/andy327/actor/game/modules/TicTacToeModuleSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/game/modules/TicTacToeModuleSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.actor.core.{PlayerActor, TurnBasedGameActor}
-import com.andy327.actor.game.{GameOperation, GameState, GridGameState, MovePayload}
+import com.andy327.actor.game.{GameOperation, GameView, GridGameView, MovePayload}
 import com.andy327.actor.lobby.Player
 import com.andy327.actor.tictactoe.TicTacToeActor
 import com.andy327.model.core.GameError
@@ -31,7 +31,7 @@ class TicTacToeModuleSpec extends AnyWordSpecLike with Matchers {
 
     "convert a valid GameOperation.MakeMove to a GameCommand" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
       val move = MovePayload.TicTacToeMove(0, 1)
 
       val result = TicTacToeModule.toGameCommand(GameOperation.MakeMove(alice.id, move), replyProbe.ref)
@@ -47,7 +47,7 @@ class TicTacToeModuleSpec extends AnyWordSpecLike with Matchers {
     }
 
     "convert GetState to a GetState GameCommand" in {
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
 
       val result = TicTacToeModule.toGameCommand(GameOperation.GetState, replyProbe.ref)
 
@@ -68,23 +68,23 @@ class TicTacToeModuleSpec extends AnyWordSpecLike with Matchers {
       val bob = Player("bob")
       val game = TicTacToe.empty(alice.id, bob.id) // X (alice) leads
 
-      val toAct = TicTacToeModule.serialize(game, Some(alice.id)).asInstanceOf[GridGameState]
+      val toAct = TicTacToeModule.project(game, Some(alice.id)).asInstanceOf[GridGameView]
       toAct.legalMoves should have size 9
 
-      TicTacToeModule.serialize(game, Some(bob.id)).asInstanceOf[GridGameState].legalMoves shouldBe empty
-      TicTacToeModule.serialize(game, None).asInstanceOf[GridGameState].legalMoves shouldBe empty // spectator
+      TicTacToeModule.project(game, Some(bob.id)).asInstanceOf[GridGameView].legalMoves shouldBe empty
+      TicTacToeModule.project(game, None).asInstanceOf[GridGameView].legalMoves shouldBe empty // spectator
     }
 
-    "serialize a TicTacToe game to GridGameState" in {
+    "serialize a TicTacToe game to GridGameView" in {
       val alice = Player("alice")
       val bob = Player("bob")
       val game = TicTacToe.empty(alice.id, bob.id)
-      TicTacToeModule.serialize(game, None) shouldBe a[GridGameState]
+      TicTacToeModule.project(game, None) shouldBe a[GridGameView]
     }
 
     "return error when passing unsupported MovePayload to toGameCommand" in {
       val alice = Player("alice")
-      val replyProbe = TestProbe[Either[GameError, GameState]]()
+      val replyProbe = TestProbe[Either[GameError, GameView]]()
       val unsupportedMove = null.asInstanceOf[MovePayload] // simulate invalid move type
 
       val result = TicTacToeModule.toGameCommand(

--- a/game-service-actor/src/test/scala/com/andy327/actor/liarsdice/LiarsDiceActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/liarsdice/LiarsDiceActorSpec.scala
@@ -9,14 +9,14 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.actor.core.{GameManager, TurnBasedGameActor}
 import com.andy327.actor.events.NoOpEventPublisher
-import com.andy327.actor.game.GameState
+import com.andy327.actor.game.GameView
 import com.andy327.actor.persistence.PersistenceProtocol
 import com.andy327.model.core.{GameError, PlayerId}
 import com.andy327.model.liarsdice.{Bid, Challenge, MakeBid}
 
 /** Drives the shared turn-based actor with Liar's Dice moves to lock in the move-log encoder — in particular that a
   * challenge never records its server-rolled dice pool (the history endpoint is public) and that a wild "ones" bid
-  * records a null face. State projection and rules are covered by `LiarsDiceStateSpec` and `LiarsDiceSpec`.
+  * records a null face. State projection and rules are covered by `LiarsDiceViewSpec` and `LiarsDiceSpec`.
   */
 class LiarsDiceActorSpec extends AnyWordSpecLike with Matchers {
   private val testKit = ActorTestKit()
@@ -48,7 +48,7 @@ class LiarsDiceActorSpec extends AnyWordSpecLike with Matchers {
       player: PlayerId,
       move: com.andy327.model.liarsdice.LiarsDiceMove
   ): io.circe.Json = {
-    val replyProbe = createTestProbe[Either[GameError, GameState]]()
+    val replyProbe = createTestProbe[Either[GameError, GameView]]()
     actor ! TurnBasedGameActor.MakeMove(player, move, replyProbe.ref)
     replyProbe.receiveMessage()
     persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]

--- a/game-service-actor/src/test/scala/com/andy327/actor/pig/PigActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/pig/PigActorSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.actor.core.{GameManager, TurnBasedGameActor}
 import com.andy327.actor.events.NoOpEventPublisher
-import com.andy327.actor.game.{GameState, PigState}
+import com.andy327.actor.game.{GameView, PigView}
 import com.andy327.actor.persistence.PersistenceProtocol
 import com.andy327.model.core.{GameError, PlayerId}
 import com.andy327.model.pig.Roll
@@ -44,16 +44,16 @@ class PigActorSpec extends AnyWordSpecLike with Matchers {
 
   private def state(
       actor: ActorRef[PigActor.Command],
-      replyProbe: TestProbe[Either[GameError, GameState]]
-  ): PigState = {
+      replyProbe: TestProbe[Either[GameError, GameView]]
+  ): PigView = {
     actor ! TurnBasedGameActor.GetState(replyProbe.ref)
-    replyProbe.receiveMessage().toOption.get.asInstanceOf[PigState]
+    replyProbe.receiveMessage().toOption.get.asInstanceOf[PigView]
   }
 
   "PigActor's turn-timeout policy" should {
     "auto-hold and pass the turn when the clock fires at the start of a turn" in {
       val (actor, persistProbe) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       // Alice is idle from the very start of her turn (turnScore 0); the auto-hold is a no-score pass to Bob
       actor ! TurnBasedGameActor.TurnTimeout(alice, 0)
@@ -70,7 +70,7 @@ class PigActorSpec extends AnyWordSpecLike with Matchers {
 
     "auto-hold and bank the accumulated points when the clock fires mid-turn" in {
       val (actor, persistProbe) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       // Alice rolls a 4 (turnScore 4, moveCount 0 → 1), then goes idle
       actor ! TurnBasedGameActor.MakeMove(alice, Roll(4), replyProbe.ref)

--- a/game-service-actor/src/test/scala/com/andy327/actor/pig/PigActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/pig/PigActorSpec.scala
@@ -62,8 +62,8 @@ class PigActorSpec extends AnyWordSpecLike with Matchers {
         Right("hold")
 
       val after = state(actor, replyProbe)
-      after.currentPlayer shouldBe "P2"
-      after.scores("P1") shouldBe 0
+      after.currentPlayer shouldBe 1
+      after.scores(0) shouldBe 0
       after.turnScore shouldBe 0
       after.winner shouldBe None
     }
@@ -85,8 +85,8 @@ class PigActorSpec extends AnyWordSpecLike with Matchers {
         Right("hold")
 
       val after = state(actor, replyProbe)
-      after.currentPlayer shouldBe "P2"
-      after.scores("P1") shouldBe 4
+      after.currentPlayer shouldBe 1
+      after.scores(0) shouldBe 4
       after.turnScore shouldBe 0
     }
   }

--- a/game-service-actor/src/test/scala/com/andy327/actor/texasholdem/TexasHoldEmActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/texasholdem/TexasHoldEmActorSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.actor.core.{GameManager, TurnBasedGameActor}
 import com.andy327.actor.events.NoOpEventPublisher
-import com.andy327.actor.game.GameState
+import com.andy327.actor.game.GameView
 import com.andy327.actor.persistence.PersistenceProtocol
 import com.andy327.model.core.{GameError, PlayerId}
 import com.andy327.model.holdem.Action.{Call, Raise}
@@ -17,7 +17,7 @@ import com.andy327.model.holdem.{Card, HoldEmMove}
 
 /** Drives the shared turn-based actor with Texas Hold 'Em moves to lock in the move-log encoder — in particular that
   * the deck each move carries never reaches the public history log, and that a raise records its amount. State
-  * projection and rules are covered by `TexasHoldEmStateSpec` and `TexasHoldEmSpec`.
+  * projection and rules are covered by `TexasHoldEmViewSpec` and `TexasHoldEmSpec`.
   */
 class TexasHoldEmActorSpec extends AnyWordSpecLike with Matchers {
   private val testKit = ActorTestKit()
@@ -51,7 +51,7 @@ class TexasHoldEmActorSpec extends AnyWordSpecLike with Matchers {
       player: PlayerId,
       move: HoldEmMove
   ): io.circe.Json = {
-    val replyProbe = createTestProbe[Either[GameError, GameState]]()
+    val replyProbe = createTestProbe[Either[GameError, GameView]]()
     actor ! TurnBasedGameActor.MakeMove(player, move, replyProbe.ref)
     replyProbe.receiveMessage()
     persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]

--- a/game-service-actor/src/test/scala/com/andy327/actor/tictactoe/TicTacToeActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/tictactoe/TicTacToeActorSpec.scala
@@ -17,7 +17,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 import com.andy327.actor.core.{GameManager, PlayerActor, PlayerEvent, TurnBasedGameActor}
 import com.andy327.actor.events.{EventPublisher, GameEvent, NoOpEventPublisher}
-import com.andy327.actor.game.{GameState, GridGameState}
+import com.andy327.actor.game.{GameView, GridGameView}
 import com.andy327.actor.lobby.GameLifecycleStatus
 import com.andy327.actor.persistence.PersistenceProtocol
 import com.andy327.model.core.{Game, GameError, GameType, MatchId, PlayerId}
@@ -80,11 +80,11 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
   "TicTacToeActor" should {
     "return an empty 3×3 board on GetState" in {
       val (actor, _) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
 
-      val Right(GridGameState(board, current, winner, draw, _)) = replyProbe.receiveMessage()
+      val Right(GridGameView(board, current, winner, draw, _)) = replyProbe.receiveMessage()
       board.flatten should contain only None
       current shouldBe X
       winner shouldBe None
@@ -116,10 +116,10 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       )
       val actor = spawn(behavior)
 
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
 
-      val Right(GridGameState(board, current, winner, draw, _)) = replyProbe.receiveMessage()
+      val Right(GridGameView(board, current, winner, draw, _)) = replyProbe.receiveMessage()
       board(0)(0) shouldBe Some(X)
       board(1)(1) shouldBe Some(O)
       current shouldBe X
@@ -187,15 +187,15 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
     "apply a valid move and switch currentPlayer" in {
       val (actor, _) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.MakeMove(alice, Location(0, 0), replyProbe.ref)
-      val Right(GridGameState(board1, current1, _, _, _)) = replyProbe.receiveMessage()
+      val Right(GridGameView(board1, current1, _, _, _)) = replyProbe.receiveMessage()
       board1(0)(0) shouldBe Some(X)
       current1 shouldBe O
 
       actor ! TurnBasedGameActor.MakeMove(bob, Location(1, 1), replyProbe.ref)
-      val Right(GridGameState(board2, current2, _, _, _)) = replyProbe.receiveMessage()
+      val Right(GridGameView(board2, current2, _, _, _)) = replyProbe.receiveMessage()
       board2(0)(0) shouldBe Some(X)
       board2(1)(1) shouldBe Some(O)
       current2 shouldBe X
@@ -203,7 +203,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
     "append each applied move to history with an incrementing seq and the move payload" in {
       val (actor, persistProbe) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.MakeMove(alice, Location(0, 0), replyProbe.ref)
       replyProbe.receiveMessage()
@@ -224,7 +224,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
     "reject a move when it is not the player's turn" in {
       val (actor, _) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.MakeMove(bob, Location(0, 0), replyProbe.ref)
       replyProbe.receiveMessage() shouldBe Left(GameError.InvalidTurn)
@@ -233,7 +233,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
     "reject a move from a player not in the game" in {
       val eve: PlayerId = UUID.randomUUID()
       val (actor, _) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.MakeMove(eve, Location(0, 0), replyProbe.ref)
       replyProbe.receiveMessage() shouldBe Left(GameError.InvalidPlayer(eve))
@@ -241,7 +241,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
     "reject an invalid move" in {
       val (actor, _) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.MakeMove(alice, Location(0, 3), replyProbe.ref)
       replyProbe.receiveMessage() shouldBe Left(OutOfBounds)
@@ -249,7 +249,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
     "log success and continue when SnapshotSaved succeeds" in {
       val (actor, persistProbe) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       // Trigger a move, which will cause a SaveSnapshot to be sent
       actor ! TurnBasedGameActor.MakeMove(alice, Location(0, 0), replyProbe.ref)
@@ -270,7 +270,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
       actor ! TurnBasedGameActor.SnapshotSaved(Left(ex))
 
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
       replyProbe.receiveMessage() shouldBe a[Right[_, _]]
     }
@@ -280,7 +280,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       val subscriberProbe = createTestProbe[PlayerActor.Command]()
 
       actor ! TurnBasedGameActor.Subscribe(subscriberProbe.ref, alice)
-      actor ! TurnBasedGameActor.MakeMove(alice, Location(0, 0), createTestProbe[Either[GameError, GameState]]().ref)
+      actor ! TurnBasedGameActor.MakeMove(alice, Location(0, 0), createTestProbe[Either[GameError, GameView]]().ref)
 
       subscriberProbe.expectMessageType[PlayerActor.SendEvent].event shouldBe a[PlayerEvent.GameStateUpdated]
     }
@@ -289,7 +289,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       val gameManagerProbe = createTestProbe[GameManager.Command]()
       val (actor, persistProbe) = newActor(gmRef = gameManagerProbe.ref)
       val subscriberProbe = createTestProbe[PlayerActor.Command]()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.Subscribe(subscriberProbe.ref, alice)
       subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial state push on subscribe
@@ -324,7 +324,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       actor ! TurnBasedGameActor.Subscribe(subscriberProbe.ref, alice)
       subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial state push on subscribe
       actor ! TurnBasedGameActor.Unsubscribe(subscriberProbe.ref)
-      actor ! TurnBasedGameActor.MakeMove(alice, Location(0, 0), createTestProbe[Either[GameError, GameState]]().ref)
+      actor ! TurnBasedGameActor.MakeMove(alice, Location(0, 0), createTestProbe[Either[GameError, GameView]]().ref)
 
       subscriberProbe.expectNoMessage()
     }
@@ -332,7 +332,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
     "drop a terminated subscriber without crashing" in {
       val (actor, _) = newActor()
       val subscriber = spawn(Behaviors.empty[PlayerActor.Command])
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.Subscribe(subscriber, alice)
       // the game actor watches the subscriber; stopping it must drop it via Terminated, not DeathPactException
@@ -345,7 +345,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
     "stop after receiving SnapshotSaved(Right) in terminating state" in {
       val (actor, persistProbe) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       xWinsMoves.foreach { case (player, loc) =>
         actor ! TurnBasedGameActor.MakeMove(player, loc, replyProbe.ref)
@@ -359,7 +359,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
     "stop after receiving SnapshotSaved(Left) in terminating state" in {
       val (actor, persistProbe) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
       val ex = new RuntimeException("snapshot failure") with NoStackTrace
 
       xWinsMoves.foreach { case (player, loc) =>
@@ -374,7 +374,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
     "reject a GetState landing in terminating state with GameOver instead of dropping it" in {
       val (actor, persistProbe) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       xWinsMoves.foreach { case (player, loc) =>
         actor ! TurnBasedGameActor.MakeMove(player, loc, replyProbe.ref)
@@ -393,7 +393,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
     "reject a MakeMove landing in terminating state with GameOver instead of dropping it" in {
       val (actor, persistProbe) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       xWinsMoves.foreach { case (player, loc) =>
         actor ! TurnBasedGameActor.MakeMove(player, loc, replyProbe.ref)
@@ -410,7 +410,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
     "reject a PlayerLeft landing in terminating state with GameOver instead of dropping it" in {
       val (actor, persistProbe) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       xWinsMoves.foreach { case (player, loc) =>
         actor ! TurnBasedGameActor.MakeMove(player, loc, replyProbe.ref)
@@ -427,7 +427,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
     "silently ignore Subscribe and Broadcast landing in terminating state" in {
       val (actor, persistProbe) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
       val subscriberProbe = createTestProbe[PlayerActor.Command]()
 
       xWinsMoves.foreach { case (player, loc) =>
@@ -436,7 +436,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
         expectMovePersisted(persistProbe)
       }
 
-      // these have no GameError/GameState reply to give, so — unlike MakeMove/PlayerLeft/GetState — they are dropped
+      // these have no GameError/GameView reply to give, so — unlike MakeMove/PlayerLeft/GetState — they are dropped
       // exactly as before: no push to the would-be subscriber, and the actor stays alive awaiting SnapshotSaved
       actor ! TurnBasedGameActor.Subscribe(subscriberProbe.ref, alice)
       actor ! TurnBasedGameActor.Broadcast(
@@ -450,7 +450,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
     "not crash when a watched subscriber terminates while in terminating state" in {
       val (actor, persistProbe) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
       val subscriber = spawn(Behaviors.empty[PlayerActor.Command])
       val deathWatch = createTestProbe[Any]()
 
@@ -477,7 +477,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       val gameManagerProbe = createTestProbe[GameManager.Command]()
       val matchId: MatchId = UUID.randomUUID()
       val (actor, persistProbe) = newActor(gmRef = gameManagerProbe.ref, matchId = matchId)
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       xWinsMoves.foreach { case (player, loc) =>
         actor ! TurnBasedGameActor.MakeMove(player, loc, replyProbe.ref)
@@ -497,14 +497,14 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       val matchId: MatchId = UUID.randomUUID()
       val (actor, persistProbe) = newActor(gmRef = gameManagerProbe.ref, matchId = matchId)
       val subscriberProbe = createTestProbe[PlayerActor.Command]()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.Subscribe(subscriberProbe.ref, alice)
       subscriberProbe.expectMessageType[PlayerActor.SendEvent] // initial state push on subscribe
 
       // Bob (O) leaves the in-progress game → Alice (X) wins by forfeit
       actor ! TurnBasedGameActor.PlayerLeft(bob, replyProbe.ref)
-      val Right(GridGameState(_, _, winner, _, _)) = replyProbe.receiveMessage()
+      val Right(GridGameView(_, _, winner, _, _)) = replyProbe.receiveMessage()
       winner shouldBe Some(X)
 
       // a forfeit saves a final snapshot and records each player's result with the forfeit flag, but — unlike a move —
@@ -534,7 +534,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
     "record a Win for the winner and a Loss for the loser when the game completes" in {
       val matchId: MatchId = UUID.randomUUID()
       val (actor, persistProbe) = newActor(matchId = matchId)
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       xWinsMoves.foreach { case (player, loc) =>
         actor ! TurnBasedGameActor.MakeMove(player, loc, replyProbe.ref)
@@ -554,7 +554,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
     "record a Draw for both players when the game ends in a draw" in {
       val matchId: MatchId = UUID.randomUUID()
       val (actor, persistProbe) = newActor(matchId = matchId)
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       drawMoves.foreach { case (player, loc) =>
         actor ! TurnBasedGameActor.MakeMove(player, loc, replyProbe.ref)
@@ -573,7 +573,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
     "reject a leave from a player not in the game" in {
       val eve: PlayerId = UUID.randomUUID()
       val (actor, _) = newActor()
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       actor ! TurnBasedGameActor.PlayerLeft(eve, replyProbe.ref)
       replyProbe.receiveMessage() shouldBe Left(GameError.InvalidPlayer(eve))
@@ -589,7 +589,7 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       val (_, behavior) =
         TicTacToeActor.create(matchId, matchId, Seq(alice, bob), persistProbe.ref, dummyGameManager, capturing)
       val actor = spawn(behavior)
-      val replyProbe = createTestProbe[Either[GameError, GameState]]()
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
 
       drawMoves.foreach { case (player, loc) =>
         actor ! TurnBasedGameActor.MakeMove(player, loc, replyProbe.ref)

--- a/game-service-actor/src/test/scala/com/andy327/actor/tictactoe/TicTacToeActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/tictactoe/TicTacToeActorSpec.scala
@@ -84,9 +84,9 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
 
-      val Right(GridGameState(board, current, winner, draw)) = replyProbe.receiveMessage()
-      board.flatten should contain only ""
-      current shouldBe "X"
+      val Right(GridGameState(board, current, winner, draw, _)) = replyProbe.receiveMessage()
+      board.flatten should contain only None
+      current shouldBe X
       winner shouldBe None
       draw shouldBe false
     }
@@ -119,10 +119,10 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       val replyProbe = createTestProbe[Either[GameError, GameState]]()
       actor ! TurnBasedGameActor.GetState(replyProbe.ref)
 
-      val Right(GridGameState(board, current, winner, draw)) = replyProbe.receiveMessage()
-      board(0)(0) shouldBe "X"
-      board(1)(1) shouldBe "O"
-      current shouldBe "X"
+      val Right(GridGameState(board, current, winner, draw, _)) = replyProbe.receiveMessage()
+      board(0)(0) shouldBe Some(X)
+      board(1)(1) shouldBe Some(O)
+      current shouldBe X
       winner shouldBe None
       draw shouldBe false
     }
@@ -190,15 +190,15 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
       val replyProbe = createTestProbe[Either[GameError, GameState]]()
 
       actor ! TurnBasedGameActor.MakeMove(alice, Location(0, 0), replyProbe.ref)
-      val Right(GridGameState(board1, current1, _, _)) = replyProbe.receiveMessage()
-      board1(0)(0) shouldBe "X"
-      current1 shouldBe "O"
+      val Right(GridGameState(board1, current1, _, _, _)) = replyProbe.receiveMessage()
+      board1(0)(0) shouldBe Some(X)
+      current1 shouldBe O
 
       actor ! TurnBasedGameActor.MakeMove(bob, Location(1, 1), replyProbe.ref)
-      val Right(GridGameState(board2, current2, _, _)) = replyProbe.receiveMessage()
-      board2(0)(0) shouldBe "X"
-      board2(1)(1) shouldBe "O"
-      current2 shouldBe "X"
+      val Right(GridGameState(board2, current2, _, _, _)) = replyProbe.receiveMessage()
+      board2(0)(0) shouldBe Some(X)
+      board2(1)(1) shouldBe Some(O)
+      current2 shouldBe X
     }
 
     "append each applied move to history with an incrementing seq and the move payload" in {
@@ -504,8 +504,8 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
 
       // Bob (O) leaves the in-progress game → Alice (X) wins by forfeit
       actor ! TurnBasedGameActor.PlayerLeft(bob, replyProbe.ref)
-      val Right(GridGameState(_, _, winner, _)) = replyProbe.receiveMessage()
-      winner shouldBe Some("X")
+      val Right(GridGameState(_, _, winner, _, _)) = replyProbe.receiveMessage()
+      winner shouldBe Some(X)
 
       // a forfeit saves a final snapshot and records each player's result with the forfeit flag, but — unlike a move —
       // appends nothing to the history log

--- a/game-service-model/src/main/scala/com/andy327/model/battleship/Battleship.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/battleship/Battleship.scala
@@ -95,6 +95,24 @@ final case class Battleship(
   /** The number of shots fired so far across both boards — one per move. */
   def moveCount: Int = board1.shots.size + board2.shots.size
 
+  /** Every shot [[currentPlayer]] may legally fire right now — each cell of the opponent's board not yet targeted — or
+    * nothing once the game is over.
+    *
+    * The dual of [[play]]'s validation: a target appears here exactly when `play` would accept firing at it, so a
+    * caller that chooses a move — or offers the choice — does not restate the rules.
+    */
+  def legalMoves: List[Fire] =
+    if (gameStatus != InProgress) Nil
+    else {
+      val fired = boardFor(opponent(currentPlayer)).shots
+      (for {
+        row <- 0 until Size
+        col <- 0 until Size
+        coord = Coord(row, col)
+        if !fired.contains(coord)
+      } yield Fire(coord)).toList
+    }
+
   /** The board belonging to `seat`. */
   private def boardFor(seat: Seat): PlayerBoard = seat match {
     case Player1 => board1

--- a/game-service-model/src/main/scala/com/andy327/model/checkers/Checkers.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/checkers/Checkers.scala
@@ -168,6 +168,14 @@ final case class Checkers(
   /** The roster in seat order: `Red` then `Black`. */
   def players: List[PlayerId] = List(playerRed, playerBlack)
 
+  /** Every move [[currentPlayer]] may legally play right now, or nothing once the game is over.
+    *
+    * Captures being mandatory, this lists only jumps whenever any exist, and a multi-jump spells out its whole chain —
+    * the same set [[play]] validates against, so it accepts exactly the moves listed here and rejects everything else.
+    */
+  def legalMoves: List[Move] =
+    if (gameStatus != InProgress) Nil else legalMovesFor(board, currentPlayer)
+
   /** Applies `move` for `player`.
     *
     * Validates turn order and piece ownership, then checks the move against the legal moves for the position — which

--- a/game-service-model/src/main/scala/com/andy327/model/connectfour/ConnectFour.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/connectfour/ConnectFour.scala
@@ -97,6 +97,17 @@ final case class ConnectFour(
   /** The number of pieces dropped so far — one per move. */
   def moveCount: Int = board.flatten.count(_.isDefined)
 
+  /** Every move [[currentPlayer]] may legally play right now — a drop into each column that still has room, or nothing
+    * once the game is over.
+    *
+    * The dual of [[play]]'s validation: a column appears here exactly when `play` would accept a drop into it.
+    * Enumerating moves rather than only rejecting them lets callers that need to choose a move (or offer the choice) do
+    * so without restating the rules.
+    */
+  def legalMoves: List[Drop] =
+    if (gameStatus != InProgress) Nil
+    else (0 until Cols).filter(col => lowestEmptyRow(board, col).isDefined).map(Drop(_)).toList
+
   private def nextPlayer: Mark = currentPlayer match {
     case Red    => Yellow
     case Yellow => Red

--- a/game-service-model/src/main/scala/com/andy327/model/connectfour/ConnectFour.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/connectfour/ConnectFour.scala
@@ -100,9 +100,8 @@ final case class ConnectFour(
   /** Every move [[currentPlayer]] may legally play right now — a drop into each column that still has room, or nothing
     * once the game is over.
     *
-    * The dual of [[play]]'s validation: a column appears here exactly when `play` would accept a drop into it.
-    * Enumerating moves rather than only rejecting them lets callers that need to choose a move (or offer the choice) do
-    * so without restating the rules.
+    * The dual of [[play]]'s validation: a column appears here exactly when `play` would accept a drop into it, so a
+    * caller that chooses a move — or offers the choice — does not restate the rules.
     */
   def legalMoves: List[Drop] =
     if (gameStatus != InProgress) Nil

--- a/game-service-model/src/main/scala/com/andy327/model/holdem/TexasHoldEm.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/holdem/TexasHoldEm.scala
@@ -180,6 +180,32 @@ final case class TexasHoldEm(
   /** The amount `seat` must put in to call the current bet. */
   def toCall(seat: Int): Int = math.max(0, currentBet - streetContrib(seat))
 
+  /** The chip-free actions [[currentPlayer]] may take right now, or nothing once the game is over: folding is always
+    * open, checking when nothing is owed, and calling when something is. Sizing actions live in [[betBounds]] — a bet
+    * or raise is not one move but a range of them.
+    *
+    * Calling with nothing owed is accepted by [[play]] as a zero-chip no-op, but it is not listed: checking is that
+    * move's honest name.
+    */
+  def legalActions: List[Action] =
+    if (winner.isDefined) Nil
+    else Fold :: (if (toCall(toAct) == 0) List(Check) else List(Call))
+
+  /** The range of street-contribution totals [[currentPlayer]] may bet (opening the betting) or raise to (against a
+    * standing bet), or `None` when no sizing action is open — the game is over, or the seat's chips cannot exceed the
+    * standing bet. Every total from `min` to `max` is accepted by [[play]]: `max` is the seat's all-in, and when the
+    * stack cannot reach the normal minimum — the big blind, or the last raise re-raised — the all-in alone remains and
+    * `min == max`.
+    */
+  def betBounds: Option[(Int, Int)] =
+    if (winner.isDefined) None
+    else {
+      val maxTotal = streetContrib(toAct) + stacks(toAct)
+      if (currentBet == 0) Some((math.min(BigBlind, maxTotal), maxTotal))
+      else if (maxTotal <= currentBet) None
+      else Some((math.min(currentBet + lastRaiseSize, maxTotal), maxTotal))
+    }
+
   // --- seat predicates -------------------------------------------------------------------------------------------
 
   private def inHand(seat: Int): Boolean = !folded(seat)

--- a/game-service-model/src/main/scala/com/andy327/model/liarsdice/LiarsDice.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/liarsdice/LiarsDice.scala
@@ -103,6 +103,27 @@ final case class LiarsDice(
   /** Number of dice seat `seat` still holds; a seat with none has been eliminated. */
   def diceCount(seat: Int): Int = dice(seat).size
 
+  /** Every bid [[currentPlayer]] may usefully make right now, or nothing once the game is over.
+    *
+    * Lists each well-formed bid that opens the round or raises the standing bid, with quantity capped at the number of
+    * dice on the table. [[play]] itself accepts a raise of any quantity, but a bid beyond the table's dice can never be
+    * true — challenging it is a guaranteed win — so the cap costs a chooser nothing while keeping the list finite.
+    * Challenging is not listed: it is not a bid, and it is available exactly when a standing bid exists.
+    */
+  def legalBids: List[Bid] =
+    if (gameStatus != InProgress) Nil
+    else {
+      val tableDice = dice.map(_.size).sum
+      val candidates = for {
+        quantity <- (1 to tableDice).toList
+        face <- None :: (2 to 6).map(Some(_)).toList
+      } yield Bid(quantity, face)
+      standing match {
+        case Some(StandingBid(current, _)) => candidates.filter(current.canRaiseTo)
+        case None                          => candidates
+      }
+    }
+
   /** Next seat clockwise from `seat` that still holds dice. Only called while at least one other seat is active (during
     * a round, or when advancing past an eliminated loser), so the search always terminates.
     */

--- a/game-service-model/src/main/scala/com/andy327/model/tictactoe/TicTacToe.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/tictactoe/TicTacToe.scala
@@ -74,6 +74,21 @@ final case class TicTacToe(
   /** The number of marks placed so far — one per move. */
   def moveCount: Int = board.flatten.count(_.isDefined)
 
+  /** Every move [[currentPlayer]] may legally play right now — each empty cell, or nothing once the game is over.
+    *
+    * The dual of [[play]]'s validation: a location appears here exactly when `play` would accept it. Enumerating moves
+    * rather than only rejecting them lets callers that need to choose a move (or offer the choice) do so without
+    * restating the rules.
+    */
+  def legalMoves: List[Location] =
+    if (gameStatus != InProgress) Nil
+    else
+      (for {
+        row <- board.indices
+        col <- board(row).indices
+        if board(row)(col).isEmpty
+      } yield Location(row, col)).toList
+
   private def nextPlayer: Mark = currentPlayer match {
     case X => O
     case O => X

--- a/game-service-model/src/main/scala/com/andy327/model/tictactoe/TicTacToe.scala
+++ b/game-service-model/src/main/scala/com/andy327/model/tictactoe/TicTacToe.scala
@@ -76,9 +76,8 @@ final case class TicTacToe(
 
   /** Every move [[currentPlayer]] may legally play right now — each empty cell, or nothing once the game is over.
     *
-    * The dual of [[play]]'s validation: a location appears here exactly when `play` would accept it. Enumerating moves
-    * rather than only rejecting them lets callers that need to choose a move (or offer the choice) do so without
-    * restating the rules.
+    * The dual of [[play]]'s validation: a location appears here exactly when `play` would accept it, so a caller that
+    * chooses a move — or offers the choice — does not restate the rules.
     */
   def legalMoves: List[Location] =
     if (gameStatus != InProgress) Nil

--- a/game-service-model/src/test/scala/com/andy327/model/battleship/BattleshipSpec.scala
+++ b/game-service-model/src/test/scala/com/andy327/model/battleship/BattleshipSpec.scala
@@ -109,6 +109,40 @@ class BattleshipSpec extends AnyWordSpec with Matchers {
     }
   }
 
+  "legalMoves" should {
+    "offer every cell of the opponent's board before any shot is fired" in {
+      val game = gameWith(board(Set(Coord(0, 0))), board(Set(Coord(0, 0))))
+      game.legalMoves should have size (Battleship.Size * Battleship.Size).toLong
+    }
+
+    "exclude cells the current player has already fired at" in {
+      // Player1's shots are recorded on board2; (3,3) and (7,2) have been fired at
+      val game = gameWith(
+        board(Set(Coord(0, 0))),
+        PlayerBoard(List(Ship(Set(Coord(0, 0)))), Set(Coord(3, 3), Coord(7, 2)))
+      )
+      game.legalMoves should have size (Battleship.Size * Battleship.Size - 2).toLong
+      game.legalMoves should not contain Fire(Coord(3, 3))
+      game.legalMoves should not contain Fire(Coord(7, 2))
+    }
+
+    "accept exactly the moves listed, and reject a repeated shot both ways" in {
+      val fired = Coord(3, 3)
+      val game = gameWith(
+        board(Set(Coord(0, 0))),
+        PlayerBoard(List(Ship(Set(Coord(0, 0)))), Set(fired))
+      )
+      game.legalMoves.take(5).foreach(fire => game.play(Player1, fire) shouldBe a[Right[_, _]])
+      game.legalMoves should not contain Fire(fired)
+      game.play(Player1, Fire(fired)) shouldBe Left(AlreadyFired)
+    }
+
+    "offer no moves once the game is over" in {
+      val game = gameWith(board(Set(Coord(0, 0))), board(Set(Coord(0, 0))), winner = Some(Player1))
+      game.legalMoves shouldBe empty
+    }
+  }
+
   "A leaving player" should {
     "forfeit to the opponent" in {
       val game = gameWith(board(Set(Coord(0, 0))), board(Set(Coord(0, 0))))

--- a/game-service-model/src/test/scala/com/andy327/model/checkers/CheckersSpec.scala
+++ b/game-service-model/src/test/scala/com/andy327/model/checkers/CheckersSpec.scala
@@ -178,6 +178,47 @@ class CheckersSpec extends AnyWordSpec with Matchers {
       won.playerLeft(bob) shouldBe Left(GameError.GameOver)
     }
 
+    "list only jumps in legalMoves when a capture is available" in {
+      val game = gameWith(Red, Square(5, 2) -> pawn(Red), Square(4, 3) -> pawn(Black))
+      game.legalMoves shouldBe List(Move(Square(5, 2), List(Square(3, 4))))
+    }
+
+    "spell out the whole chain of a multi-jump in legalMoves" in {
+      val game = gameWith(
+        Red,
+        Square(5, 2) -> pawn(Red),
+        Square(4, 3) -> pawn(Black),
+        Square(2, 3) -> pawn(Black),
+        Square(0, 7) -> pawn(Black)
+      )
+      game.legalMoves shouldBe List(Move(Square(5, 2), List(Square(3, 4), Square(1, 2))))
+    }
+
+    "list the simple slides in legalMoves when no capture is available" in {
+      val game = gameWith(Red, Square(5, 2) -> pawn(Red), Square(0, 7) -> pawn(Black))
+      // a Red pawn moves up the board, so it may slide to either forward diagonal
+      game.legalMoves should contain theSameElementsAs List(
+        Move(Square(5, 2), List(Square(4, 1))),
+        Move(Square(5, 2), List(Square(4, 3)))
+      )
+    }
+
+    "accept exactly the moves listed in legalMoves" in {
+      val game = gameWith(Red, Square(5, 2) -> pawn(Red), Square(0, 7) -> pawn(Black))
+      game.legalMoves.foreach(move => game.play(Red, move) shouldBe a[Right[_, _]])
+      // a backward slide is absent from the list and rejected by play alike
+      val backward = Move(Square(5, 2), List(Square(6, 1)))
+      game.legalMoves should not contain backward
+      game.play(Red, backward) shouldBe Left(IllegalMove)
+    }
+
+    "offer no moves once the game is over" in {
+      val game = gameWith(Red, Square(5, 2) -> pawn(Red), Square(4, 3) -> pawn(Black))
+      val Right(won) = game.play(Red, Move(Square(5, 2), List(Square(3, 4))))
+      won.gameStatus shouldBe Won(Red)
+      won.legalMoves shouldBe empty
+    }
+
     "render the board as a human-readable string" in {
       val game = gameWith(Red, Square(0, 1) -> king(Red), Square(5, 0) -> pawn(Black))
       val lines = game.render.split("\n")

--- a/game-service-model/src/test/scala/com/andy327/model/connectfour/ConnectFourSpec.scala
+++ b/game-service-model/src/test/scala/com/andy327/model/connectfour/ConnectFourSpec.scala
@@ -63,6 +63,41 @@ class ConnectFourSpec extends AnyWordSpec with Matchers {
       full.play(full.currentPlayer, Drop(0)) shouldBe Left(ColumnFull)
     }
 
+    "offer every column as a legal move on an empty board" in {
+      ConnectFour.empty(alice, bob).legalMoves shouldBe (0 until ConnectFour.Cols).map(Drop(_)).toList
+    }
+
+    "drop a column from legalMoves once it fills up" in {
+      val full = (0 until ConnectFour.Rows).foldLeft(ConnectFour.empty(alice, bob)) { (game, _) =>
+        game.play(game.currentPlayer, Drop(0)).toOption.get
+      }
+      full.legalMoves should not contain Drop(0)
+      full.legalMoves should have size (ConnectFour.Cols - 1).toLong
+    }
+
+    "agree with play about which columns are open" in {
+      val game = (0 until ConnectFour.Rows).foldLeft(ConnectFour.empty(alice, bob)) { (g, _) =>
+        g.play(g.currentPlayer, Drop(0)).toOption.get
+      }
+      // every enumerated drop is accepted, and the filled column is both rejected and absent
+      game.legalMoves.foreach(drop => game.play(game.currentPlayer, drop) shouldBe a[Right[_, _]])
+      game.play(game.currentPlayer, Drop(0)) shouldBe Left(ColumnFull)
+    }
+
+    "offer no moves once the game is over" in {
+      val game = ConnectFour.empty(alice, bob)
+        .play(Red, Drop(0)).toOption.get
+        .play(Yellow, Drop(1)).toOption.get
+        .play(Red, Drop(0)).toOption.get
+        .play(Yellow, Drop(1)).toOption.get
+        .play(Red, Drop(0)).toOption.get
+        .play(Yellow, Drop(1)).toOption.get
+        .play(Red, Drop(0)).toOption.get // Red connects four vertically in column 0
+
+      game.gameStatus shouldBe Won(Red)
+      game.legalMoves shouldBe empty
+    }
+
     "detect a horizontal win" in {
       // Red wins bottom row cols 0–3; Yellow stacks safely in col 6
       val game = ConnectFour.empty(alice, bob)

--- a/game-service-model/src/test/scala/com/andy327/model/holdem/TexasHoldEmSpec.scala
+++ b/game-service-model/src/test/scala/com/andy327/model/holdem/TexasHoldEmSpec.scala
@@ -348,6 +348,61 @@ class TexasHoldEmSpec extends AnyWordSpec with Matchers with OptionValues with E
     }
   }
 
+  "TexasHoldEm.legalActions" should {
+    "offer fold and call while chips are owed, fold and check once the bet is matched" in {
+      val g = headsUp // seat 0 to act, owing to the big blind
+      g.toCall(g.toAct) should be > 0
+      g.legalActions shouldBe List(Fold, Call)
+
+      val matched = playAll(g, (0, Call)) // heads-up: the caller matches the blind and the big blind is to act
+      matched.toCall(matched.toAct) shouldBe 0
+      matched.legalActions shouldBe List(Fold, Check)
+    }
+
+    "offer nothing once the game is over" in {
+      val g = headsUp.copy(winner = Some(0))
+      g.legalActions shouldBe empty
+      g.betBounds shouldBe None
+    }
+  }
+
+  "TexasHoldEm.betBounds" should {
+    "span a min-raise to the all-in against a standing bet" in {
+      val g = headsUp // currentBet 10 (the blind), lastRaiseSize 10, seat 0 holds 995 with 5 in
+      g.betBounds shouldBe Some((20, 1000)) // raise to 20 at least, or up to the 995 + 5 all-in
+
+      // both bounds — and a total in between — are accepted by play
+      g.play(0, move(Raise(20), full)) shouldBe a[Right[_, _]]
+      g.play(0, move(Raise(500), full)) shouldBe a[Right[_, _]]
+      g.play(0, move(Raise(1000), full)) shouldBe a[Right[_, _]]
+    }
+
+    "span the big blind to the all-in when opening the betting" in {
+      val flop = playAll(headsUp, (0, Call), (1, Check)) // the flop opens with no standing bet
+      flop.currentBet shouldBe 0
+      val (min, max) = flop.betBounds.value
+      min shouldBe TexasHoldEm.BigBlind
+      max shouldBe flop.stacks(flop.toAct)
+      flop.play(flop.toAct, move(Bet(min), full)) shouldBe a[Right[_, _]]
+      flop.play(flop.toAct, move(Bet(max), full)) shouldBe a[Right[_, _]]
+    }
+
+    "collapse to the all-in alone when the stack cannot reach a min-raise" in {
+      val g = headsUp
+      val short = g.copy(stacks = g.stacks.updated(0, 12)) // seat 0 holds 12 with 5 in: all-in total 17, min-raise 20
+      short.betBounds shouldBe Some((17, 17))
+      short.play(0, move(Raise(17), full)) shouldBe a[Right[_, _]]
+      short.play(0, move(Raise(18), full)) shouldBe a[Left[_, _]] // beyond the stack
+    }
+
+    "vanish when the stack cannot exceed the standing bet at all" in {
+      val g = headsUp
+      val tooShort = g.copy(stacks = g.stacks.updated(0, 4)) // all-in total 9 <= the standing 10
+      tooShort.betBounds shouldBe None
+      tooShort.legalActions shouldBe List(Fold, Call) // the short all-in call remains
+    }
+  }
+
   "Street.next" should {
     "advance through the betting streets and stop after the river" in {
       Street.next(Street.PreFlop) shouldBe Some(Street.Flop)

--- a/game-service-model/src/test/scala/com/andy327/model/liarsdice/LiarsDiceSpec.scala
+++ b/game-service-model/src/test/scala/com/andy327/model/liarsdice/LiarsDiceSpec.scala
@@ -273,6 +273,42 @@ class LiarsDiceSpec extends AnyWordSpec with Matchers with OptionValues {
     }
   }
 
+  "LiarsDice.legalBids" should {
+
+    "offer every well-formed bid up to the table's dice when opening a round" in {
+      val g = game(Vector(2, 3), Vector(4, 5)) // 4 dice on the table, no standing bid
+      val bids = g.legalBids
+      bids should have size (4 * 6).toLong // quantities 1–4, each with faces 2–6 or wild ones
+      bids.foreach(bid => bid.isWellFormed shouldBe true)
+      bids.map(_.quantity).max shouldBe 4
+    }
+
+    "offer exactly the raises the standing bid allows" in {
+      val g = game(Vector(2, 3), Vector(4, 5)).copy(standing = Some(StandingBid(Bid(2, Some(4)), 1)))
+      val bids = g.legalBids
+      bids.foreach(bid => Bid(2, Some(4)).canRaiseTo(bid) shouldBe true)
+      bids should contain(Bid(2, Some(5))) // same quantity, higher face
+      bids should not contain Bid(2, Some(3)) // same quantity, lower face
+      bids should not contain Bid(1, Some(6)) // lower quantity
+    }
+
+    "agree with play about every bid it offers" in {
+      val g = game(Vector(2, 3), Vector(4, 5)).copy(standing = Some(StandingBid(Bid(2, Some(4)), 1)))
+      g.legalBids.foreach(bid => g.play(0, MakeBid(bid)) shouldBe a[Right[_, _]])
+    }
+
+    "cap the quantity at the table's dice even though play accepts more" in {
+      val g = game(Vector(2, 3), Vector(4, 5)) // 4 dice on the table
+      g.legalBids.map(_.quantity).max shouldBe 4
+      // a bid beyond the cap is still accepted by play — it just can never be true, so the list omits it
+      g.play(0, MakeBid(Bid(5, Some(4)))) shouldBe a[Right[_, _]]
+    }
+
+    "offer nothing once the game is over" in {
+      game(Vector(2, 3), Vector.empty).copy(winner = Some(0)).legalBids shouldBe empty
+    }
+  }
+
   "LiarsDice.countToward" should {
 
     "count the named face plus wild ones for a numbered bid" in {

--- a/game-service-model/src/test/scala/com/andy327/model/tictactoe/TicTacToeSpec.scala
+++ b/game-service-model/src/test/scala/com/andy327/model/tictactoe/TicTacToeSpec.scala
@@ -123,6 +123,40 @@ class TicTacToeSpec extends AnyWordSpec with Matchers {
       game.playerLeft(bob) shouldBe Left(GameError.GameOver)
     }
 
+    "offer every cell as a legal move on an empty board" in {
+      TicTacToe.empty(alice, bob).legalMoves should contain theSameElementsAs
+        (for { row <- 0 until 3; col <- 0 until 3 } yield Location(row, col))
+    }
+
+    "drop a cell from legalMoves once it is claimed" in {
+      val game = TicTacToe.empty(alice, bob).play(X, Location(1, 1)).toOption.get
+      game.legalMoves should have size 8
+      game.legalMoves should not contain Location(1, 1)
+    }
+
+    "agree with play about which moves are legal" in {
+      val game = TicTacToe.empty(alice, bob)
+        .play(X, Location(0, 0)).toOption.get
+        .play(O, Location(1, 1)).toOption.get
+
+      // every enumerated move is accepted, and every rejected move is absent — the two are duals
+      game.legalMoves.foreach(loc => game.play(X, loc) shouldBe a[Right[_, _]])
+      val claimed = List(Location(0, 0), Location(1, 1))
+      claimed.foreach(loc => game.legalMoves should not contain loc)
+    }
+
+    "offer no moves once the game is over" in {
+      val game = TicTacToe.empty(alice, bob)
+        .play(X, Location(0, 0)).toOption.get
+        .play(O, Location(1, 0)).toOption.get
+        .play(X, Location(0, 1)).toOption.get
+        .play(O, Location(1, 1)).toOption.get
+        .play(X, Location(0, 2)).toOption.get // X wins the top row
+
+      game.gameStatus shouldBe Won(X)
+      game.legalMoves shouldBe empty
+    }
+
     "properly render a game board" in {
       val game = TicTacToe.empty(alice, bob)
         .play(X, Location(0, 0)).toOption.get

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -24,7 +24,6 @@ import com.andy327.actor.core.PlayerEvent
 import com.andy327.actor.game.{
   BattleshipCell,
   BattleshipState,
-  BidView,
   CheckersState,
   GameState,
   GridGameState,
@@ -34,12 +33,12 @@ import com.andy327.actor.game.{
   HoldEmState,
   LiarsDiceState,
   MastermindState,
-  PigState,
-  RevealView
+  PigState
 }
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyCodecs, LobbyMetadata, Player}
 import com.andy327.actor.tracing.TraceEvent
 import com.andy327.model.checkers.Piece
+import com.andy327.model.liarsdice.{Bid, LiarsDice}
 import com.andy327.model.pig.Pig
 import com.andy327.persistence.db.MoveRecord
 import com.andy327.persistence.db.PlayerHistoryRepository.GameResult
@@ -211,9 +210,34 @@ object JsonProtocol extends CirceSupport {
       "viewerRole" -> view.viewerRole.map(_.label).asJson
     )
   }
-  implicit val bidViewCodec: Codec[BidView] = deriveCodec[BidView]
-  implicit val revealViewCodec: Codec[RevealView] = deriveCodec[RevealView]
-  implicit val liarsDiceStateCodec: Codec[LiarsDiceState] = deriveCodec[LiarsDiceState]
+
+  /** Write-only: seats travel as their `"P1"`/`"P2"` labels — including the per-seat keys of `diceCounts` and a
+    * reveal's `dice` — which decoding cannot invert to seat indices without the roster size. A wild "ones" bid's
+    * absent face stays absent on the wire. `legalMoves` is not emitted.
+    */
+  implicit val liarsDiceStateEncoder: Encoder[LiarsDiceState] = Encoder.instance { view =>
+    def label(seat: Int): String = LiarsDice.seatLabel(seat)
+    def bidJson(bid: Bid): Json = Json.obj("quantity" -> bid.quantity.asJson, "face" -> bid.face.asJson)
+    Json.obj(
+      "dice" -> view.dice.asJson,
+      "diceCounts" -> view.diceCounts.zipWithIndex.map { case (n, seat) => label(seat) -> n }.toMap.asJson,
+      "currentBid" -> view.currentBid.map(bidJson).asJson,
+      "currentPlayer" -> label(view.currentPlayer).asJson,
+      "winner" -> view.winner.map(label).asJson,
+      "viewerSeat" -> view.viewerSeat.map(label).asJson,
+      "lastReveal" -> view.lastReveal.map { reveal =>
+        Json.obj(
+          "bid" -> bidJson(reveal.bid),
+          "count" -> reveal.count.asJson,
+          "dice" -> reveal.allDice.zipWithIndex.map { case (dice, seat) => label(seat) -> dice }.toMap.asJson,
+          "challenger" -> label(reveal.challengerSeat).asJson,
+          "bidder" -> label(reveal.bidderSeat).asJson,
+          "loser" -> label(reveal.loserSeat).asJson,
+          "diceLost" -> reveal.diceLost.asJson
+        )
+      }.asJson
+    )
+  }
   implicit val holdEmSeatCodec: Codec[HoldEmSeat] = deriveCodec[HoldEmSeat]
   implicit val holdEmPotAwardCodec: Codec[HoldEmPotAward] = deriveCodec[HoldEmPotAward]
   implicit val holdEmHandResultCodec: Codec[HoldEmHandResult] = deriveCodec[HoldEmHandResult]

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -23,14 +23,14 @@ import com.andy327.actor.core.LobbyManager.LobbySummary
 import com.andy327.actor.core.PlayerEvent
 import com.andy327.actor.game.{
   BattleshipCell,
-  BattleshipState,
-  CheckersState,
-  GameState,
-  GridGameState,
-  HoldEmState,
-  LiarsDiceState,
-  MastermindState,
-  PigState
+  BattleshipView,
+  CheckersView,
+  GameView,
+  GridGameView,
+  HoldEmView,
+  LiarsDiceView,
+  MastermindView,
+  PigView
 }
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyCodecs, LobbyMetadata, Player}
 import com.andy327.actor.tracing.TraceEvent
@@ -57,11 +57,14 @@ import com.andy327.server.http.player.{PlayerGameSummary, PlayerHistory}
 
 /** Circe codecs and Pekko HTTP marshallers for all API types.
   *
-  * Case-class codecs are derived via `deriveCodec`. The value codecs for `Player`, `GameLifecycleStatus`, and
-  * `LobbyMetadata` (which also fixes the `GameType` and UUID-key formats) are reused from `LobbyCodecs` and re-exported
-  * as members here, so the wire format is defined once and is shared by the HTTP layer and Redis persistence.
-  * [[playerEventEncoder]] is write-only (server-push only). Marshalling is provided by [[CirceSupport]]: any type with
-  * an `Encoder` can be `complete`d, any type with a `Decoder` read with `entity(as[A])`.
+  * Request and response case classes get round-trip codecs via `deriveCodec`. The value codecs for `Player`,
+  * `GameLifecycleStatus`, and `LobbyMetadata` (which also fixes the `GameType` and UUID-key formats) are reused from
+  * `LobbyCodecs` and re-exported as members here, so the wire format is defined once and is shared by the HTTP layer
+  * and Redis persistence. The game-view encoders are hand-written and write-only: a `GameView` holds domain types the
+  * wire flattens to labels and symbols, and being a per-viewer projection it is lossy by design, so nothing ever
+  * decodes one — each encoder documents its own rendering. [[playerEventEncoder]] is likewise write-only (server-push
+  * only). Marshalling is provided by [[CirceSupport]]: any type with an `Encoder` can be `complete`d, any type with a
+  * `Decoder` read with `entity(as[A])`.
   */
 object JsonProtocol extends CirceSupport {
 
@@ -129,7 +132,7 @@ object JsonProtocol extends CirceSupport {
     * since the same `"R"` denotes a different game's mark. `legalMoves` is not emitted — it serves consumers that
     * choose a move, and the client contract covers the board alone.
     */
-  implicit val gridGameStateEncoder: Encoder[GridGameState] = Encoder.instance { view =>
+  implicit val gridGameViewEncoder: Encoder[GridGameView] = Encoder.instance { view =>
     Json.obj(
       "board" -> view.board.map(_.map(_.fold("")(_.symbol))).asJson,
       "currentPlayer" -> view.currentPlayer.symbol.asJson,
@@ -141,7 +144,7 @@ object JsonProtocol extends CirceSupport {
   /** Write-only: a pawn renders as its color's symbol in lower case and a king in upper (`""` for an empty square),
     * and a square's own color is not carried, so decoding cannot rebuild the board. `legalMoves` is not emitted.
     */
-  implicit val checkersStateEncoder: Encoder[CheckersState] = Encoder.instance { view =>
+  implicit val checkersStateEncoder: Encoder[CheckersView] = Encoder.instance { view =>
     val cells = view.board.map(_.map {
       case Some(Piece(color, isKing)) => if (isKing) color.symbol else color.symbol.toLowerCase
       case None                       => ""
@@ -158,7 +161,7 @@ object JsonProtocol extends CirceSupport {
     * an `"unknown"` cell carries no way back to what lies beneath it, so decoding cannot rebuild a board. `legalMoves`
     * is not emitted.
     */
-  implicit val battleshipStateEncoder: Encoder[BattleshipState] = Encoder.instance { view =>
+  implicit val battleshipStateEncoder: Encoder[BattleshipView] = Encoder.instance { view =>
     def token(cell: BattleshipCell): String = cell match {
       case BattleshipCell.Hit     => "hit"
       case BattleshipCell.Miss    => "miss"
@@ -178,7 +181,7 @@ object JsonProtocol extends CirceSupport {
   /** Write-only: seats travel as their `"P1"`/`"P2"` labels, which decoding cannot invert to seat indices without the
     * roster size. `legalMoves` is not emitted.
     */
-  implicit val pigStateEncoder: Encoder[PigState] = Encoder.instance { view =>
+  implicit val pigStateEncoder: Encoder[PigView] = Encoder.instance { view =>
     Json.obj(
       "scores" -> view.scores.zipWithIndex.map { case (score, seat) => Pig.seatLabel(seat) -> score }.toMap.asJson,
       "currentPlayer" -> Pig.seatLabel(view.currentPlayer).asJson,
@@ -192,7 +195,7 @@ object JsonProtocol extends CirceSupport {
   /** Write-only: pegs and roles travel as their lower-case names, and a guess flattens its `Attempt` into one object
     * holding the peg names beside the black/white counts. `legalMoves` is not emitted.
     */
-  implicit val mastermindStateEncoder: Encoder[MastermindState] = Encoder.instance { view =>
+  implicit val mastermindStateEncoder: Encoder[MastermindView] = Encoder.instance { view =>
     Json.obj(
       "guesses" -> view.guesses.map { attempt =>
         Json.obj(
@@ -213,7 +216,7 @@ object JsonProtocol extends CirceSupport {
     * reveal's `dice` — which decoding cannot invert to seat indices without the roster size. A wild "ones" bid's
     * absent face stays absent on the wire. `legalMoves` is not emitted.
     */
-  implicit val liarsDiceStateEncoder: Encoder[LiarsDiceState] = Encoder.instance { view =>
+  implicit val liarsDiceStateEncoder: Encoder[LiarsDiceView] = Encoder.instance { view =>
     def label(seat: Int): String = LiarsDice.seatLabel(seat)
     def bidJson(bid: Bid): Json = Json.obj("quantity" -> bid.quantity.asJson, "face" -> bid.face.asJson)
     Json.obj(
@@ -241,7 +244,7 @@ object JsonProtocol extends CirceSupport {
     * position, and a hand result's shown hands are keyed by label — and cards as their compact text (`"As"`, `"Td"`),
     * none of which decoding can invert without the roster. `legalMoves` and `betSizing` are not emitted.
     */
-  implicit val holdEmStateEncoder: Encoder[HoldEmState] = Encoder.instance { view =>
+  implicit val holdEmStateEncoder: Encoder[HoldEmView] = Encoder.instance { view =>
     def label(seat: Int): String = TexasHoldEm.seatLabel(seat)
     Json.obj(
       "seats" -> view.seats.zipWithIndex.map { case (s, i) =>
@@ -281,18 +284,18 @@ object JsonProtocol extends CirceSupport {
     )
   }
 
-  /** Encoder for the polymorphic `GameState` hierarchy (grid games share `GridGameState`; Battleship has its own
-    * per-viewer `BattleshipState`; Pig has `PigState`; Mastermind has `MastermindState`; Liar's Dice has
-    * `LiarsDiceState`; Texas Hold 'Em has `HoldEmState`).
+  /** Encoder for the polymorphic `GameView` hierarchy (grid games share `GridGameView`; Battleship has its own
+    * per-viewer `BattleshipView`; Pig has `PigView`; Mastermind has `MastermindView`; Liar's Dice has
+    * `LiarsDiceView`; Texas Hold 'Em has `HoldEmView`).
     */
-  implicit val gameStateEncoder: Encoder[GameState] = Encoder.instance {
-    case s: GridGameState   => s.asJson
-    case s: CheckersState   => s.asJson
-    case s: BattleshipState => s.asJson
-    case s: PigState        => s.asJson
-    case s: MastermindState => s.asJson
-    case s: LiarsDiceState  => s.asJson
-    case s: HoldEmState     => s.asJson
+  implicit val gameStateEncoder: Encoder[GameView] = Encoder.instance {
+    case s: GridGameView   => s.asJson
+    case s: CheckersView   => s.asJson
+    case s: BattleshipView => s.asJson
+    case s: PigView        => s.asJson
+    case s: MastermindView => s.asJson
+    case s: LiarsDiceView  => s.asJson
+    case s: HoldEmView     => s.asJson
   }
 
   // Entity unmarshallers, declared per-type so they don't shadow the predefined `String` unmarshaller (see

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -28,7 +28,6 @@ import com.andy327.actor.game.{
   CheckersState,
   GameState,
   GridGameState,
-  GuessResult,
   HoldEmHandResult,
   HoldEmPotAward,
   HoldEmSeat,
@@ -192,8 +191,26 @@ object JsonProtocol extends CirceSupport {
       "viewerSeat" -> view.viewerSeat.map(Pig.seatLabel).asJson
     )
   }
-  implicit val guessResultCodec: Codec[GuessResult] = deriveCodec[GuessResult]
-  implicit val mastermindStateCodec: Codec[MastermindState] = deriveCodec[MastermindState]
+
+  /** Write-only: pegs and roles travel as their lower-case names, and a guess flattens its `Attempt` into one object
+    * holding the peg names beside the black/white counts. `legalMoves` is not emitted.
+    */
+  implicit val mastermindStateEncoder: Encoder[MastermindState] = Encoder.instance { view =>
+    Json.obj(
+      "guesses" -> view.guesses.map { attempt =>
+        Json.obj(
+          "pegs" -> attempt.guess.map(_.name).asJson,
+          "black" -> attempt.feedback.black.asJson,
+          "white" -> attempt.feedback.white.asJson
+        )
+      }.asJson,
+      "secret" -> view.secret.map(_.map(_.name)).asJson,
+      "currentPlayer" -> view.currentPlayer.label.asJson,
+      "winner" -> view.winner.map(_.label).asJson,
+      "guessesRemaining" -> view.guessesRemaining.asJson,
+      "viewerRole" -> view.viewerRole.map(_.label).asJson
+    )
+  }
   implicit val bidViewCodec: Codec[BidView] = deriveCodec[BidView]
   implicit val revealViewCodec: Codec[RevealView] = deriveCodec[RevealView]
   implicit val liarsDiceStateCodec: Codec[LiarsDiceState] = deriveCodec[LiarsDiceState]

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -39,6 +39,7 @@ import com.andy327.actor.game.{
 }
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyCodecs, LobbyMetadata, Player}
 import com.andy327.actor.tracing.TraceEvent
+import com.andy327.model.checkers.Piece
 import com.andy327.model.pig.Pig
 import com.andy327.persistence.db.MoveRecord
 import com.andy327.persistence.db.PlayerHistoryRepository.GameResult
@@ -139,7 +140,22 @@ object JsonProtocol extends CirceSupport {
       "draw" -> view.draw.asJson
     )
   }
-  implicit val checkersStateCodec: Codec[CheckersState] = deriveCodec[CheckersState]
+
+  /** Write-only: a pawn renders as its color's symbol in lower case and a king in upper (`""` for an empty square),
+    * and a square's own color is not carried, so decoding cannot rebuild the board. `legalMoves` is not emitted.
+    */
+  implicit val checkersStateEncoder: Encoder[CheckersState] = Encoder.instance { view =>
+    val cells = view.board.map(_.map {
+      case Some(Piece(color, isKing)) => if (isKing) color.symbol else color.symbol.toLowerCase
+      case None                       => ""
+    })
+    Json.obj(
+      "board" -> cells.asJson,
+      "currentPlayer" -> view.currentPlayer.symbol.asJson,
+      "winner" -> view.winner.map(_.symbol).asJson,
+      "viewerSeat" -> view.viewerSeat.map(_.symbol).asJson
+    )
+  }
   implicit val battleshipStateCodec: Codec[BattleshipState] = deriveCodec[BattleshipState]
 
   /** Write-only: seats travel as their `"P1"`/`"P2"` labels, which decoding cannot invert to seat indices without the

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -126,7 +126,19 @@ object JsonProtocol extends CirceSupport {
   implicit val playerSessionsCodec: Codec[PlayerSessions] = deriveCodec[PlayerSessions]
 
   // Game state views
-  implicit val gridGameStateCodec: Codec[GridGameState] = deriveCodec[GridGameState]
+  /** Write-only: the grid view holds domain `Mark`s, which the wire flattens to their symbols (`""` for an empty
+    * cell). Decoding cannot invert that — the same `"R"` denotes a different game's mark — and nothing reads a view
+    * back, so only an encoder is provided. `legalMoves` is deliberately not emitted: it exists for consumers that
+    * choose a move, and adding it here would change the documented client contract.
+    */
+  implicit val gridGameStateEncoder: Encoder[GridGameState] = Encoder.instance { view =>
+    Json.obj(
+      "board" -> view.board.map(_.map(_.fold("")(_.symbol))).asJson,
+      "currentPlayer" -> view.currentPlayer.symbol.asJson,
+      "winner" -> view.winner.map(_.symbol).asJson,
+      "draw" -> view.draw.asJson
+    )
+  }
   implicit val checkersStateCodec: Codec[CheckersState] = deriveCodec[CheckersState]
   implicit val battleshipStateCodec: Codec[BattleshipState] = deriveCodec[BattleshipState]
   implicit val pigStateCodec: Codec[PigState] = deriveCodec[PigState]

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -27,9 +27,6 @@ import com.andy327.actor.game.{
   CheckersState,
   GameState,
   GridGameState,
-  HoldEmHandResult,
-  HoldEmPotAward,
-  HoldEmSeat,
   HoldEmState,
   LiarsDiceState,
   MastermindState,
@@ -38,6 +35,7 @@ import com.andy327.actor.game.{
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyCodecs, LobbyMetadata, Player}
 import com.andy327.actor.tracing.TraceEvent
 import com.andy327.model.checkers.Piece
+import com.andy327.model.holdem.TexasHoldEm
 import com.andy327.model.liarsdice.{Bid, LiarsDice}
 import com.andy327.model.pig.Pig
 import com.andy327.persistence.db.MoveRecord
@@ -238,10 +236,50 @@ object JsonProtocol extends CirceSupport {
       }.asJson
     )
   }
-  implicit val holdEmSeatCodec: Codec[HoldEmSeat] = deriveCodec[HoldEmSeat]
-  implicit val holdEmPotAwardCodec: Codec[HoldEmPotAward] = deriveCodec[HoldEmPotAward]
-  implicit val holdEmHandResultCodec: Codec[HoldEmHandResult] = deriveCodec[HoldEmHandResult]
-  implicit val holdEmStateCodec: Codec[HoldEmState] = deriveCodec[HoldEmState]
+
+  /** Write-only: seats travel as their `"P1"`/`"P2"` labels — a seat object regains its `seat` label from its
+    * position, and a hand result's shown hands are keyed by label — and cards as their compact text (`"As"`, `"Td"`),
+    * none of which decoding can invert without the roster. `legalMoves` and `betSizing` are not emitted.
+    */
+  implicit val holdEmStateEncoder: Encoder[HoldEmState] = Encoder.instance { view =>
+    def label(seat: Int): String = TexasHoldEm.seatLabel(seat)
+    Json.obj(
+      "seats" -> view.seats.zipWithIndex.map { case (s, i) =>
+        Json.obj(
+          "seat" -> label(i).asJson,
+          "stack" -> s.stack.asJson,
+          "committed" -> s.committed.asJson,
+          "bet" -> s.bet.asJson,
+          "folded" -> s.folded.asJson,
+          "allIn" -> s.allIn.asJson
+        )
+      }.asJson,
+      "holeCards" -> view.holeCards.map(_.map(_.toString)).asJson,
+      "board" -> view.board.map(_.toString).asJson,
+      "button" -> label(view.button).asJson,
+      "currentPlayer" -> label(view.currentPlayer).asJson,
+      "currentBet" -> view.currentBet.asJson,
+      "minRaise" -> view.minRaise.asJson,
+      "pot" -> view.pot.asJson,
+      "toCall" -> view.toCall.asJson,
+      "street" -> view.street.toString.asJson,
+      "winner" -> view.winner.map(label).asJson,
+      "viewerSeat" -> view.viewerSeat.map(label).asJson,
+      "handResult" -> view.handResult.map { result =>
+        Json.obj(
+          "board" -> result.board.map(_.toString).asJson,
+          "shownHands" -> result.shownHands.map { case (seat, cards) => label(seat) -> cards.map(_.toString) }.asJson,
+          "awards" -> result.awards.map { award =>
+            Json.obj(
+              "amount" -> award.amount.asJson,
+              "winners" -> award.winners.map(label).asJson,
+              "description" -> award.description.asJson
+            )
+          }.asJson
+        )
+      }.asJson
+    )
+  }
 
   /** Encoder for the polymorphic `GameState` hierarchy (grid games share `GridGameState`; Battleship has its own
     * per-viewer `BattleshipState`; Pig has `PigState`; Mastermind has `MastermindState`; Liar's Dice has

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -22,6 +22,7 @@ import com.andy327.actor.core.GameManager.{
 import com.andy327.actor.core.LobbyManager.LobbySummary
 import com.andy327.actor.core.PlayerEvent
 import com.andy327.actor.game.{
+  BattleshipCell,
   BattleshipState,
   BidView,
   CheckersState,
@@ -156,7 +157,27 @@ object JsonProtocol extends CirceSupport {
       "viewerSeat" -> view.viewerSeat.map(_.symbol).asJson
     )
   }
-  implicit val battleshipStateCodec: Codec[BattleshipState] = deriveCodec[BattleshipState]
+
+  /** Write-only: each cell travels as its lower-case token (`"hit"`, `"miss"`, `"ship"`, `"water"`, `"unknown"`), and
+    * an `"unknown"` cell carries no way back to what lies beneath it, so decoding cannot rebuild a board. `legalMoves`
+    * is not emitted.
+    */
+  implicit val battleshipStateEncoder: Encoder[BattleshipState] = Encoder.instance { view =>
+    def token(cell: BattleshipCell): String = cell match {
+      case BattleshipCell.Hit     => "hit"
+      case BattleshipCell.Miss    => "miss"
+      case BattleshipCell.Ship    => "ship"
+      case BattleshipCell.Water   => "water"
+      case BattleshipCell.Unknown => "unknown"
+    }
+    Json.obj(
+      "board1" -> view.board1.map(_.map(token)).asJson,
+      "board2" -> view.board2.map(_.map(token)).asJson,
+      "currentPlayer" -> view.currentPlayer.symbol.asJson,
+      "winner" -> view.winner.map(_.symbol).asJson,
+      "viewerSeat" -> view.viewerSeat.map(_.symbol).asJson
+    )
+  }
 
   /** Write-only: seats travel as their `"P1"`/`"P2"` labels, which decoding cannot invert to seat indices without the
     * roster size. `legalMoves` is not emitted.

--- a/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/json/JsonProtocol.scala
@@ -39,6 +39,7 @@ import com.andy327.actor.game.{
 }
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyCodecs, LobbyMetadata, Player}
 import com.andy327.actor.tracing.TraceEvent
+import com.andy327.model.pig.Pig
 import com.andy327.persistence.db.MoveRecord
 import com.andy327.persistence.db.PlayerHistoryRepository.GameResult
 import com.andy327.persistence.db.schema.GameTypeCodecs.gameTypeCodec
@@ -126,10 +127,9 @@ object JsonProtocol extends CirceSupport {
   implicit val playerSessionsCodec: Codec[PlayerSessions] = deriveCodec[PlayerSessions]
 
   // Game state views
-  /** Write-only: the grid view holds domain `Mark`s, which the wire flattens to their symbols (`""` for an empty
-    * cell). Decoding cannot invert that — the same `"R"` denotes a different game's mark — and nothing reads a view
-    * back, so only an encoder is provided. `legalMoves` is deliberately not emitted: it exists for consumers that
-    * choose a move, and adding it here would change the documented client contract.
+  /** Write-only: the wire flattens each `Mark` to its symbol (`""` for an empty cell), which decoding cannot invert,
+    * since the same `"R"` denotes a different game's mark. `legalMoves` is not emitted — it serves consumers that
+    * choose a move, and the client contract covers the board alone.
     */
   implicit val gridGameStateEncoder: Encoder[GridGameState] = Encoder.instance { view =>
     Json.obj(
@@ -141,7 +141,20 @@ object JsonProtocol extends CirceSupport {
   }
   implicit val checkersStateCodec: Codec[CheckersState] = deriveCodec[CheckersState]
   implicit val battleshipStateCodec: Codec[BattleshipState] = deriveCodec[BattleshipState]
-  implicit val pigStateCodec: Codec[PigState] = deriveCodec[PigState]
+
+  /** Write-only: seats travel as their `"P1"`/`"P2"` labels, which decoding cannot invert to seat indices without the
+    * roster size. `legalMoves` is not emitted.
+    */
+  implicit val pigStateEncoder: Encoder[PigState] = Encoder.instance { view =>
+    Json.obj(
+      "scores" -> view.scores.zipWithIndex.map { case (score, seat) => Pig.seatLabel(seat) -> score }.toMap.asJson,
+      "currentPlayer" -> Pig.seatLabel(view.currentPlayer).asJson,
+      "turnScore" -> view.turnScore.asJson,
+      "lastRoll" -> view.lastRoll.asJson,
+      "winner" -> view.winner.map(Pig.seatLabel).asJson,
+      "viewerSeat" -> view.viewerSeat.map(Pig.seatLabel).asJson
+    )
+  }
   implicit val guessResultCodec: Codec[GuessResult] = deriveCodec[GuessResult]
   implicit val mastermindStateCodec: Codec[MastermindState] = deriveCodec[MastermindState]
   implicit val bidViewCodec: Codec[BidView] = deriveCodec[BidView]

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/BattleshipStateSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/BattleshipStateSpec.scala
@@ -5,7 +5,8 @@ import java.util.UUID
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import com.andy327.actor.game.BattleshipState
+import com.andy327.actor.game.MovePayload.BattleshipMove
+import com.andy327.actor.game.{BattleshipCell, BattleshipState}
 import com.andy327.model.battleship.{Battleship, Coord, Player1, Player2, PlayerBoard, Seat, Ship}
 import com.andy327.model.core.PlayerId
 
@@ -24,19 +25,32 @@ class BattleshipStateSpec extends AnyWordSpec with Matchers {
   "BattleshipState.of for the owning player" should {
     "reveal that player's own board fully and fog the opponent's" in {
       val view = BattleshipState.of(game(), Some(Player1))
-      view.viewerSeat shouldBe Some("P1")
+      view.viewerSeat shouldBe Some(Player1)
 
       // own board (board1) is fully revealed
-      view.board1(0)(0) shouldBe "hit" // ship that was hit
-      view.board1(0)(1) shouldBe "ship" // un-hit ship
-      view.board1(9)(9) shouldBe "miss" // empty cell that was fired at
-      view.board1(2)(2) shouldBe "water" // empty, un-fired
+      view.board1(0)(0) shouldBe BattleshipCell.Hit // ship that was hit
+      view.board1(0)(1) shouldBe BattleshipCell.Ship // un-hit ship
+      view.board1(9)(9) shouldBe BattleshipCell.Miss // empty cell that was fired at
+      view.board1(2)(2) shouldBe BattleshipCell.Water // empty, un-fired
 
       // opponent board (board2) is fog-of-war: resolved shots show, un-fired cells stay unknown, ships hidden
-      view.board2(5)(5) shouldBe "hit"
-      view.board2.flatten should contain("unknown")
-      view.board2.flatten should not contain "ship"
-      view.board2.flatten should not contain "water"
+      view.board2(5)(5) shouldBe BattleshipCell.Hit
+      view.board2.flatten should contain(BattleshipCell.Unknown)
+      view.board2.flatten should not contain BattleshipCell.Ship
+      view.board2.flatten should not contain BattleshipCell.Water
+    }
+
+    "offer exactly the opponent cells still unknown to the viewer as their legal shots" in {
+      val view = BattleshipState.of(game(), Some(Player1)) // Player1 is to act
+      val unknownCells = for {
+        row <- 0 until Battleship.Size
+        col <- 0 until Battleship.Size
+        if view.board2(row)(col) == BattleshipCell.Unknown
+      } yield BattleshipMove(row, col)
+
+      // the viewer's options are derivable from their own fogged projection — nothing hidden is consulted
+      view.legalMoves should contain theSameElementsAs unknownCells
+      view.legalMoves should have size (Battleship.Size * Battleship.Size - board2.shots.size).toLong
     }
   }
 
@@ -45,26 +59,31 @@ class BattleshipStateSpec extends AnyWordSpec with Matchers {
       val view = BattleshipState.of(game(), None)
       view.viewerSeat shouldBe None
 
-      view.board1.flatten should not contain "ship"
-      view.board2.flatten should not contain "ship"
+      view.board1.flatten should not contain BattleshipCell.Ship
+      view.board2.flatten should not contain BattleshipCell.Ship
 
       // resolved shots are still visible to everyone
-      view.board1(0)(0) shouldBe "hit"
-      view.board1(9)(9) shouldBe "miss"
-      view.board2(5)(5) shouldBe "hit"
+      view.board1(0)(0) shouldBe BattleshipCell.Hit
+      view.board1(9)(9) shouldBe BattleshipCell.Miss
+      view.board2(5)(5) shouldBe BattleshipCell.Hit
 
       // un-fired cells (including the un-hit ship cell at (0,1)) are hidden
-      view.board1(0)(1) shouldBe "unknown"
-      view.board1.flatten should contain("unknown")
+      view.board1(0)(1) shouldBe BattleshipCell.Unknown
+      view.board1.flatten should contain(BattleshipCell.Unknown)
+    }
+
+    "offer no moves to a spectator or to the player waiting on their opponent" in {
+      BattleshipState.of(game(), None).legalMoves shouldBe empty
+      BattleshipState.of(game(), Some(Player2)).legalMoves shouldBe empty // Player1 is to act
     }
   }
 
   "BattleshipState.of" should {
-    "report the current player and winner as seat symbols" in {
+    "report the current player and winner as seats" in {
       val view = BattleshipState.of(game(currentPlayer = Player2, winner = Some(Player1)), Some(Player2))
-      view.currentPlayer shouldBe "P2"
-      view.winner shouldBe Some("P1")
-      view.viewerSeat shouldBe Some("P2")
+      view.currentPlayer shouldBe Player2
+      view.winner shouldBe Some(Player1)
+      view.viewerSeat shouldBe Some(Player2)
     }
   }
 }

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/BattleshipViewSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/BattleshipViewSpec.scala
@@ -6,11 +6,11 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import com.andy327.actor.game.MovePayload.BattleshipMove
-import com.andy327.actor.game.{BattleshipCell, BattleshipState}
+import com.andy327.actor.game.{BattleshipCell, BattleshipView}
 import com.andy327.model.battleship.{Battleship, Coord, Player1, Player2, PlayerBoard, Seat, Ship}
 import com.andy327.model.core.PlayerId
 
-class BattleshipStateSpec extends AnyWordSpec with Matchers {
+class BattleshipViewSpec extends AnyWordSpec with Matchers {
   val alice: PlayerId = UUID.randomUUID()
   val bob: PlayerId = UUID.randomUUID()
 
@@ -22,9 +22,9 @@ class BattleshipStateSpec extends AnyWordSpec with Matchers {
   private def game(currentPlayer: Seat = Player1, winner: Option[Seat] = None): Battleship =
     Battleship(alice, bob, board1, board2, currentPlayer, winner)
 
-  "BattleshipState.of for the owning player" should {
+  "BattleshipView.of for the owning player" should {
     "reveal that player's own board fully and fog the opponent's" in {
-      val view = BattleshipState.of(game(), Some(Player1))
+      val view = BattleshipView.of(game(), Some(Player1))
       view.viewerSeat shouldBe Some(Player1)
 
       // own board (board1) is fully revealed
@@ -41,7 +41,7 @@ class BattleshipStateSpec extends AnyWordSpec with Matchers {
     }
 
     "offer exactly the opponent cells still unknown to the viewer as their legal shots" in {
-      val view = BattleshipState.of(game(), Some(Player1)) // Player1 is to act
+      val view = BattleshipView.of(game(), Some(Player1)) // Player1 is to act
       val unknownCells = for {
         row <- 0 until Battleship.Size
         col <- 0 until Battleship.Size
@@ -54,9 +54,9 @@ class BattleshipStateSpec extends AnyWordSpec with Matchers {
     }
   }
 
-  "BattleshipState.of for a spectator" should {
+  "BattleshipView.of for a spectator" should {
     "fog both boards, hiding every un-hit ship" in {
-      val view = BattleshipState.of(game(), None)
+      val view = BattleshipView.of(game(), None)
       view.viewerSeat shouldBe None
 
       view.board1.flatten should not contain BattleshipCell.Ship
@@ -73,14 +73,14 @@ class BattleshipStateSpec extends AnyWordSpec with Matchers {
     }
 
     "offer no moves to a spectator or to the player waiting on their opponent" in {
-      BattleshipState.of(game(), None).legalMoves shouldBe empty
-      BattleshipState.of(game(), Some(Player2)).legalMoves shouldBe empty // Player1 is to act
+      BattleshipView.of(game(), None).legalMoves shouldBe empty
+      BattleshipView.of(game(), Some(Player2)).legalMoves shouldBe empty // Player1 is to act
     }
   }
 
-  "BattleshipState.of" should {
+  "BattleshipView.of" should {
     "report the current player and winner as seats" in {
-      val view = BattleshipState.of(game(currentPlayer = Player2, winner = Some(Player1)), Some(Player2))
+      val view = BattleshipView.of(game(currentPlayer = Player2, winner = Some(Player1)), Some(Player2))
       view.currentPlayer shouldBe Player2
       view.winner shouldBe Some(Player1)
       view.viewerSeat shouldBe Some(Player2)

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/GameStateWireSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/GameStateWireSpec.scala
@@ -15,7 +15,7 @@ import com.andy327.model.connectfour.{ConnectFour, Red => CfRed, Yellow => CfYel
 import com.andy327.model.core.PlayerId
 import com.andy327.model.holdem.{Card, Street, TexasHoldEm}
 import com.andy327.model.liarsdice.{Bid, LiarsDice, StandingBid}
-import com.andy327.model.mastermind.{Attempt, Feedback, Mastermind, Peg}
+import com.andy327.model.mastermind.{Attempt, Codebreaker, Feedback, Mastermind, Peg}
 import com.andy327.model.pig.Pig
 import com.andy327.model.tictactoe.{O, TicTacToe, X}
 
@@ -349,6 +349,28 @@ class GameStateWireSpec extends AnyWordSpec with Matchers {
           "currentPlayer": "codebreaker",
           "guessesRemaining": 10,
           "viewerRole": "codemaker"
+        }
+      """)
+    }
+
+    "encode a finished game to its exact wire form, naming the winner and revealing the secret to all" in {
+      val secret = Vector(Peg.Red, Peg.Blue, Peg.Green, Peg.Yellow)
+      val game = Mastermind(
+        codemakerId = alice,
+        codebreakerId = bob,
+        secret = Some(secret),
+        guesses = List(Attempt(secret, Feedback(black = 4, white = 0))),
+        winner = Some(Codebreaker)
+      )
+
+      wire(GameStateConverters.serializeGame(game, Some(bob))) shouldBe expected("""
+        {
+          "guesses": [{"pegs": ["red","blue","green","yellow"], "black": 4, "white": 0}],
+          "secret": ["red","blue","green","yellow"],
+          "currentPlayer": "codebreaker",
+          "winner": "codebreaker",
+          "guessesRemaining": 9,
+          "viewerRole": "codebreaker"
         }
       """)
     }

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/GameStateWireSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/GameStateWireSpec.scala
@@ -13,7 +13,7 @@ import com.andy327.model.battleship.{Battleship, Coord, Player1, Player2, Player
 import com.andy327.model.checkers.{Black => CkBlack, Checkers, Piece, Red => CkRed}
 import com.andy327.model.connectfour.{ConnectFour, Red => CfRed, Yellow => CfYellow}
 import com.andy327.model.core.PlayerId
-import com.andy327.model.holdem.{Card, Street, TexasHoldEm}
+import com.andy327.model.holdem.{Card, HandResult, PotAward, Street, TexasHoldEm}
 import com.andy327.model.liarsdice.{Bid, LiarsDice, Reveal, StandingBid}
 import com.andy327.model.mastermind.{Attempt, Codebreaker, Feedback, Mastermind, Peg}
 import com.andy327.model.pig.Pig
@@ -481,6 +481,62 @@ class GameStateWireSpec extends AnyWordSpec with Matchers {
           "toCall": 0,
           "street": "Flop",
           "viewerSeat": "P1"
+        }
+      """)
+    }
+
+    "encode a finished game to its exact wire form, naming the winner and exposing the showdown" in {
+      // the sit-and-go ended on a showdown: P1's aces tripped up and took P2's last chips
+      val board = List(Card("AD"), Card("7C"), Card("2D"), Card("5S"), Card("9H"))
+      val game = TexasHoldEm(
+        playerIds = Vector(alice, bob),
+        stacks = Vector(2000, 0),
+        button = 1,
+        holeCards = Vector(List(Card("AS"), Card("AH")), List(Card("KS"), Card("KH"))),
+        board = board,
+        deck = Nil,
+        street = Street.River,
+        toAct = 0,
+        streetContrib = Vector(0, 0),
+        committed = Vector(0, 0),
+        currentBet = 0,
+        lastRaiseSize = 10,
+        hasActed = Vector(true, true),
+        folded = Vector(false, false),
+        allIn = Vector(false, true),
+        handResult = Some(
+          HandResult(
+            board = board,
+            shownHands = Map(0 -> List(Card("AS"), Card("AH")), 1 -> List(Card("KS"), Card("KH"))),
+            awards = List(PotAward(200, List(0), Some("three of a kind, As")))
+          )
+        ),
+        winner = Some(0),
+        moveCount = 42
+      )
+
+      wire(GameStateConverters.serializeGame(game, Some(alice))) shouldBe expected("""
+        {
+          "seats": [
+            {"seat": "P1", "stack": 2000, "committed": 0, "bet": 0, "folded": false, "allIn": false},
+            {"seat": "P2", "stack": 0, "committed": 0, "bet": 0, "folded": false, "allIn": true}
+          ],
+          "holeCards": ["AS","AH"],
+          "board": ["AD","7C","2D","5S","9H"],
+          "button": "P2",
+          "currentPlayer": "P1",
+          "currentBet": 0,
+          "minRaise": 10,
+          "pot": 0,
+          "toCall": 0,
+          "street": "River",
+          "winner": "P1",
+          "viewerSeat": "P1",
+          "handResult": {
+            "board": ["AD","7C","2D","5S","9H"],
+            "shownHands": {"P1": ["AS","AH"], "P2": ["KS","KH"]},
+            "awards": [{"amount": 200, "winners": ["P1"], "description": "three of a kind, As"}]
+          }
         }
       """)
     }

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/GameStateWireSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/GameStateWireSpec.scala
@@ -1,0 +1,321 @@
+package com.andy327.server.http.json
+
+import java.util.UUID
+
+import io.circe.Json
+import io.circe.parser.parse
+import io.circe.syntax._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import com.andy327.actor.game.{GameState, GameStateConverters}
+import com.andy327.model.battleship.{Battleship, Coord, Player1, PlayerBoard, Ship}
+import com.andy327.model.checkers.{Black => CkBlack, Checkers, Piece, Red => CkRed}
+import com.andy327.model.connectfour.{ConnectFour, Red => CfRed, Yellow => CfYellow}
+import com.andy327.model.core.PlayerId
+import com.andy327.model.holdem.{Card, Street, TexasHoldEm}
+import com.andy327.model.liarsdice.{Bid, LiarsDice, StandingBid}
+import com.andy327.model.mastermind.{Attempt, Feedback, Mastermind, Peg}
+import com.andy327.model.pig.Pig
+import com.andy327.model.tictactoe.{O, TicTacToe, X}
+
+/** Pins the exact JSON every game view puts on the wire.
+  *
+  * Unlike the other serialization specs, which assert on individual fields, each case here fixes a whole game model and
+  * compares the encoded result against a literal document. That makes this the regression net for changes to the
+  * projection layer: a refactor is free to restructure the view types and their encoders, but if it alters a single
+  * byte the client sees, a case here fails. The models and the expected documents are therefore meant to stay frozen
+  * while the code between them changes.
+  *
+  * Views are compared after `deepDropNullValues`, because that is what the transport applies before sending — see
+  * `CirceSupport` for HTTP responses and `WebSocketRoutes.render` for pushed events. Asserting on the raw encoding
+  * would pin absent fields that no client ever receives.
+  */
+class GameStateWireSpec extends AnyWordSpec with Matchers {
+  import JsonProtocol._
+
+  private val alice: PlayerId = UUID.randomUUID()
+  private val bob: PlayerId = UUID.randomUUID()
+
+  /** The document a client actually receives for `state`. */
+  private def wire(state: GameState): Json = state.asJson.deepDropNullValues
+
+  /** Parses an expected document, failing the test (rather than the suite) if the literal itself is malformed. */
+  private def expected(raw: String): Json =
+    parse(raw).fold(err => fail(s"malformed expected JSON: $err"), identity)
+
+  "TicTacToe" should {
+    "encode to its exact wire form" in {
+      val game = TicTacToe(
+        playerX = alice,
+        playerO = bob,
+        board = Vector(
+          Vector(Some(X), None, None),
+          Vector(None, Some(O), None),
+          Vector(None, None, None)
+        ),
+        currentPlayer = X,
+        winner = None,
+        isDraw = false
+      )
+
+      wire(GameStateConverters.serializeGame(game, Some(alice))) shouldBe expected("""
+        {
+          "board": [["X","",""],["","O",""],["","",""]],
+          "currentPlayer": "X",
+          "draw": false
+        }
+      """)
+    }
+  }
+
+  "ConnectFour" should {
+    "encode to its exact wire form, including a decided winner" in {
+      val empty = Vector.fill(7)(Option.empty[com.andy327.model.connectfour.Mark])
+      val game = ConnectFour(
+        playerRed = alice,
+        playerYellow = bob,
+        board = Vector.fill(5)(empty) :+
+          Vector(Some(CfRed), Some(CfYellow), None, None, None, None, None),
+        currentPlayer = CfYellow,
+        winner = Some(CfRed),
+        isDraw = false
+      )
+
+      wire(GameStateConverters.serializeGame(game, Some(alice))) shouldBe expected("""
+        {
+          "board": [
+            ["","","","","","",""],
+            ["","","","","","",""],
+            ["","","","","","",""],
+            ["","","","","","",""],
+            ["","","","","","",""],
+            ["R","Y","","","","",""]
+          ],
+          "currentPlayer": "Y",
+          "winner": "R",
+          "draw": false
+        }
+      """)
+    }
+  }
+
+  "Checkers" should {
+    "encode to its exact wire form, distinguishing pawns from kings by case" in {
+      val blank = Vector.fill(8)(Option.empty[Piece])
+      val game = Checkers(
+        playerRed = alice,
+        playerBlack = bob,
+        board = Vector(
+          blank,
+          blank,
+          blank.updated(3, Some(Piece(CkBlack, isKing = false))),
+          blank,
+          blank.updated(1, Some(Piece(CkRed, isKing = true))),
+          blank.updated(0, Some(Piece(CkRed, isKing = false))),
+          blank,
+          blank
+        ),
+        currentPlayer = CkRed,
+        winner = None,
+        moveCount = 12
+      )
+
+      wire(GameStateConverters.serializeGame(game, Some(alice))) shouldBe expected("""
+        {
+          "board": [
+            ["","","","","","","",""],
+            ["","","","","","","",""],
+            ["","","","b","","","",""],
+            ["","","","","","","",""],
+            ["","R","","","","","",""],
+            ["r","","","","","","",""],
+            ["","","","","","","",""],
+            ["","","","","","","",""]
+          ],
+          "currentPlayer": "R",
+          "viewerSeat": "R"
+        }
+      """)
+    }
+  }
+
+  "Battleship" should {
+    "encode to its exact wire form, revealing the viewer's fleet and fogging the opponent's" in {
+      // P1 holds a 2-cell ship at (0,0)-(0,1) and has been fired at on (0,0) [hit] and (9,9) [miss];
+      // P2 holds a 1-cell ship at (5,5), already hit.
+      val game = Battleship(
+        alice,
+        bob,
+        PlayerBoard(List(Ship(Set(Coord(0, 0), Coord(0, 1)))), Set(Coord(0, 0), Coord(9, 9))),
+        PlayerBoard(List(Ship(Set(Coord(5, 5)))), Set(Coord(5, 5))),
+        Player1,
+        None
+      )
+
+      wire(GameStateConverters.serializeGame(game, Some(alice))) shouldBe expected("""
+        {
+          "board1": [
+            ["hit","ship","water","water","water","water","water","water","water","water"],
+            ["water","water","water","water","water","water","water","water","water","water"],
+            ["water","water","water","water","water","water","water","water","water","water"],
+            ["water","water","water","water","water","water","water","water","water","water"],
+            ["water","water","water","water","water","water","water","water","water","water"],
+            ["water","water","water","water","water","water","water","water","water","water"],
+            ["water","water","water","water","water","water","water","water","water","water"],
+            ["water","water","water","water","water","water","water","water","water","water"],
+            ["water","water","water","water","water","water","water","water","water","water"],
+            ["water","water","water","water","water","water","water","water","water","miss"]
+          ],
+          "board2": [
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","hit","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"]
+          ],
+          "currentPlayer": "P1",
+          "viewerSeat": "P1"
+        }
+      """)
+    }
+  }
+
+  "Pig" should {
+    "encode to its exact wire form" in {
+      val game = Pig(
+        playerIds = Vector(alice, bob),
+        scores = Vector(23, 41),
+        currentSeat = 1,
+        turnScore = 7,
+        lastRoll = Some(4),
+        winner = None,
+        moveCount = 9
+      )
+
+      wire(GameStateConverters.serializeGame(game, Some(bob))) shouldBe expected("""
+        {
+          "scores": {"P1": 23, "P2": 41},
+          "currentPlayer": "P2",
+          "turnScore": 7,
+          "lastRoll": 4,
+          "viewerSeat": "P2"
+        }
+      """)
+    }
+  }
+
+  "Mastermind" should {
+    "encode to its exact wire form, withholding the secret from the codebreaker" in {
+      val game = Mastermind(
+        codemakerId = alice,
+        codebreakerId = bob,
+        secret = Some(Vector(Peg.Red, Peg.Blue, Peg.Green, Peg.Yellow)),
+        guesses = List(Attempt(Vector(Peg.Red, Peg.Red, Peg.Blue, Peg.Blue), Feedback(black = 1, white = 1))),
+        winner = None
+      )
+
+      wire(GameStateConverters.serializeGame(game, Some(bob))) shouldBe expected("""
+        {
+          "guesses": [{"pegs": ["red","red","blue","blue"], "black": 1, "white": 1}],
+          "currentPlayer": "codebreaker",
+          "guessesRemaining": 9,
+          "viewerRole": "codebreaker"
+        }
+      """)
+    }
+
+    "encode the secret to its exact wire form for the codemaker" in {
+      val game = Mastermind(
+        codemakerId = alice,
+        codebreakerId = bob,
+        secret = Some(Vector(Peg.Red, Peg.Blue, Peg.Green, Peg.Yellow)),
+        guesses = Nil,
+        winner = None
+      )
+
+      wire(GameStateConverters.serializeGame(game, Some(alice))) shouldBe expected("""
+        {
+          "guesses": [],
+          "secret": ["red","blue","green","yellow"],
+          "currentPlayer": "codebreaker",
+          "guessesRemaining": 10,
+          "viewerRole": "codemaker"
+        }
+      """)
+    }
+  }
+
+  "Liar's Dice" should {
+    "encode to its exact wire form, showing only the viewer's own dice" in {
+      val game = LiarsDice(
+        playerIds = Vector(alice, bob),
+        dice = Vector(Vector(3, 3, 5), Vector(1, 2, 6)),
+        currentSeat = 0,
+        standing = Some(StandingBid(Bid(quantity = 3, face = Some(5)), bidderSeat = 1)),
+        lastReveal = None,
+        winner = None,
+        moveCount = 4
+      )
+
+      wire(GameStateConverters.serializeGame(game, Some(alice))) shouldBe expected("""
+        {
+          "dice": [3,3,5],
+          "diceCounts": {"P1": 3, "P2": 3},
+          "currentBid": {"quantity": 3, "face": 5},
+          "currentPlayer": "P1",
+          "viewerSeat": "P1"
+        }
+      """)
+    }
+  }
+
+  "Texas Hold 'Em" should {
+    "encode to its exact wire form, showing only the viewer's own hole cards" in {
+      val game = TexasHoldEm(
+        playerIds = Vector(alice, bob),
+        stacks = Vector(980, 960),
+        button = 0,
+        holeCards = Vector(List(Card("AS"), Card("KD")), List(Card("7H"), Card("2C"))),
+        board = List(Card("QS"), Card("JD"), Card("TC"), Card("9H"), Card("8S")),
+        deck = Nil,
+        street = Street.Flop,
+        toAct = 1,
+        streetContrib = Vector(20, 0),
+        committed = Vector(40, 20),
+        currentBet = 20,
+        lastRaiseSize = 20,
+        hasActed = Vector(true, false),
+        folded = Vector(false, false),
+        allIn = Vector(false, false),
+        handResult = None,
+        winner = None,
+        moveCount = 6
+      )
+
+      wire(GameStateConverters.serializeGame(game, Some(alice))) shouldBe expected("""
+        {
+          "seats": [
+            {"seat": "P1", "stack": 980, "committed": 40, "bet": 20, "folded": false, "allIn": false},
+            {"seat": "P2", "stack": 960, "committed": 20, "bet": 0, "folded": false, "allIn": false}
+          ],
+          "holeCards": ["AS","KD"],
+          "board": ["QS","JD","TC"],
+          "button": "P1",
+          "currentPlayer": "P2",
+          "currentBet": 20,
+          "minRaise": 40,
+          "pot": 60,
+          "toCall": 0,
+          "street": "Flop",
+          "viewerSeat": "P1"
+        }
+      """)
+    }
+  }
+}

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/GameStateWireSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/GameStateWireSpec.scala
@@ -14,7 +14,7 @@ import com.andy327.model.checkers.{Black => CkBlack, Checkers, Piece, Red => CkR
 import com.andy327.model.connectfour.{ConnectFour, Red => CfRed, Yellow => CfYellow}
 import com.andy327.model.core.PlayerId
 import com.andy327.model.holdem.{Card, Street, TexasHoldEm}
-import com.andy327.model.liarsdice.{Bid, LiarsDice, StandingBid}
+import com.andy327.model.liarsdice.{Bid, LiarsDice, Reveal, StandingBid}
 import com.andy327.model.mastermind.{Attempt, Codebreaker, Feedback, Mastermind, Peg}
 import com.andy327.model.pig.Pig
 import com.andy327.model.tictactoe.{O, TicTacToe, X}
@@ -395,6 +395,48 @@ class GameStateWireSpec extends AnyWordSpec with Matchers {
           "currentBid": {"quantity": 3, "face": 5},
           "currentPlayer": "P1",
           "viewerSeat": "P1"
+        }
+      """)
+    }
+
+    "encode a finished game to its exact wire form, naming the winner and exposing the closing reveal" in {
+      // seat 1 bid 3×4s holding one die; seat 0 challenged, the count came to 1, and seat 1 lost its last die
+      val game = LiarsDice(
+        playerIds = Vector(alice, bob),
+        dice = Vector(Vector(2, 2, 2), Vector.empty),
+        currentSeat = 0,
+        standing = None,
+        lastReveal = Some(
+          Reveal(
+            bid = Bid(quantity = 3, face = Some(4)),
+            count = 1,
+            allDice = Vector(Vector(4, 2, 5), Vector(6)),
+            challengerSeat = 0,
+            bidderSeat = 1,
+            loserSeat = 1,
+            diceLost = 1
+          )
+        ),
+        winner = Some(0),
+        moveCount = 9
+      )
+
+      wire(GameStateConverters.serializeGame(game, Some(alice))) shouldBe expected("""
+        {
+          "dice": [2,2,2],
+          "diceCounts": {"P1": 3, "P2": 0},
+          "currentPlayer": "P1",
+          "winner": "P1",
+          "viewerSeat": "P1",
+          "lastReveal": {
+            "bid": {"quantity": 3, "face": 4},
+            "count": 1,
+            "dice": {"P1": [4,2,5], "P2": [6]},
+            "challenger": "P1",
+            "bidder": "P2",
+            "loser": "P2",
+            "diceLost": 1
+          }
         }
       """)
     }

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/GameStateWireSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/GameStateWireSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import com.andy327.actor.game.{GameState, GameStateConverters}
-import com.andy327.model.battleship.{Battleship, Coord, Player1, PlayerBoard, Ship}
+import com.andy327.model.battleship.{Battleship, Coord, Player1, Player2, PlayerBoard, Ship}
 import com.andy327.model.checkers.{Black => CkBlack, Checkers, Piece, Red => CkRed}
 import com.andy327.model.connectfour.{ConnectFour, Red => CfRed, Yellow => CfYellow}
 import com.andy327.model.core.PlayerId
@@ -219,6 +219,49 @@ class GameStateWireSpec extends AnyWordSpec with Matchers {
           ],
           "currentPlayer": "P1",
           "viewerSeat": "P1"
+        }
+      """)
+    }
+
+    "encode a finished game for a spectator to its exact wire form, naming the winner and fogging both fleets" in {
+      // P2's single-cell fleet at (5,5) is fully sunk, so P1 has won; P1's fleet took one hit at (0,0)
+      val game = Battleship(
+        alice,
+        bob,
+        PlayerBoard(List(Ship(Set(Coord(0, 0), Coord(0, 1)))), Set(Coord(0, 0))),
+        PlayerBoard(List(Ship(Set(Coord(5, 5)))), Set(Coord(5, 5))),
+        Player2,
+        Some(Player1)
+      )
+
+      wire(GameStateConverters.serializeGame(game, None)) shouldBe expected("""
+        {
+          "board1": [
+            ["hit","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"]
+          ],
+          "board2": [
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","hit","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
+            ["unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"]
+          ],
+          "currentPlayer": "P2",
+          "winner": "P1"
         }
       """)
     }

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/GameStateWireSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/GameStateWireSpec.scala
@@ -137,6 +137,45 @@ class GameStateWireSpec extends AnyWordSpec with Matchers {
         }
       """)
     }
+
+    "encode a finished game to its exact wire form, naming the winning color" in {
+      val blank = Vector.fill(8)(Option.empty[Piece])
+      val game = Checkers(
+        playerRed = alice,
+        playerBlack = bob,
+        board = Vector(
+          blank,
+          blank,
+          blank,
+          blank,
+          blank,
+          blank.updated(0, Some(Piece(CkRed, isKing = false))), // Black has no pieces left
+          blank,
+          blank
+        ),
+        currentPlayer = CkBlack,
+        winner = Some(CkRed),
+        moveCount = 47
+      )
+
+      wire(GameStateConverters.serializeGame(game, Some(bob))) shouldBe expected("""
+        {
+          "board": [
+            ["","","","","","","",""],
+            ["","","","","","","",""],
+            ["","","","","","","",""],
+            ["","","","","","","",""],
+            ["","","","","","","",""],
+            ["r","","","","","","",""],
+            ["","","","","","","",""],
+            ["","","","","","","",""]
+          ],
+          "currentPlayer": "B",
+          "winner": "R",
+          "viewerSeat": "B"
+        }
+      """)
+    }
   }
 
   "Battleship" should {

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/GameStateWireSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/GameStateWireSpec.scala
@@ -21,11 +21,10 @@ import com.andy327.model.tictactoe.{O, TicTacToe, X}
 
 /** Pins the exact JSON every game view puts on the wire.
   *
-  * Unlike the other serialization specs, which assert on individual fields, each case here fixes a whole game model and
-  * compares the encoded result against a literal document. That makes this the regression net for changes to the
-  * projection layer: a refactor is free to restructure the view types and their encoders, but if it alters a single
-  * byte the client sees, a case here fails. The models and the expected documents are therefore meant to stay frozen
-  * while the code between them changes.
+  * Each case fixes a whole game model and compares the encoded result against a literal document, making this the
+  * regression net for the projection layer: the view types and their encoders may be restructured freely, but if a
+  * single byte the client sees changes, a case here fails. The models and the expected documents are therefore meant
+  * to stay frozen while the code between them changes.
   *
   * Views are compared after `deepDropNullValues`, because that is what the transport applies before sending — see
   * `CirceSupport` for HTTP responses and `WebSocketRoutes.render` for pushed events. Asserting on the raw encoding
@@ -205,6 +204,28 @@ class GameStateWireSpec extends AnyWordSpec with Matchers {
           "turnScore": 7,
           "lastRoll": 4,
           "viewerSeat": "P2"
+        }
+      """)
+    }
+
+    "encode a finished game to its exact wire form, naming the winning seat" in {
+      val game = Pig(
+        playerIds = Vector(alice, bob),
+        scores = Vector(45, 100),
+        currentSeat = 1,
+        turnScore = 0,
+        lastRoll = None,
+        winner = Some(1),
+        moveCount = 31
+      )
+
+      wire(GameStateConverters.serializeGame(game, Some(alice))) shouldBe expected("""
+        {
+          "scores": {"P1": 45, "P2": 100},
+          "currentPlayer": "P2",
+          "turnScore": 0,
+          "winner": "P2",
+          "viewerSeat": "P1"
         }
       """)
     }

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/GameViewWireSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/GameViewWireSpec.scala
@@ -8,7 +8,7 @@ import io.circe.syntax._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import com.andy327.actor.game.{GameState, GameStateConverters}
+import com.andy327.actor.game.{GameProjection, GameView}
 import com.andy327.model.battleship.{Battleship, Coord, Player1, Player2, PlayerBoard, Ship}
 import com.andy327.model.checkers.{Black => CkBlack, Checkers, Piece, Red => CkRed}
 import com.andy327.model.connectfour.{ConnectFour, Red => CfRed, Yellow => CfYellow}
@@ -30,14 +30,14 @@ import com.andy327.model.tictactoe.{O, TicTacToe, X}
   * `CirceSupport` for HTTP responses and `WebSocketRoutes.render` for pushed events. Asserting on the raw encoding
   * would pin absent fields that no client ever receives.
   */
-class GameStateWireSpec extends AnyWordSpec with Matchers {
+class GameViewWireSpec extends AnyWordSpec with Matchers {
   import JsonProtocol._
 
   private val alice: PlayerId = UUID.randomUUID()
   private val bob: PlayerId = UUID.randomUUID()
 
   /** The document a client actually receives for `state`. */
-  private def wire(state: GameState): Json = state.asJson.deepDropNullValues
+  private def wire(state: GameView): Json = state.asJson.deepDropNullValues
 
   /** Parses an expected document, failing the test (rather than the suite) if the literal itself is malformed. */
   private def expected(raw: String): Json =
@@ -58,7 +58,7 @@ class GameStateWireSpec extends AnyWordSpec with Matchers {
         isDraw = false
       )
 
-      wire(GameStateConverters.serializeGame(game, Some(alice))) shouldBe expected("""
+      wire(GameProjection.project(game, Some(alice))) shouldBe expected("""
         {
           "board": [["X","",""],["","O",""],["","",""]],
           "currentPlayer": "X",
@@ -81,7 +81,7 @@ class GameStateWireSpec extends AnyWordSpec with Matchers {
         isDraw = false
       )
 
-      wire(GameStateConverters.serializeGame(game, Some(alice))) shouldBe expected("""
+      wire(GameProjection.project(game, Some(alice))) shouldBe expected("""
         {
           "board": [
             ["","","","","","",""],
@@ -120,7 +120,7 @@ class GameStateWireSpec extends AnyWordSpec with Matchers {
         moveCount = 12
       )
 
-      wire(GameStateConverters.serializeGame(game, Some(alice))) shouldBe expected("""
+      wire(GameProjection.project(game, Some(alice))) shouldBe expected("""
         {
           "board": [
             ["","","","","","","",""],
@@ -158,7 +158,7 @@ class GameStateWireSpec extends AnyWordSpec with Matchers {
         moveCount = 47
       )
 
-      wire(GameStateConverters.serializeGame(game, Some(bob))) shouldBe expected("""
+      wire(GameProjection.project(game, Some(bob))) shouldBe expected("""
         {
           "board": [
             ["","","","","","","",""],
@@ -191,7 +191,7 @@ class GameStateWireSpec extends AnyWordSpec with Matchers {
         None
       )
 
-      wire(GameStateConverters.serializeGame(game, Some(alice))) shouldBe expected("""
+      wire(GameProjection.project(game, Some(alice))) shouldBe expected("""
         {
           "board1": [
             ["hit","ship","water","water","water","water","water","water","water","water"],
@@ -234,7 +234,7 @@ class GameStateWireSpec extends AnyWordSpec with Matchers {
         Some(Player1)
       )
 
-      wire(GameStateConverters.serializeGame(game, None)) shouldBe expected("""
+      wire(GameProjection.project(game, None)) shouldBe expected("""
         {
           "board1": [
             ["hit","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown","unknown"],
@@ -279,7 +279,7 @@ class GameStateWireSpec extends AnyWordSpec with Matchers {
         moveCount = 9
       )
 
-      wire(GameStateConverters.serializeGame(game, Some(bob))) shouldBe expected("""
+      wire(GameProjection.project(game, Some(bob))) shouldBe expected("""
         {
           "scores": {"P1": 23, "P2": 41},
           "currentPlayer": "P2",
@@ -301,7 +301,7 @@ class GameStateWireSpec extends AnyWordSpec with Matchers {
         moveCount = 31
       )
 
-      wire(GameStateConverters.serializeGame(game, Some(alice))) shouldBe expected("""
+      wire(GameProjection.project(game, Some(alice))) shouldBe expected("""
         {
           "scores": {"P1": 45, "P2": 100},
           "currentPlayer": "P2",
@@ -323,7 +323,7 @@ class GameStateWireSpec extends AnyWordSpec with Matchers {
         winner = None
       )
 
-      wire(GameStateConverters.serializeGame(game, Some(bob))) shouldBe expected("""
+      wire(GameProjection.project(game, Some(bob))) shouldBe expected("""
         {
           "guesses": [{"pegs": ["red","red","blue","blue"], "black": 1, "white": 1}],
           "currentPlayer": "codebreaker",
@@ -342,7 +342,7 @@ class GameStateWireSpec extends AnyWordSpec with Matchers {
         winner = None
       )
 
-      wire(GameStateConverters.serializeGame(game, Some(alice))) shouldBe expected("""
+      wire(GameProjection.project(game, Some(alice))) shouldBe expected("""
         {
           "guesses": [],
           "secret": ["red","blue","green","yellow"],
@@ -363,7 +363,7 @@ class GameStateWireSpec extends AnyWordSpec with Matchers {
         winner = Some(Codebreaker)
       )
 
-      wire(GameStateConverters.serializeGame(game, Some(bob))) shouldBe expected("""
+      wire(GameProjection.project(game, Some(bob))) shouldBe expected("""
         {
           "guesses": [{"pegs": ["red","blue","green","yellow"], "black": 4, "white": 0}],
           "secret": ["red","blue","green","yellow"],
@@ -388,7 +388,7 @@ class GameStateWireSpec extends AnyWordSpec with Matchers {
         moveCount = 4
       )
 
-      wire(GameStateConverters.serializeGame(game, Some(alice))) shouldBe expected("""
+      wire(GameProjection.project(game, Some(alice))) shouldBe expected("""
         {
           "dice": [3,3,5],
           "diceCounts": {"P1": 3, "P2": 3},
@@ -421,7 +421,7 @@ class GameStateWireSpec extends AnyWordSpec with Matchers {
         moveCount = 9
       )
 
-      wire(GameStateConverters.serializeGame(game, Some(alice))) shouldBe expected("""
+      wire(GameProjection.project(game, Some(alice))) shouldBe expected("""
         {
           "dice": [2,2,2],
           "diceCounts": {"P1": 3, "P2": 0},
@@ -465,7 +465,7 @@ class GameStateWireSpec extends AnyWordSpec with Matchers {
         moveCount = 6
       )
 
-      wire(GameStateConverters.serializeGame(game, Some(alice))) shouldBe expected("""
+      wire(GameProjection.project(game, Some(alice))) shouldBe expected("""
         {
           "seats": [
             {"seat": "P1", "stack": 980, "committed": 40, "bet": 20, "folded": false, "allIn": false},
@@ -515,7 +515,7 @@ class GameStateWireSpec extends AnyWordSpec with Matchers {
         moveCount = 42
       )
 
-      wire(GameStateConverters.serializeGame(game, Some(alice))) shouldBe expected("""
+      wire(GameProjection.project(game, Some(alice))) shouldBe expected("""
         {
           "seats": [
             {"seat": "P1", "stack": 2000, "committed": 0, "bet": 0, "folded": false, "allIn": false},

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/MastermindStateSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/MastermindStateSpec.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import com.andy327.actor.game.{GuessResult, MastermindState}
+import com.andy327.actor.game.MastermindState
 import com.andy327.model.core.PlayerId
 import com.andy327.model.mastermind.Peg.{Blue, Green, Red, Yellow}
 import com.andy327.model.mastermind.{Attempt, Codebreaker, Codemaker, Feedback, Mastermind, Role}
@@ -23,10 +23,10 @@ class MastermindStateSpec extends AnyWordSpec with Matchers {
   "MastermindState.of for the codemaker" should {
     "always reveal the secret and expose the public guess history" in {
       val view = MastermindState.of(game(), Some(Codemaker))
-      view.viewerRole shouldBe Some("codemaker")
-      view.secret shouldBe Some(List("red", "green", "yellow", "blue"))
-      view.guesses shouldBe List(GuessResult(List("red", "green", "blue", "yellow"), 2, 2))
-      view.currentPlayer shouldBe "codebreaker"
+      view.viewerRole shouldBe Some(Codemaker)
+      view.secret shouldBe Some(code)
+      view.guesses shouldBe oneGuess
+      view.currentPlayer shouldBe Codebreaker
       view.guessesRemaining shouldBe Mastermind.MaxGuesses - 1
     }
   }
@@ -48,9 +48,9 @@ class MastermindStateSpec extends AnyWordSpec with Matchers {
   "MastermindState.of once the game is over" should {
     "reveal the secret to everyone, including the codebreaker" in {
       val finished = game(winner = Some(Codebreaker))
-      MastermindState.of(finished, Some(Codebreaker)).secret shouldBe Some(List("red", "green", "yellow", "blue"))
-      MastermindState.of(finished, None).secret shouldBe Some(List("red", "green", "yellow", "blue"))
-      MastermindState.of(finished, Some(Codebreaker)).winner shouldBe Some("codebreaker")
+      MastermindState.of(finished, Some(Codebreaker)).secret shouldBe Some(code)
+      MastermindState.of(finished, None).secret shouldBe Some(code)
+      MastermindState.of(finished, Some(Codebreaker)).winner shouldBe Some(Codebreaker)
     }
   }
 
@@ -58,7 +58,7 @@ class MastermindStateSpec extends AnyWordSpec with Matchers {
     "report the codemaker to move and no secret for the codebreaker" in {
       val fresh = Mastermind.newGame(Seq(alice, bob))
       val view = MastermindState.of(fresh, Some(Codebreaker))
-      view.currentPlayer shouldBe "codemaker"
+      view.currentPlayer shouldBe Codemaker
       view.secret shouldBe None
       view.guesses shouldBe empty
       view.guessesRemaining shouldBe Mastermind.MaxGuesses

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/MastermindViewSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/MastermindViewSpec.scala
@@ -5,12 +5,12 @@ import java.util.UUID
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import com.andy327.actor.game.MastermindState
+import com.andy327.actor.game.MastermindView
 import com.andy327.model.core.PlayerId
 import com.andy327.model.mastermind.Peg.{Blue, Green, Red, Yellow}
 import com.andy327.model.mastermind.{Attempt, Codebreaker, Codemaker, Feedback, Mastermind, Role}
 
-class MastermindStateSpec extends AnyWordSpec with Matchers {
+class MastermindViewSpec extends AnyWordSpec with Matchers {
   val alice: PlayerId = UUID.randomUUID() // codemaker
   val bob: PlayerId = UUID.randomUUID() // codebreaker
 
@@ -20,9 +20,9 @@ class MastermindStateSpec extends AnyWordSpec with Matchers {
   private def game(guesses: List[Attempt] = oneGuess, winner: Option[Role] = None): Mastermind =
     Mastermind(alice, bob, Some(code), guesses, winner)
 
-  "MastermindState.of for the codemaker" should {
+  "MastermindView.of for the codemaker" should {
     "always reveal the secret and expose the public guess history" in {
-      val view = MastermindState.of(game(), Some(Codemaker))
+      val view = MastermindView.of(game(), Some(Codemaker))
       view.viewerRole shouldBe Some(Codemaker)
       view.secret shouldBe Some(code)
       view.guesses shouldBe oneGuess
@@ -31,33 +31,33 @@ class MastermindStateSpec extends AnyWordSpec with Matchers {
     }
   }
 
-  "MastermindState.of for the codebreaker" should {
+  "MastermindView.of for the codebreaker" should {
     "hide the secret while the game is in progress" in {
-      MastermindState.of(game(), Some(Codebreaker)).secret shouldBe None
+      MastermindView.of(game(), Some(Codebreaker)).secret shouldBe None
     }
   }
 
-  "MastermindState.of for a spectator" should {
+  "MastermindView.of for a spectator" should {
     "hide the secret while the game is in progress" in {
-      val view = MastermindState.of(game(), None)
+      val view = MastermindView.of(game(), None)
       view.viewerRole shouldBe None
       view.secret shouldBe None
     }
   }
 
-  "MastermindState.of once the game is over" should {
+  "MastermindView.of once the game is over" should {
     "reveal the secret to everyone, including the codebreaker" in {
       val finished = game(winner = Some(Codebreaker))
-      MastermindState.of(finished, Some(Codebreaker)).secret shouldBe Some(code)
-      MastermindState.of(finished, None).secret shouldBe Some(code)
-      MastermindState.of(finished, Some(Codebreaker)).winner shouldBe Some(Codebreaker)
+      MastermindView.of(finished, Some(Codebreaker)).secret shouldBe Some(code)
+      MastermindView.of(finished, None).secret shouldBe Some(code)
+      MastermindView.of(finished, Some(Codebreaker)).winner shouldBe Some(Codebreaker)
     }
   }
 
-  "MastermindState.of before a code is set" should {
+  "MastermindView.of before a code is set" should {
     "report the codemaker to move and no secret for the codebreaker" in {
       val fresh = Mastermind.newGame(Seq(alice, bob))
-      val view = MastermindState.of(fresh, Some(Codebreaker))
+      val view = MastermindView.of(fresh, Some(Codebreaker))
       view.currentPlayer shouldBe Codemaker
       view.secret shouldBe None
       view.guesses shouldBe empty

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -14,7 +14,6 @@ import com.andy327.actor.core.GameManager.{LobbyCreated, LobbyJoined, LobbyLeft,
 import com.andy327.actor.core.PlayerEvent
 import com.andy327.actor.game.{
   BattleshipState,
-  BidView,
   GameState,
   GameStateConverters,
   HoldEmHandResult,
@@ -30,6 +29,7 @@ import com.andy327.model.battleship.Battleship
 import com.andy327.model.checkers.Checkers
 import com.andy327.model.connectfour.ConnectFour
 import com.andy327.model.core.GameType
+import com.andy327.model.liarsdice.Bid
 import com.andy327.model.mastermind.{Attempt, Codebreaker, Feedback, Peg}
 import com.andy327.model.tictactoe.TicTacToe
 import com.andy327.persistence.db.MoveRecord
@@ -188,13 +188,14 @@ class SerializationSpec extends AnyWordSpec with Matchers {
 
     "encode a LiarsDiceState branch, keeping the viewer's dice and a wild-ones bid's absent face" in {
       val state: GameState = LiarsDiceState(
-        dice = Some(List(2, 3, 4, 5, 6)),
-        diceCounts = Map("P1" -> 5, "P2" -> 5),
-        currentBid = Some(BidView(2, None)), // a wild "ones" bid: face is absent
-        currentPlayer = "P1",
+        dice = Some(Vector(2, 3, 4, 5, 6)),
+        diceCounts = Vector(5, 5),
+        currentBid = Some(Bid(2, None)), // a wild "ones" bid: face is absent
+        currentPlayer = 0,
         winner = None,
-        viewerSeat = Some("P1"),
-        lastReveal = None
+        viewerSeat = Some(0),
+        lastReveal = None,
+        legalMoves = Nil
       )
       val json = state.asJson
       json.hcursor.get[List[Int]]("dice") shouldBe Right(List(2, 3, 4, 5, 6))

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -127,9 +127,9 @@ class SerializationSpec extends AnyWordSpec with Matchers {
     }
   }
 
-  // The grid view is write-only — see `gridGameStateEncoder` for why it cannot be decoded — so these cover the
-  // encoding direction only. GameStateWireSpec pins the full document; what is left here is the null handling the
-  // transport depends on.
+  // The grid view is write-only — see `gridGameStateEncoder` — so these cover the encoding direction only.
+  // GameStateWireSpec pins the whole document; these cover the symbol rendering and the null handling the transport
+  // depends on.
   "GridGameState encoder" should {
     "render marks by symbol, leaving unclaimed cells empty" in {
       val view = GameStateConverters.serializeGame(TicTacToe.empty(UUID.randomUUID(), UUID.randomUUID()), None)
@@ -159,12 +159,13 @@ class SerializationSpec extends AnyWordSpec with Matchers {
 
     "encode a PigState branch" in {
       val state: GameState = PigState(
-        scores = Map("P1" -> 0, "P2" -> 0),
-        currentPlayer = "P1",
+        scores = Vector(0, 0),
+        currentPlayer = 0,
         turnScore = 0,
         lastRoll = None,
         winner = None,
-        viewerSeat = None
+        viewerSeat = None,
+        legalMoves = Nil
       )
       val json = state.asJson
       json.hcursor.downField("scores").focus should be(defined)

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -15,7 +15,6 @@ import com.andy327.actor.core.PlayerEvent
 import com.andy327.actor.game.{
   BattleshipState,
   BidView,
-  CheckersState,
   GameState,
   GameStateConverters,
   GuessResult,
@@ -236,16 +235,14 @@ class SerializationSpec extends AnyWordSpec with Matchers {
       )
     }
 
-    "encode a CheckersState branch, carrying the board and the viewer's own seat, and round-trip it" in {
+    "encode a CheckersState branch, carrying the board and the viewer's own seat" in {
       val red = UUID.randomUUID()
       val black = UUID.randomUUID()
-      val view = GameStateConverters.serializeGame(Checkers.empty(red, black), Some(red)) // rendered for Red
-      val state: GameState = view
+      val state: GameState = GameStateConverters.serializeGame(Checkers.empty(red, black), Some(red)) // for Red
       val json = state.asJson
       json.hcursor.get[String]("viewerSeat") shouldBe Right("R")
       json.hcursor.get[String]("currentPlayer") shouldBe Right("R")
-      json.hcursor.downField("board").focus should be(defined)
-      json.as[CheckersState] shouldBe Right(view)
+      json.hcursor.downField("board").downN(5).downN(0).as[String] shouldBe Right("r") // a Red pawn, un-crowned
     }
   }
 

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -13,14 +13,14 @@ import org.scalatest.wordspec.AnyWordSpec
 import com.andy327.actor.core.GameManager.{LobbyCreated, LobbyJoined, LobbyLeft, MoveHistory, SubscribeAcknowledged}
 import com.andy327.actor.core.PlayerEvent
 import com.andy327.actor.game.{
-  BattleshipState,
-  GameState,
-  GameStateConverters,
+  BattleshipView,
+  GameProjection,
+  GameView,
   HoldEmSeat,
-  HoldEmState,
-  LiarsDiceState,
-  MastermindState,
-  PigState
+  HoldEmView,
+  LiarsDiceView,
+  MastermindView,
+  PigView
 }
 import com.andy327.actor.lobby._
 import com.andy327.model.battleship.Battleship
@@ -35,7 +35,7 @@ import com.andy327.persistence.db.MoveRecord
 import com.andy327.server.http.auth.TokenResponse
 import com.andy327.server.http.model.{ErrorResponse, MessageResponse}
 
-/** Covers the codecs JsonProtocol owns: the API response types, the GridGameState view, and the write-only PlayerEvent
+/** Covers the codecs JsonProtocol owns: the API response types, the GridGameView view, and the write-only PlayerEvent
   * encoder. The reused value codecs (Player, GameType, GameLifecycleStatus, LobbyMetadata) are tested at their source
   * in LobbyCodecsSpec and GameTypeCodecsSpec.
   */
@@ -125,38 +125,38 @@ class SerializationSpec extends AnyWordSpec with Matchers {
     }
   }
 
-  // The grid view is write-only — see `gridGameStateEncoder` — so these cover the encoding direction only.
-  // GameStateWireSpec pins the whole document; these cover the symbol rendering and the null handling the transport
+  // The grid view is write-only — see `gridGameViewEncoder` — so these cover the encoding direction only.
+  // GameViewWireSpec pins the whole document; these cover the symbol rendering and the null handling the transport
   // depends on.
-  "GridGameState encoder" should {
+  "GridGameView encoder" should {
     "render marks by symbol, leaving unclaimed cells empty" in {
-      val view = GameStateConverters.serializeGame(TicTacToe.empty(UUID.randomUUID(), UUID.randomUUID()), None)
+      val view = GameProjection.project(TicTacToe.empty(UUID.randomUUID(), UUID.randomUUID()), None)
       val cells = view.asJson.hcursor.downField("board").as[Vector[Vector[String]]]
       cells shouldBe Right(Vector.fill(3)(Vector.fill(3)("")))
     }
 
     "render a ConnectFour view through the same shared encoder" in {
-      val view = GameStateConverters.serializeGame(ConnectFour.empty(UUID.randomUUID(), UUID.randomUUID()), None)
+      val view = GameProjection.project(ConnectFour.empty(UUID.randomUUID(), UUID.randomUUID()), None)
       view.asJson.hcursor.get[String]("currentPlayer") shouldBe Right("R")
     }
 
     "omit an absent winner rather than serializing it as null" in {
-      val view = GameStateConverters.serializeGame(TicTacToe.empty(UUID.randomUUID(), UUID.randomUUID()), None)
+      val view = GameProjection.project(TicTacToe.empty(UUID.randomUUID(), UUID.randomUUID()), None)
       view.asJson.deepDropNullValues.asObject.flatMap(_("winner")) should not be defined
     }
   }
 
-  "the polymorphic GameState encoder" should {
-    "encode a BattleshipState branch (not just GridGameState)" in {
-      val state: GameState =
-        BattleshipState.of(Battleship.random(UUID.randomUUID(), UUID.randomUUID(), new Random(0)), None)
+  "the polymorphic GameView encoder" should {
+    "encode a BattleshipView branch (not just GridGameView)" in {
+      val state: GameView =
+        BattleshipView.of(Battleship.random(UUID.randomUUID(), UUID.randomUUID(), new Random(0)), None)
       val json = state.asJson
       json.hcursor.get[Option[String]]("viewerSeat") shouldBe Right(None)
       json.hcursor.downField("board1").focus should be(defined)
     }
 
-    "encode a PigState branch" in {
-      val state: GameState = PigState(
+    "encode a PigView branch" in {
+      val state: GameView = PigView(
         scores = Vector(0, 0),
         currentPlayer = 0,
         turnScore = 0,
@@ -170,8 +170,8 @@ class SerializationSpec extends AnyWordSpec with Matchers {
       json.hcursor.get[String]("currentPlayer") shouldBe Right("P1")
     }
 
-    "encode a MastermindState branch" in {
-      val state: GameState = MastermindState(
+    "encode a MastermindView branch" in {
+      val state: GameView = MastermindView(
         guesses = List(Attempt(Vector(Peg.Red, Peg.Green, Peg.Yellow, Peg.Blue), Feedback(black = 2, white = 1))),
         secret = None,
         currentPlayer = Codebreaker,
@@ -185,8 +185,8 @@ class SerializationSpec extends AnyWordSpec with Matchers {
       json.hcursor.get[String]("currentPlayer") shouldBe Right("codebreaker")
     }
 
-    "encode a LiarsDiceState branch, keeping the viewer's dice and a wild-ones bid's absent face" in {
-      val state: GameState = LiarsDiceState(
+    "encode a LiarsDiceView branch, keeping the viewer's dice and a wild-ones bid's absent face" in {
+      val state: GameView = LiarsDiceView(
         dice = Some(Vector(2, 3, 4, 5, 6)),
         diceCounts = Vector(5, 5),
         currentBid = Some(Bid(2, None)), // a wild "ones" bid: face is absent
@@ -202,8 +202,8 @@ class SerializationSpec extends AnyWordSpec with Matchers {
       json.hcursor.downField("currentBid").get[Option[Int]]("face") shouldBe Right(None)
     }
 
-    "encode a HoldEmState branch, keeping the viewer's hole cards and the showdown reveal" in {
-      val state: GameState = HoldEmState(
+    "encode a HoldEmView branch, keeping the viewer's hole cards and the showdown reveal" in {
+      val state: GameView = HoldEmView(
         seats = List(
           HoldEmSeat(990, 10, 10, folded = false, allIn = false),
           HoldEmSeat(985, 15, 15, folded = false, allIn = false)
@@ -238,10 +238,10 @@ class SerializationSpec extends AnyWordSpec with Matchers {
       )
     }
 
-    "encode a CheckersState branch, carrying the board and the viewer's own seat" in {
+    "encode a CheckersView branch, carrying the board and the viewer's own seat" in {
       val red = UUID.randomUUID()
       val black = UUID.randomUUID()
-      val state: GameState = GameStateConverters.serializeGame(Checkers.empty(red, black), Some(red)) // for Red
+      val state: GameView = GameProjection.project(Checkers.empty(red, black), Some(red)) // for Red
       val json = state.asJson
       json.hcursor.get[String]("viewerSeat") shouldBe Right("R")
       json.hcursor.get[String]("currentPlayer") shouldBe Right("R")
@@ -268,7 +268,7 @@ class SerializationSpec extends AnyWordSpec with Matchers {
 
     "encode GameStateUpdated with a type discriminator, roomId, and state" in {
       val roomId = UUID.randomUUID()
-      val state = GameStateConverters.serializeGame(TicTacToe.empty(UUID.randomUUID(), UUID.randomUUID()), None)
+      val state = GameProjection.project(TicTacToe.empty(UUID.randomUUID(), UUID.randomUUID()), None)
       val json = (PlayerEvent.GameStateUpdated(roomId, state, spectatorCount = 2): PlayerEvent).asJson
       json.hcursor.get[String]("type") shouldBe Right("GameStateUpdated")
       json.hcursor.get[UUID]("roomId") shouldBe Right(roomId)

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -18,7 +18,6 @@ import com.andy327.actor.game.{
   CheckersState,
   GameState,
   GameStateConverters,
-  GridGameState,
   GuessResult,
   HoldEmHandResult,
   HoldEmPotAward,
@@ -128,15 +127,19 @@ class SerializationSpec extends AnyWordSpec with Matchers {
     }
   }
 
-  "GridGameState codec" should {
-    "round-trip a TicTacToe view" in {
+  // The grid view is write-only — see `gridGameStateEncoder` for why it cannot be decoded — so these cover the
+  // encoding direction only. GameStateWireSpec pins the full document; what is left here is the null handling the
+  // transport depends on.
+  "GridGameState encoder" should {
+    "render marks by symbol, leaving unclaimed cells empty" in {
       val view = GameStateConverters.serializeGame(TicTacToe.empty(UUID.randomUUID(), UUID.randomUUID()), None)
-      view.asJson.as[GridGameState] shouldBe Right(view)
+      val cells = view.asJson.hcursor.downField("board").as[Vector[Vector[String]]]
+      cells shouldBe Right(Vector.fill(3)(Vector.fill(3)("")))
     }
 
-    "round-trip a ConnectFour view" in {
+    "render a ConnectFour view through the same shared encoder" in {
       val view = GameStateConverters.serializeGame(ConnectFour.empty(UUID.randomUUID(), UUID.randomUUID()), None)
-      view.asJson.as[GridGameState] shouldBe Right(view)
+      view.asJson.hcursor.get[String]("currentPlayer") shouldBe Right("R")
     }
 
     "omit an absent winner rather than serializing it as null" in {

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -16,8 +16,6 @@ import com.andy327.actor.game.{
   BattleshipState,
   GameState,
   GameStateConverters,
-  HoldEmHandResult,
-  HoldEmPotAward,
   HoldEmSeat,
   HoldEmState,
   LiarsDiceState,
@@ -29,6 +27,7 @@ import com.andy327.model.battleship.Battleship
 import com.andy327.model.checkers.Checkers
 import com.andy327.model.connectfour.ConnectFour
 import com.andy327.model.core.GameType
+import com.andy327.model.holdem.{Card, HandResult, PotAward, Street}
 import com.andy327.model.liarsdice.Bid
 import com.andy327.model.mastermind.{Attempt, Codebreaker, Feedback, Peg}
 import com.andy327.model.tictactoe.TicTacToe
@@ -206,27 +205,29 @@ class SerializationSpec extends AnyWordSpec with Matchers {
     "encode a HoldEmState branch, keeping the viewer's hole cards and the showdown reveal" in {
       val state: GameState = HoldEmState(
         seats = List(
-          HoldEmSeat("P1", 990, 10, 10, folded = false, allIn = false),
-          HoldEmSeat("P2", 985, 15, 15, folded = false, allIn = false)
+          HoldEmSeat(990, 10, 10, folded = false, allIn = false),
+          HoldEmSeat(985, 15, 15, folded = false, allIn = false)
         ),
-        holeCards = Some(List("AS", "AH")),
-        board = List("2C", "7D", "9S"),
-        button = "P1",
-        currentPlayer = "P2",
+        holeCards = Some(List(Card("AS"), Card("AH"))),
+        board = List(Card("2C"), Card("7D"), Card("9S")),
+        button = 0,
+        currentPlayer = 1,
         currentBet = 15,
         minRaise = 30,
         pot = 25,
         toCall = 5,
-        street = "Flop",
+        street = Street.Flop,
         winner = None,
-        viewerSeat = Some("P1"),
+        viewerSeat = Some(0),
         handResult = Some(
-          HoldEmHandResult(
-            List("2C"),
-            Map("P1" -> List("AS", "AH")),
-            List(HoldEmPotAward(25, List("P1"), Some("one pair, As")))
+          HandResult(
+            List(Card("2C")),
+            Map(0 -> List(Card("AS"), Card("AH"))),
+            List(PotAward(25, List(0), Some("one pair, As")))
           )
-        )
+        ),
+        legalMoves = Nil,
+        betSizing = None
       )
       val json = state.asJson
       json.hcursor.get[List[String]]("holeCards") shouldBe Right(List("AS", "AH"))

--- a/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/json/SerializationSpec.scala
@@ -17,7 +17,6 @@ import com.andy327.actor.game.{
   BidView,
   GameState,
   GameStateConverters,
-  GuessResult,
   HoldEmHandResult,
   HoldEmPotAward,
   HoldEmSeat,
@@ -31,6 +30,7 @@ import com.andy327.model.battleship.Battleship
 import com.andy327.model.checkers.Checkers
 import com.andy327.model.connectfour.ConnectFour
 import com.andy327.model.core.GameType
+import com.andy327.model.mastermind.{Attempt, Codebreaker, Feedback, Peg}
 import com.andy327.model.tictactoe.TicTacToe
 import com.andy327.persistence.db.MoveRecord
 import com.andy327.server.http.auth.TokenResponse
@@ -173,15 +173,16 @@ class SerializationSpec extends AnyWordSpec with Matchers {
 
     "encode a MastermindState branch" in {
       val state: GameState = MastermindState(
-        guesses = List(GuessResult(List("red", "green", "yellow", "blue"), 2, 1)),
+        guesses = List(Attempt(Vector(Peg.Red, Peg.Green, Peg.Yellow, Peg.Blue), Feedback(black = 2, white = 1))),
         secret = None,
-        currentPlayer = "codebreaker",
+        currentPlayer = Codebreaker,
         winner = None,
         guessesRemaining = 9,
-        viewerRole = Some("codebreaker")
+        viewerRole = Some(Codebreaker)
       )
       val json = state.asJson
-      json.hcursor.downField("guesses").focus should be(defined)
+      json.hcursor.downField("guesses").downN(0).get[List[String]]("pegs") shouldBe
+        Right(List("red", "green", "yellow", "blue"))
       json.hcursor.get[String]("currentPlayer") shouldBe Right("codebreaker")
     }
 

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/GameRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/GameRoutesSpec.scala
@@ -25,7 +25,6 @@ import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.wordspec.AnyWordSpec
 
 import com.andy327.actor.core.{GameManager, InMemChatRepo, InMemMoveRepo, InMemRepo, PlayerActor, PlayerEvent}
-import com.andy327.actor.game.GridGameState
 import com.andy327.actor.lobby.{LobbyMetadata, LobbyRepository, Player}
 import com.andy327.actor.persistence.PersistenceProtocol
 import com.andy327.model.core.{GameType, RoomId}
@@ -85,8 +84,8 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
 
         Post(s"/tictactoe/$roomId/move", moveEntity).withHeaders(aliceHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
-          val gameState = io.circe.parser.decode[GridGameState](responseAs[String]).toOption.get
-          gameState.board(0)(0) shouldBe "X"
+          val gameState = io.circe.parser.parse(responseAs[String]).toOption.get
+          gameState.hcursor.downField("board").downN(0).downN(0).as[String] shouldBe Right("X")
         }
       }
 
@@ -137,8 +136,8 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
 
         Get(s"/tictactoe/$roomId/status") ~> routes ~> check {
           status shouldBe StatusCodes.OK
-          val gameState = io.circe.parser.decode[GridGameState](responseAs[String]).toOption.get
-          gameState.currentPlayer shouldBe "X"
+          val gameState = io.circe.parser.parse(responseAs[String]).toOption.get
+          gameState.hcursor.get[String]("currentPlayer") shouldBe Right("X")
         }
       }
 
@@ -446,8 +445,8 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
 
         Post(s"/connectfour/$roomId/move", moveEntity).withHeaders(aliceHeader) ~> routes ~> check {
           status shouldBe StatusCodes.OK
-          val gameState = io.circe.parser.decode[GridGameState](responseAs[String]).toOption.get
-          gameState.board(5)(3) shouldBe "R"
+          val gameState = io.circe.parser.parse(responseAs[String]).toOption.get
+          gameState.hcursor.downField("board").downN(5).downN(3).as[String] shouldBe Right("R")
         }
       }
 
@@ -474,8 +473,8 @@ class GameRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
 
         Get(s"/connectfour/$roomId/status") ~> routes ~> check {
           status shouldBe StatusCodes.OK
-          val gameState = io.circe.parser.decode[GridGameState](responseAs[String]).toOption.get
-          gameState.currentPlayer shouldBe "R"
+          val gameState = io.circe.parser.parse(responseAs[String]).toOption.get
+          gameState.hcursor.get[String]("currentPlayer") shouldBe Right("R")
         }
       }
 


### PR DESCRIPTION
### Summary

Closes #77. The per-viewer game views were JSON-shaped DTOs — boards of strings, seats as `"P1"` labels, cards as `"As"` — because projection and serialization were fused into one step. This splits them: a typed, redacted `GameView` per game, produced by a `GameProjection` type class, with hand-written write-only encoders rendering the wire format. The wire does not change — a golden-JSON suite pins every document byte-for-byte before and after — and the bundled web client is untouched. The immediate motivation is #14: an AI player needs a typed, redacted view to decide from, and redaction-as-a-type makes it structurally impossible for a bot to see hidden state.

### The view layer

- **Domain types throughout** — `Vector[Vector[Option[Mark]]]` boards, `Piece`/`Color` for Checkers, `Card`/`Street` for Hold 'Em, seat indices instead of `"P1"` labels; the encoder alone renders symbols, labels, and card text.
- **Model types travel as themselves** — `GuessResult`, `BidView`, `RevealView`, `HoldEmPotAward`, and `HoldEmHandResult` are deleted; the views carry the model's own `Attempt`, `Bid`, `Reveal`, and `HandResult` verbatim.
- **Redaction is structural** — Battleship's `BattleshipCell` ADT has no way to say what lies beneath an un-fired opponent cell, and hidden hands simply have no field, so a projected view cannot leak by construction.

### Legal moves

- Views carry the moves **their viewer** may play right now — a player's own move set on their turn, empty for waiting opponents and spectators (`GameView.movesFor`, lazily built).
- Enumeration lives on the models as the dual of `play`'s validation: `TicTacToe.legalMoves`, `ConnectFour.legalMoves`, `Checkers.legalMoves` (mandatory captures, full jump chains), `Battleship.legalMoves`, `LiarsDice.legalBids`, and Hold 'Em's `legalActions` + `betBounds`.
- Two deliberate sound-not-complete calls, each pinned by tests on both sides: Liar's Dice caps bid quantities at the table's dice (`play` accepts more, but such bids can never be true), and Hold 'Em omits the zero-chip call when checking is free.
- Two games represent their space intensionally rather than as a list: Hold 'Em's sizings are a contiguous `BetSizing(action, min, max)` range collapsing to the all-in for short stacks, and Mastermind carries no field at all — its space is the constant `Peg.all ^ CodeLength`, stated in the scaladoc.
- `legalMoves` is not serialized: the wire contract is unchanged, and exposing move hints to clients stays a separate, one-line-per-encoder decision.

### Serialization

- Each view gets a hand-written `Encoder` in `JsonProtocol` reproducing the previous `deriveCodec` output exactly; the view codecs become write-only, since a per-viewer projection is lossy by design and nothing ever decoded one outside tests.
- `GameViewWireSpec` is the regression net: model-driven golden cases pinning each view's exact wire document (after `deepDropNullValues`, which is what the transport sends), including a finished game per view so winner and reveal rendering stay covered.

### Naming

- `GameState` → `GameView`, `XxxState` → `XxxView`; `GameStateView` and `GameStateConverters` merge into a single `GameProjection` (type class + instances + `project`); `GameModule.serialize` → `project` and `GameModuleBundle.serializeGame` → `projectGame`, leaving "serialize" to the layers that genuinely serialize.
- The WebSocket event tag `"GameStateUpdated"` and the `PlayerEvent.GameStateUpdated` class are unchanged — the web client dispatches on that string.

### Testing

- Golden wire documents for all eight views, mid-game and finished, held frozen across every commit of the branch; model suites for each `legalMoves`/`legalBids`/`betBounds` including agreement-with-`play` checks in both directions; module suites pinning the viewer-scoping rule (player to act, waiting opponent, spectator) per game; route assertions rewritten against raw wire JSON. Full `sbt ci` green across all modules (998 tests, 99.56% statement coverage); scalafmt, scalafix, and scaladoc clean.