### PR TITLE
Add AI bot players that fill seats and play autonomously (#14)

### DIFF
--- a/game-service-actor/src/main/scala/com/andy327/actor/bot/AiPolicy.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/bot/AiPolicy.scala
@@ -1,0 +1,23 @@
+package com.andy327.actor.bot
+
+import scala.util.Random
+
+import com.andy327.actor.game.{GameView, MovePayload}
+
+/** A bot's decision function: given the bot's own view of a game, choose the move to submit.
+  *
+  * A policy is a pure function — no actors, no effects, no global randomness. `rng` is a parameter, so a seeded
+  * instance replays identically and a test can pin exact choices. The view is the same per-viewer projection a human
+  * client receives, redacted at projection time, so a policy is structurally unable to read hidden state; and a view
+  * carries only its own viewer's legal moves, so `None` doubles as "nothing to play" — another seat's turn, a
+  * spectator's view, or a finished game.
+  *
+  * The returned payload takes the same path a human move does: it is submitted to the game operation endpoint, where
+  * the game's module validates it and injects any server-side randomness (Pig's die, Hold 'Em's deck, Liar's Dice's
+  * re-roll pool) before the model applies it.
+  */
+trait AiPolicy {
+
+  /** The move to submit for the viewer `view` was projected for, or `None` when that viewer has nothing to play. */
+  def decide(view: GameView, rng: Random): Option[MovePayload]
+}

--- a/game-service-actor/src/main/scala/com/andy327/actor/bot/BotActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/bot/BotActor.scala
@@ -1,0 +1,134 @@
+package com.andy327.actor.bot
+
+import scala.concurrent.duration._
+import scala.util.Random
+
+import org.apache.pekko.actor.typed.scaladsl.{Behaviors, TimerScheduler}
+import org.apache.pekko.actor.typed.{ActorRef, Behavior}
+
+import com.andy327.actor.core.{GameManager, PlayerActor, PlayerEvent}
+import com.andy327.actor.game.{GameOperation, MovePayload}
+import com.andy327.model.core.{PlayerId, RoomId}
+
+/** The session that stands in for a bot player in a running game.
+  *
+  * A bot holds no WebSocket, but from the game actor's side it is just another subscriber: it is registered with the
+  * game's own `PlayerActor` `Subscribe` command through a session adapter, and thereafter receives the same per-viewer
+  * push events a human client would. When a push carries a state in which the bot has a move to make — which its
+  * [[AiPolicy]] signals by returning `Some`, since a view lists only its own viewer's legal moves — the bot pauses for
+  * a short "thinking" beat and then submits the chosen move through the same `GameManager.RunGameOperation` path a
+  * human move takes. The pause both makes play feel natural and keeps a bot-versus-bot game from resolving in a tight
+  * loop.
+  *
+  * The bot decides only from the view it is pushed, so it cannot act on information a human in its seat would not have;
+  * and because the game is turn-based, exactly one push per turn hands it the move, so at most one submission is in
+  * flight at a time (tracked as the `pending` move). A terminal `GameEnded` push stops the actor — a rematch spawns a
+  * fresh bot rather than reusing this one.
+  *
+  * Actor relationships:
+  *   - Parent: `GameManager` (spawns one per bot seat at game start and on restore)
+  *   - Receives from: the game actor (push events, via the session adapter), its own turn-delay timer
+  *   - Sends to: `GameManager` (`RunGameOperation` to submit a move)
+  */
+object BotActor {
+
+  /** How long a bot "thinks" before submitting, unless overridden. Long enough to feel deliberate and to keep a
+    * bot-versus-bot game from spinning, short enough not to try a waiting human's patience.
+    */
+  val DefaultThinkDelay: FiniteDuration = 700.millis
+
+  sealed trait Command
+
+  /** A push event delivered to the bot's session adapter by the game actor. */
+  final private case class WrappedEvent(event: PlayerEvent) extends Command
+
+  /** The turn-delay timer has elapsed: submit `move`, decided when the turn was recognized. */
+  final private case class Act(move: MovePayload) extends Command
+
+  /** The game ended (or the session was closed): stop. */
+  private case object Stop extends Command
+
+  /** The reply to a submitted move, adapted from `GameManager.GameResponse`; observed only to log a rejection. */
+  final private case class MoveResult(response: GameManager.GameResponse) extends Command
+
+  /** Timer key for the single turn-delay timer; re-arming replaces any prior turn's pending act. */
+  private case object ActKey
+
+  /** Creates a bot session for `botId` in `roomId`, deciding with `policy` and submitting through `gameManager`.
+    *
+    * @param rng source of randomness the policy draws from; seed it for reproducible play
+    * @param thinkDelay pause between recognizing a turn and submitting; `Duration.Zero` submits immediately (used by
+    *                   tests for determinism)
+    * @param register called once on start with the bot's session adapter, so the caller — which holds the game actor
+    *                 ref — can subscribe it; keeps this actor free of the game-actor command type
+    */
+  def apply(
+      botId: PlayerId,
+      roomId: RoomId,
+      policy: AiPolicy,
+      gameManager: ActorRef[GameManager.Command],
+      rng: Random = new Random,
+      thinkDelay: FiniteDuration = DefaultThinkDelay
+  )(register: ActorRef[PlayerActor.Command] => Unit): Behavior[Command] =
+    Behaviors.setup { context =>
+      val session = context.messageAdapter[PlayerActor.Command] {
+        case PlayerActor.SendEvent(event) => WrappedEvent(event)
+        case PlayerActor.Disconnect       => Stop
+      }
+      register(session)
+      Behaviors.withTimers { timers =>
+        active(botId, roomId, policy, gameManager, rng, thinkDelay, timers, pending = false)
+      }
+    }
+
+  private def active(
+      botId: PlayerId,
+      roomId: RoomId,
+      policy: AiPolicy,
+      gameManager: ActorRef[GameManager.Command],
+      rng: Random,
+      thinkDelay: FiniteDuration,
+      timers: TimerScheduler[Command],
+      pending: Boolean
+  ): Behavior[Command] = Behaviors.receive { (context, message) =>
+    def loop(pending: Boolean): Behavior[Command] =
+      active(botId, roomId, policy, gameManager, rng, thinkDelay, timers, pending)
+
+    message match {
+      case WrappedEvent(PlayerEvent.GameStateUpdated(_, view, _)) =>
+        // a fresh turn hands us exactly one push; ignore further pushes while a move is already scheduled
+        if (pending) Behaviors.same
+        else
+          policy.decide(view, rng) match {
+            case Some(move) =>
+              if (thinkDelay <= Duration.Zero) context.self ! Act(move)
+              else timers.startSingleTimer(ActKey, Act(move), thinkDelay)
+              loop(pending = true)
+            case None => Behaviors.same // not our turn, or nothing to play
+          }
+
+      case WrappedEvent(PlayerEvent.GameEnded(_)) =>
+        context.log.debug(s"[$roomId] bot $botId sees the game ended; stopping")
+        Behaviors.stopped
+
+      case WrappedEvent(_) =>
+        Behaviors.same // chat and other events are not the bot's concern
+
+      case Act(move) =>
+        val adapter = context.messageAdapter[GameManager.GameResponse](MoveResult(_))
+        gameManager ! GameManager.RunGameOperation(roomId, GameOperation.MakeMove(botId, move), adapter)
+        loop(pending = false)
+
+      case MoveResult(GameManager.MoveRejected(reason)) =>
+        // the legality tests make this unreachable in practice; if it ever fires, a policy produced an illegal move
+        context.log.warn(s"[$roomId] bot $botId move rejected: $reason")
+        Behaviors.same
+
+      case MoveResult(_) =>
+        Behaviors.same // the accepted state arrives as a GameStateUpdated push, so the reply itself is unused
+
+      case Stop =>
+        Behaviors.stopped
+    }
+  }
+}

--- a/game-service-actor/src/main/scala/com/andy327/actor/bot/BotConfig.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/bot/BotConfig.scala
@@ -1,0 +1,28 @@
+package com.andy327.actor.bot
+
+import scala.concurrent.duration.FiniteDuration
+import scala.jdk.DurationConverters._
+
+import com.typesafe.config.{Config, ConfigFactory}
+
+/** Runtime tuning for bot play.
+  *
+  * Loaded from the `pekko-game-service.bot` stanza in `application.conf` (or the reference defaults). Absent settings
+  * fall back to the code defaults, so the feature needs no configuration to run.
+  *
+  * @param thinkDelay the pause a bot takes between recognizing its turn and submitting; a shorter value speeds a
+  *                   bot-versus-bot game (and load tests), zero removes the pause entirely
+  */
+final case class BotConfig(thinkDelay: FiniteDuration)
+
+object BotConfig {
+  private val ThinkDelayPath = "pekko-game-service.bot.think-delay"
+
+  /** Reads the `bot` stanza; an absent `think-delay` keeps [[BotActor.DefaultThinkDelay]]. */
+  def fromConfig(config: Config): BotConfig =
+    if (config.hasPath(ThinkDelayPath)) BotConfig(config.getDuration(ThinkDelayPath).toScala)
+    else BotConfig(BotActor.DefaultThinkDelay)
+
+  /** Loads from the standard `ConfigFactory.load()` resolution chain (application.conf → reference.conf). */
+  lazy val default: BotConfig = fromConfig(ConfigFactory.load())
+}

--- a/game-service-actor/src/main/scala/com/andy327/actor/bot/BotPolicies.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/bot/BotPolicies.scala
@@ -2,25 +2,49 @@ package com.andy327.actor.bot
 
 import com.andy327.model.core.GameType
 
-/** How strong an opponent a bot seat plays. A single level exists today; the seam keeps a stronger (or gentler) bot a
-  * registry entry away rather than a redesign.
+/** How strong an opponent a bot seat plays — a property of the seat, chosen when the bot is added and carried with it
+  * into the game.
+  *
+  * The ladder is deliberately universal rather than per-game: a player asks for a hard opponent without caring which
+  * game they are playing, so one vocabulary serves every game type and one control serves the whole UI. What differs
+  * per game is only which policy each rung resolves to, and a game that has not implemented a rung yet falls back to
+  * the closest one it has (see [[BotPolicies]]).
+  *
+  * One rung exists today. Adding another is a new case object here plus its per-game entries in [[BotPolicies]] —
+  * nothing else in the bot machinery changes.
   */
-sealed trait BotDifficulty
+sealed trait BotDifficulty {
+
+  /** The stable lower-case name this level travels under on the wire. */
+  def label: String
+}
 
 object BotDifficulty {
 
   /** The strength every bot currently plays at. */
-  case object Standard extends BotDifficulty
+  case object Standard extends BotDifficulty { val label = "standard" }
+
+  /** Every level a caller may ask for, in ascending order of strength. */
+  val all: List[BotDifficulty] = List(Standard)
+
+  /** The level a bot takes when none is requested. */
+  val Default: BotDifficulty = Standard
+
+  private val byLabel: Map[String, BotDifficulty] = all.map(level => level.label -> level).toMap
+
+  /** Resolves a (case-insensitive) wire name to its level, or `None` if it is not a known one. */
+  def fromString(s: String): Option[BotDifficulty] = byLabel.get(s.toLowerCase)
 }
 
-/** Resolves the [[AiPolicy]] a bot plays for a given game type and difficulty.
+/** Resolves the [[AiPolicy]] a bot plays, given its game type and the difficulty its seat was created with.
   *
-  * Every game type currently resolves to [[RandomPolicy]]; a per-game heuristic replaces its entry here without
-  * touching the bot machinery or the other games.
+  * Every pairing currently resolves to [[RandomPolicy]]. A per-game heuristic replaces one entry here without touching
+  * the bot machinery or the other games, and a game with no entry for a level keeps the random baseline rather than
+  * failing — so a new rung can be rolled out one game at a time.
   */
 object BotPolicies {
 
-  def forGame(gameType: GameType, difficulty: BotDifficulty = BotDifficulty.Standard): AiPolicy =
+  def forGame(gameType: GameType, difficulty: BotDifficulty = BotDifficulty.Default): AiPolicy =
     (gameType, difficulty) match {
       case (_, BotDifficulty.Standard) => RandomPolicy
     }

--- a/game-service-actor/src/main/scala/com/andy327/actor/bot/BotPolicies.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/bot/BotPolicies.scala
@@ -1,0 +1,27 @@
+package com.andy327.actor.bot
+
+import com.andy327.model.core.GameType
+
+/** How strong an opponent a bot seat plays. A single level exists today; the seam keeps a stronger (or gentler) bot a
+  * registry entry away rather than a redesign.
+  */
+sealed trait BotDifficulty
+
+object BotDifficulty {
+
+  /** The strength every bot currently plays at. */
+  case object Standard extends BotDifficulty
+}
+
+/** Resolves the [[AiPolicy]] a bot plays for a given game type and difficulty.
+  *
+  * Every game type currently resolves to [[RandomPolicy]]; a per-game heuristic replaces its entry here without
+  * touching the bot machinery or the other games.
+  */
+object BotPolicies {
+
+  def forGame(gameType: GameType, difficulty: BotDifficulty = BotDifficulty.Standard): AiPolicy =
+    (gameType, difficulty) match {
+      case (_, BotDifficulty.Standard) => RandomPolicy
+    }
+}

--- a/game-service-actor/src/main/scala/com/andy327/actor/bot/RandomPolicy.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/bot/RandomPolicy.scala
@@ -1,0 +1,61 @@
+package com.andy327.actor.bot
+
+import scala.util.Random
+
+import com.andy327.actor.game.{
+  BattleshipView,
+  CheckersView,
+  GameView,
+  GridGameView,
+  HoldEmView,
+  LiarsDiceView,
+  MastermindView,
+  MovePayload,
+  PigView
+}
+import com.andy327.model.mastermind.{Codebreaker, Codemaker, Mastermind}
+
+/** The uniformly random baseline policy: every legal move is equally likely.
+  *
+  * For the games whose view lists its moves, this picks one of `legalMoves`. Mastermind's move space is described
+  * rather than listed, so a random code is drawn from the palette — for the code-setting and every guess alike — and
+  * Texas Hold 'Em's bet sizings form a range, so one uniformly drawn total stands alongside the listed chip-free
+  * actions as a single equally weighted candidate.
+  *
+  * This is the floor every game type starts from: legal, deterministic under a seeded `rng`, and indifferent to
+  * strategy.
+  */
+object RandomPolicy extends AiPolicy {
+
+  override def decide(view: GameView, rng: Random): Option[MovePayload] = view match {
+    case v: GridGameView   => pick(v.legalMoves, rng)
+    case v: CheckersView   => pick(v.legalMoves, rng)
+    case v: BattleshipView => pick(v.legalMoves, rng)
+    case v: PigView        => pick(v.legalMoves, rng)
+    case v: LiarsDiceView  => pick(v.legalMoves, rng)
+    case v: MastermindView => mastermind(v, rng)
+    case v: HoldEmView     => holdEm(v, rng)
+  }
+
+  private def pick[A](moves: List[A], rng: Random): Option[A] =
+    if (moves.isEmpty) None else Some(moves(rng.nextInt(moves.size)))
+
+  /** A random code from the palette, played under the action the viewer's role names, on that role's turn only. */
+  private def mastermind(view: MastermindView, rng: Random): Option[MovePayload] =
+    if (view.viewerRole.contains(view.currentPlayer) && view.winner.isEmpty) {
+      val pegs = Mastermind.randomCode(rng).map(_.name).toList
+      val action = view.currentPlayer match {
+        case Codemaker   => "setcode"
+        case Codebreaker => "guess"
+      }
+      Some(MovePayload.MastermindAction(action, pegs))
+    } else None
+
+  /** One of the chip-free actions, or — when a sizing is open — a bet or raise to a uniformly drawn total. */
+  private def holdEm(view: HoldEmView, rng: Random): Option[MovePayload] = {
+    val sized = view.betSizing.map { sizing =>
+      MovePayload.HoldEmAction(sizing.action, Some(sizing.min + rng.nextInt(sizing.max - sizing.min + 1)))
+    }
+    pick(view.legalMoves ++ sized, rng)
+  }
+}

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
@@ -12,7 +12,7 @@ import org.apache.pekko.actor.typed.scaladsl.{ActorContext, Behaviors, StashBuff
 import org.apache.pekko.actor.typed.{ActorRef, Behavior}
 import org.apache.pekko.util.Timeout
 
-import com.andy327.actor.bot.{BotActor, BotConfig, BotPolicies}
+import com.andy327.actor.bot.{BotActor, BotConfig, BotDifficulty, BotPolicies}
 import com.andy327.actor.chat.{ChatRepository, NoOpChatRepository}
 import com.andy327.actor.events.{EventPublisher, GameEvent, NoOpEventPublisher}
 import com.andy327.actor.game.{GameOperation, GameRegistry, GameView}
@@ -65,10 +65,15 @@ object GameManager {
     */
   final case class CancelLobby(roomId: RoomId, playerId: PlayerId, replyTo: ActorRef[GameResponse]) extends Command
 
-  /** Seat a bot in a pre-game lobby the caller hosts; replies with [[LobbyJoined]] carrying the bot or a
-    * [[LobbyErrorResponse]] (not host, lobby full, not joinable, not found).
+  /** Seat a bot playing at `difficulty` in a pre-game lobby the caller hosts; replies with [[LobbyJoined]] carrying
+    * the bot or a [[LobbyErrorResponse]] (not host, lobby full, not joinable, not found).
     */
-  final case class AddBot(roomId: RoomId, requesterId: PlayerId, replyTo: ActorRef[GameResponse]) extends Command
+  final case class AddBot(
+      roomId: RoomId,
+      requesterId: PlayerId,
+      difficulty: BotDifficulty,
+      replyTo: ActorRef[GameResponse]
+  ) extends Command
 
   /** Remove a bot from a pre-game lobby the caller hosts; replies with [[LobbyLeft]] or a [[LobbyErrorResponse]]
     * (not host, no such bot, not joinable, not found).
@@ -197,6 +202,9 @@ object GameManager {
   /** Sent by LobbyManager after validating a StartGame request; GameManager spawns the child actor. Carries the stable
     * `roomId`, the freshly-minted `matchId` for this playthrough, and the seated `players` in turn order (seat 0 moves
     * first); LobbyManager rotates that order across rematches.
+    *
+    * `bots` names the difficulty of each bot seat in `players`, so the spawner knows which policy to give each one; it
+    * is empty for an all-human roster.
     */
   final private[core] case class SpawnGame(
       roomId: RoomId,
@@ -204,7 +212,8 @@ object GameManager {
       gameType: GameType,
       players: Seq[PlayerId],
       replyTo: ActorRef[GameResponse],
-      subscribers: Map[PlayerId, ActorRef[PlayerActor.Command]] = Map.empty
+      subscribers: Map[PlayerId, ActorRef[PlayerActor.Command]] = Map.empty,
+      bots: Map[PlayerId, BotDifficulty] = Map.empty
   ) extends Command
 
   /** Adapter wrapper — converts a game actor's `Either[GameError, GameView]` reply into a [[GameResponse]]. */
@@ -359,9 +368,12 @@ object GameManager {
 
   /** Spawn a [[BotActor]] for each bot seat in `players` and subscribe it to `gameActor`, so a seated bot begins
     * playing as soon as the game is live. Human seats are skipped — their sessions subscribe themselves. Each bot
-    * decides with the policy [[BotPolicies]] resolves for `gameType` and submits moves back through this GameManager,
-    * exactly as a human client does; the think delay comes from the actor system's [[BotConfig]]. A no-op when the
-    * roster holds no bots.
+    * decides with the policy [[BotPolicies]] resolves for `gameType` and the difficulty `bots` recorded for its seat,
+    * and submits moves back through this GameManager, exactly as a human client does; the think delay comes from the
+    * actor system's [[BotConfig]]. A no-op when the roster holds no bots.
+    *
+    * A bot seat missing from `bots` falls back to the default difficulty — the case for a match restored without its
+    * lobby, where the recorded choice is no longer reachable.
     */
   private def spawnBots(
       context: ActorContext[Command],
@@ -369,6 +381,7 @@ object GameManager {
       matchId: MatchId,
       roomId: RoomId,
       players: Seq[PlayerId],
+      bots: Map[PlayerId, BotDifficulty],
       gameActor: ActorRef[GameActor.GameCommand],
       tracingConfig: TracingConfig,
       traceEmit: TraceEvent => Unit
@@ -376,8 +389,9 @@ object GameManager {
     val actorPlugin = GameRegistry.forType(gameType).actor
     val thinkDelay = BotConfig.fromConfig(context.system.settings.config).thinkDelay
     players.filter(BotId.isBot).foreach { botId =>
-      val behavior = BotActor(botId, roomId, BotPolicies.forGame(gameType), context.self, thinkDelay = thinkDelay) {
-        session => gameActor ! actorPlugin.subscribeCommand(session, botId)
+      val policy = BotPolicies.forGame(gameType, bots.getOrElse(botId, BotDifficulty.Default))
+      val behavior = BotActor(botId, roomId, policy, context.self, thinkDelay = thinkDelay) { session =>
+        gameActor ! actorPlugin.subscribeCommand(session, botId)
       }
       context.spawn(TracingInterceptor.wrap(behavior, tracingConfig, traceEmit), s"bot-$matchId-$botId")
     }
@@ -514,6 +528,11 @@ object GameManager {
         val matchToRoom: Map[MatchId, RoomId] =
           lobbies.flatMap(m => m.currentMatchId.map(_ -> m.roomId)).toMap
 
+        // the difficulty each restored match's bot seats were created with, recovered from the room that recorded the
+        // match; an orphan match has none, and its bots fall back to the default
+        val matchToBots: Map[MatchId, Map[PlayerId, BotDifficulty]] =
+          lobbies.flatMap(m => m.currentMatchId.map(_ -> m.bots)).toMap
+
         // resolve each restored game to its room once, then derive the actor map and the player index from it
         val resolved = games.toList.map { case (matchId, (gameType, game)) =>
           val roomId = matchToRoom.getOrElse(matchId, matchId)
@@ -532,7 +551,17 @@ object GameManager {
           // a restored game keeps no live sessions, so its bots must be re-created to keep playing; a terminal
           // snapshot's actor stops itself on restore, so only an in-progress game gets bots
           if (game.gameStatus == InProgress)
-            spawnBots(context, gameType, matchId, roomId, game.players, actorRef, tracingConfig, traceEmit)
+            spawnBots(
+              context,
+              gameType,
+              matchId,
+              roomId,
+              game.players,
+              matchToBots.getOrElse(matchId, Map.empty),
+              actorRef,
+              tracingConfig,
+              traceEmit
+            )
           roomId -> (gameType, matchId, actorRef)
         }.toMap
 
@@ -639,11 +668,11 @@ object GameManager {
             lobbyManager ! LobbyManager.CancelLobby(roomId, playerId, replyTo)
           Behaviors.same
 
-        case AddBot(roomId, requesterId, replyTo) =>
+        case AddBot(roomId, requesterId, difficulty, replyTo) =>
           // no auto-subscribe interception here: that wiring subscribes the caller's connected session to lobby
           // pushes, and this caller — the host — was wired when the lobby was created, while the seated bot has no
           // session to wire
-          lobbyManager ! LobbyManager.AddBot(roomId, requesterId, replyTo)
+          lobbyManager ! LobbyManager.AddBot(roomId, requesterId, difficulty, replyTo)
           Behaviors.same
 
         case RemoveBot(roomId, requesterId, botId, replyTo) =>
@@ -796,7 +825,7 @@ object GameManager {
           replyTo ! context.child("trace-collector").map(_.unsafeUpcast[TraceCollector.Command])
           Behaviors.same
 
-        case SpawnGame(roomId, matchId, gameType, players, replyTo, subscribers) =>
+        case SpawnGame(roomId, matchId, gameType, players, replyTo, subscribers, bots) =>
           val n = players.size
           if (n < gameType.minPlayers || n > gameType.maxPlayers) {
             val expected =
@@ -815,7 +844,7 @@ object GameManager {
             ).unsafeUpcast[GameActor.GameCommand]
 
             subscribers.foreach { case (pid, ref) => actorRef ! bundle.actor.subscribeCommand(ref, pid) }
-            spawnBots(context, gameType, matchId, roomId, players, actorRef, tracingConfig, traceEmit)
+            spawnBots(context, gameType, matchId, roomId, players, bots, actorRef, tracingConfig, traceEmit)
 
             persistActor ! PersistenceProtocol.SaveSnapshot(
               matchId,

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
@@ -53,8 +53,8 @@ object GameManager {
   /** Join an existing lobby; replies with [[LobbyJoined]] or a [[LobbyErrorResponse]]. */
   final case class JoinLobby(roomId: RoomId, player: Player, replyTo: ActorRef[GameResponse]) extends Command
 
-  /** Leave a lobby. If the host leaves, the host role migrates to a remaining member and the lobby survives; it is
-    * cancelled only when the host was the last player. Rejected with
+  /** Leave a lobby. If the host leaves, the host role migrates to a remaining human member and the lobby survives; it
+    * is cancelled when the host was the last human. Rejected with
     * [[com.andy327.actor.lobby.LobbyError.GameInProgress]] once the game has started (leaving is then a forfeit).
     */
   final case class LeaveLobby(roomId: RoomId, player: Player, replyTo: ActorRef[GameResponse]) extends Command
@@ -63,6 +63,17 @@ object GameManager {
     * (not host, lobby not found). Rejected once the game has started — at that point leaving is a forfeit.
     */
   final case class CancelLobby(roomId: RoomId, playerId: PlayerId, replyTo: ActorRef[GameResponse]) extends Command
+
+  /** Seat a bot in a pre-game lobby the caller hosts; replies with [[LobbyJoined]] carrying the bot or a
+    * [[LobbyErrorResponse]] (not host, lobby full, not joinable, not found).
+    */
+  final case class AddBot(roomId: RoomId, requesterId: PlayerId, replyTo: ActorRef[GameResponse]) extends Command
+
+  /** Remove a bot from a pre-game lobby the caller hosts; replies with [[LobbyLeft]] or a [[LobbyErrorResponse]]
+    * (not host, no such bot, not joinable, not found).
+    */
+  final case class RemoveBot(roomId: RoomId, requesterId: PlayerId, botId: PlayerId, replyTo: ActorRef[GameResponse])
+      extends Command
 
   /** Start a game in a lobby the caller hosts; replies with [[GameStarted]] or a [[LobbyErrorResponse]]. */
   final case class StartGame(roomId: RoomId, playerId: PlayerId, replyTo: ActorRef[GameResponse]) extends Command
@@ -595,6 +606,17 @@ object GameManager {
             replyTo ! LobbyErrorResponse(LobbyError.GameInProgress(roomId))
           else
             lobbyManager ! LobbyManager.CancelLobby(roomId, playerId, replyTo)
+          Behaviors.same
+
+        case AddBot(roomId, requesterId, replyTo) =>
+          // no auto-subscribe interception here: that wiring subscribes the caller's connected session to lobby
+          // pushes, and this caller — the host — was wired when the lobby was created, while the seated bot has no
+          // session to wire
+          lobbyManager ! LobbyManager.AddBot(roomId, requesterId, replyTo)
+          Behaviors.same
+
+        case RemoveBot(roomId, requesterId, botId, replyTo) =>
+          lobbyManager ! LobbyManager.RemoveBot(roomId, requesterId, botId, replyTo)
           Behaviors.same
 
         case StartGame(roomId, playerId, replyTo) =>

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/GameManager.scala
@@ -12,13 +12,14 @@ import org.apache.pekko.actor.typed.scaladsl.{ActorContext, Behaviors, StashBuff
 import org.apache.pekko.actor.typed.{ActorRef, Behavior}
 import org.apache.pekko.util.Timeout
 
+import com.andy327.actor.bot.{BotActor, BotConfig, BotPolicies}
 import com.andy327.actor.chat.{ChatRepository, NoOpChatRepository}
 import com.andy327.actor.events.{EventPublisher, GameEvent, NoOpEventPublisher}
 import com.andy327.actor.game.{GameOperation, GameRegistry, GameView}
-import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyError, LobbyMetadata, LobbyRepository, Player}
+import com.andy327.actor.lobby.{BotId, GameLifecycleStatus, LobbyError, LobbyMetadata, LobbyRepository, Player}
 import com.andy327.actor.persistence.PersistenceProtocol
 import com.andy327.actor.tracing.{TraceCollector, TraceEvent, TracingConfig, TracingInterceptor}
-import com.andy327.model.core.{Game, GameError, GameType, MatchId, PlayerId, RoomId}
+import com.andy327.model.core.{Game, GameError, GameType, InProgress, MatchId, PlayerId, RoomId}
 import com.andy327.persistence.db.{GameRepository, MoveHistoryRepository, MoveRecord, NoOpMoveHistoryRepository}
 
 /** A supervisor actor responsible for game actor lifecycle and request routing.
@@ -356,6 +357,32 @@ object GameManager {
   /** Timeout for internal `context.ask` calls used to look up player refs during subscribe flows. */
   private val subscribeAskTimeout: Timeout = Timeout(3.seconds)
 
+  /** Spawn a [[BotActor]] for each bot seat in `players` and subscribe it to `gameActor`, so a seated bot begins
+    * playing as soon as the game is live. Human seats are skipped — their sessions subscribe themselves. Each bot
+    * decides with the policy [[BotPolicies]] resolves for `gameType` and submits moves back through this GameManager,
+    * exactly as a human client does; the think delay comes from the actor system's [[BotConfig]]. A no-op when the
+    * roster holds no bots.
+    */
+  private def spawnBots(
+      context: ActorContext[Command],
+      gameType: GameType,
+      matchId: MatchId,
+      roomId: RoomId,
+      players: Seq[PlayerId],
+      gameActor: ActorRef[GameActor.GameCommand],
+      tracingConfig: TracingConfig,
+      traceEmit: TraceEvent => Unit
+  ): Unit = {
+    val actorPlugin = GameRegistry.forType(gameType).actor
+    val thinkDelay = BotConfig.fromConfig(context.system.settings.config).thinkDelay
+    players.filter(BotId.isBot).foreach { botId =>
+      val behavior = BotActor(botId, roomId, BotPolicies.forGame(gameType), context.self, thinkDelay = thinkDelay) {
+        session => gameActor ! actorPlugin.subscribeCommand(session, botId)
+      }
+      context.spawn(TracingInterceptor.wrap(behavior, tracingConfig, traceEmit), s"bot-$matchId-$botId")
+    }
+  }
+
   /** Look up the live PlayerActor for `playerId` and hand the result (`None` if not connected) to `onResolved`, which
     * builds the follow-up command sent back to self. Centralizes the spectate/auto-subscribe lookups so the ask wiring
     * — and its single ask-timeout fallback (mapped, like a miss, to `None`) — lives in one place.
@@ -502,6 +529,10 @@ object GameManager {
             TracingInterceptor.wrap(behavior, tracingConfig, traceEmit),
             s"game-$matchId"
           ).unsafeUpcast[GameActor.GameCommand]
+          // a restored game keeps no live sessions, so its bots must be re-created to keep playing; a terminal
+          // snapshot's actor stops itself on restore, so only an in-progress game gets bots
+          if (game.gameStatus == InProgress)
+            spawnBots(context, gameType, matchId, roomId, game.players, actorRef, tracingConfig, traceEmit)
           roomId -> (gameType, matchId, actorRef)
         }.toMap
 
@@ -784,6 +815,7 @@ object GameManager {
             ).unsafeUpcast[GameActor.GameCommand]
 
             subscribers.foreach { case (pid, ref) => actorRef ! bundle.actor.subscribeCommand(ref, pid) }
+            spawnBots(context, gameType, matchId, roomId, players, actorRef, tracingConfig, traceEmit)
 
             persistActor ! PersistenceProtocol.SaveSnapshot(
               matchId,

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
@@ -14,7 +14,7 @@ import com.github.blemale.scaffeine.{Cache, Scaffeine}
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
 import org.apache.pekko.actor.typed.{ActorRef, Behavior, Terminated}
 
-import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyError, LobbyMetadata, LobbyRepository, Player}
+import com.andy327.actor.lobby.{BotId, GameLifecycleStatus, LobbyError, LobbyMetadata, LobbyRepository, Player}
 import com.andy327.model.core.{GameType, PlayerId, RoomId}
 
 /** A child actor of GameManager that owns all lobby lifecycle state.
@@ -64,12 +64,32 @@ object LobbyManager {
   final case class JoinLobby(roomId: RoomId, player: Player, replyTo: ActorRef[GameManager.GameResponse])
       extends Command
 
-  /** Remove `player` from a lobby. If the host leaves, the host role migrates to a remaining member and the lobby
-    * survives; it is cancelled only when the host was the last player. Rejected with
+  /** Remove `player` from a lobby. If the host leaves, the host role migrates to a remaining human member and the
+    * lobby survives; it is cancelled when the host was the last human, since a bot can hold neither the host role nor
+    * the room. Rejected with
     * [[lobby.LobbyError.GameInProgress]] once the game has started.
     */
   final case class LeaveLobby(roomId: RoomId, player: Player, replyTo: ActorRef[GameManager.GameResponse])
       extends Command
+
+  /** Seat a bot in a pre-game lobby on behalf of its host. The bot is a full roster member — it counts toward the
+    * player limits and is dealt in on start — identified by a reserved [[lobby.BotId]] id, so no account or connection
+    * backs it. Replies with [[GameManager.LobbyJoined]] carrying the bot, or [[GameManager.LobbyErrorResponse]] if the
+    * caller is not the host, the lobby is full, no longer joinable, or unknown.
+    */
+  final case class AddBot(roomId: RoomId, requesterId: PlayerId, replyTo: ActorRef[GameManager.GameResponse])
+      extends Command
+
+  /** Remove a bot seat from a pre-game lobby on behalf of its host. Replies with [[GameManager.LobbyLeft]], or
+    * [[GameManager.LobbyErrorResponse]] if the caller is not the host, `botId` is not a bot seated here, or the lobby
+    * is no longer pre-game or unknown.
+    */
+  final case class RemoveBot(
+      roomId: RoomId,
+      requesterId: PlayerId,
+      botId: PlayerId,
+      replyTo: ActorRef[GameManager.GameResponse]
+  ) extends Command
 
   /** Cancel a pre-game lobby on behalf of its host, moving it to the recently-ended cache and notifying subscribers.
     * Replies with [[GameManager.LobbyLeft]] on success, [[GameManager.LobbyErrorResponse]] if the caller is not the
@@ -311,6 +331,94 @@ object LobbyManager {
             Behaviors.same
         }
 
+      case AddBot(roomId, requesterId, replyTo) =>
+        lobbies.get(roomId) match {
+          case Some(metadata) if !metadata.status.isJoinable =>
+            replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotJoinable(roomId))
+            Behaviors.same
+
+          case Some(metadata) if metadata.hostId != requesterId =>
+            replyTo ! GameManager.LobbyErrorResponse(LobbyError.NotHostError(roomId))
+            Behaviors.same
+
+          case Some(metadata) if metadata.players.size >= metadata.gameType.maxPlayers =>
+            replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyFull(roomId))
+            Behaviors.same
+
+          case Some(metadata) =>
+            val bot = BotId.nextFor(metadata.players.keySet)
+            context.log.info(s"Host seated ${bot.name} in lobby $roomId")
+            val updatedPlayers = metadata.players + (bot.id -> bot)
+            val updatedStatus =
+              if (updatedPlayers.size >= metadata.gameType.minPlayers) GameLifecycleStatus.ReadyToStart
+              else GameLifecycleStatus.WaitingForPlayers
+            val updatedMetadata =
+              metadata.copy(players = updatedPlayers, status = updatedStatus, lastActivityAt = Instant.now())
+            replyTo ! GameManager.LobbyJoined(roomId, updatedMetadata, bot)
+            fanOut(
+              subscribers,
+              roomId,
+              PlayerEvent.LobbyUpdated(updatedMetadata, spectatorCount(subscribers, roomId, updatedMetadata))
+            )
+            persist(lobbyRepo.saveLobby(updatedMetadata))
+            running(
+              lobbies + (roomId -> updatedMetadata),
+              recentlyEnded,
+              subscribers,
+              gameManager,
+              lobbyRepo,
+              emptyRoomGrace
+            )
+
+          case None =>
+            replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotFound(roomId))
+            Behaviors.same
+        }
+
+      case RemoveBot(roomId, requesterId, botId, replyTo) =>
+        lobbies.get(roomId) match {
+          case Some(metadata) if !metadata.status.isJoinable =>
+            replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotJoinable(roomId))
+            Behaviors.same
+
+          case Some(metadata) if metadata.hostId != requesterId =>
+            replyTo ! GameManager.LobbyErrorResponse(LobbyError.NotHostError(roomId))
+            Behaviors.same
+
+          case Some(metadata) if !BotId.isBot(botId) || !metadata.players.contains(botId) =>
+            replyTo ! GameManager.LobbyErrorResponse(LobbyError.NoSuchBot(roomId))
+            Behaviors.same
+
+          case Some(metadata) =>
+            val bot = metadata.players(botId)
+            context.log.info(s"Host removed ${bot.name} from lobby $roomId")
+            val updatedPlayers = metadata.players - botId
+            val updatedStatus =
+              if (updatedPlayers.size >= metadata.gameType.minPlayers) GameLifecycleStatus.ReadyToStart
+              else GameLifecycleStatus.WaitingForPlayers
+            val updatedMetadata =
+              metadata.copy(players = updatedPlayers, status = updatedStatus, lastActivityAt = Instant.now())
+            replyTo ! GameManager.LobbyLeft(roomId, s"${bot.name} removed from lobby $roomId")
+            fanOut(
+              subscribers,
+              roomId,
+              PlayerEvent.LobbyUpdated(updatedMetadata, spectatorCount(subscribers, roomId, updatedMetadata))
+            )
+            persist(lobbyRepo.saveLobby(updatedMetadata))
+            running(
+              lobbies + (roomId -> updatedMetadata),
+              recentlyEnded,
+              subscribers,
+              gameManager,
+              lobbyRepo,
+              emptyRoomGrace
+            )
+
+          case None =>
+            replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotFound(roomId))
+            Behaviors.same
+        }
+
       case LeaveLobby(roomId, player, replyTo) =>
         lobbies.get(roomId) match {
           // Leaving an in-progress game is a forfeit, handled by the game actor; GameManager routes those directly and
@@ -333,9 +441,11 @@ object LobbyManager {
               replyTo ! GameManager.LobbyLeft(roomId, s"${player.name} already absent from lobby $roomId")
               Behaviors.same
             } else if (player.id == metadata.hostId) {
-              updatedPlayers.headOption match {
+              // host powers only ever pass to a person: bots cannot start a game or cancel a room, so a lobby whose
+              // remaining members are all bots disbands exactly as an empty one does
+              updatedPlayers.find { case (id, _) => !BotId.isBot(id) } match {
                 case None =>
-                  // host was the last player remaining — disband the lobby
+                  // host was the last human remaining — disband the lobby
                   context.log.info(s"Host (${player.name}) left lobby $roomId with no players left. Cancelling game...")
                   val cancelled = newMetadata.copy(status = GameLifecycleStatus.Cancelled)
                   recentlyEnded.put(roomId, cancelled)

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/LobbyManager.scala
@@ -14,6 +14,7 @@ import com.github.blemale.scaffeine.{Cache, Scaffeine}
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
 import org.apache.pekko.actor.typed.{ActorRef, Behavior, Terminated}
 
+import com.andy327.actor.bot.BotDifficulty
 import com.andy327.actor.lobby.{BotId, GameLifecycleStatus, LobbyError, LobbyMetadata, LobbyRepository, Player}
 import com.andy327.model.core.{GameType, PlayerId, RoomId}
 
@@ -77,8 +78,12 @@ object LobbyManager {
     * backs it. Replies with [[GameManager.LobbyJoined]] carrying the bot, or [[GameManager.LobbyErrorResponse]] if the
     * caller is not the host, the lobby is full, no longer joinable, or unknown.
     */
-  final case class AddBot(roomId: RoomId, requesterId: PlayerId, replyTo: ActorRef[GameManager.GameResponse])
-      extends Command
+  final case class AddBot(
+      roomId: RoomId,
+      requesterId: PlayerId,
+      difficulty: BotDifficulty,
+      replyTo: ActorRef[GameManager.GameResponse]
+  ) extends Command
 
   /** Remove a bot seat from a pre-game lobby on behalf of its host. Replies with [[GameManager.LobbyLeft]], or
     * [[GameManager.LobbyErrorResponse]] if the caller is not the host, `botId` is not a bot seated here, or the lobby
@@ -331,7 +336,7 @@ object LobbyManager {
             Behaviors.same
         }
 
-      case AddBot(roomId, requesterId, replyTo) =>
+      case AddBot(roomId, requesterId, difficulty, replyTo) =>
         lobbies.get(roomId) match {
           case Some(metadata) if !metadata.status.isJoinable =>
             replyTo ! GameManager.LobbyErrorResponse(LobbyError.LobbyNotJoinable(roomId))
@@ -347,13 +352,17 @@ object LobbyManager {
 
           case Some(metadata) =>
             val bot = BotId.nextFor(metadata.players.keySet)
-            context.log.info(s"Host seated ${bot.name} in lobby $roomId")
+            context.log.info(s"Host seated ${bot.name} (${difficulty.label}) in lobby $roomId")
             val updatedPlayers = metadata.players + (bot.id -> bot)
             val updatedStatus =
               if (updatedPlayers.size >= metadata.gameType.minPlayers) GameLifecycleStatus.ReadyToStart
               else GameLifecycleStatus.WaitingForPlayers
-            val updatedMetadata =
-              metadata.copy(players = updatedPlayers, status = updatedStatus, lastActivityAt = Instant.now())
+            val updatedMetadata = metadata.copy(
+              players = updatedPlayers,
+              status = updatedStatus,
+              lastActivityAt = Instant.now(),
+              bots = metadata.bots + (bot.id -> difficulty)
+            )
             replyTo ! GameManager.LobbyJoined(roomId, updatedMetadata, bot)
             fanOut(
               subscribers,
@@ -396,8 +405,12 @@ object LobbyManager {
             val updatedStatus =
               if (updatedPlayers.size >= metadata.gameType.minPlayers) GameLifecycleStatus.ReadyToStart
               else GameLifecycleStatus.WaitingForPlayers
-            val updatedMetadata =
-              metadata.copy(players = updatedPlayers, status = updatedStatus, lastActivityAt = Instant.now())
+            val updatedMetadata = metadata.copy(
+              players = updatedPlayers,
+              status = updatedStatus,
+              lastActivityAt = Instant.now(),
+              bots = metadata.bots - botId // the freed seat takes its difficulty with it
+            )
             replyTo ! GameManager.LobbyLeft(roomId, s"${bot.name} removed from lobby $roomId")
             fanOut(
               subscribers,
@@ -543,7 +556,8 @@ object LobbyManager {
               metadata.gameType,
               seatOrder(metadata),
               replyTo,
-              lobbySubscribers
+              lobbySubscribers,
+              metadata.bots
             )
             persist(lobbyRepo.saveLobby(updatedMetadata))
             running(

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/TurnBasedGameActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/TurnBasedGameActor.scala
@@ -318,8 +318,10 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
         }
         publisher.publish(GameEvent.GameCompleted(matchId, gameType, outcome, nextState.moveCount))
         // hand the subscriber set back to the room so it survives this match's actor stopping and can keep fanning out
-        // chat and the post-game state; re-key by playerId to match the GameCompleted/MatchEnded shape
-        val subscribersByPlayer = subscribers.map { case (ref, pid) => pid -> ref }
+        // chat and the post-game state; re-key by playerId to match the GameCompleted/MatchEnded shape. Bots are
+        // dropped: they stop on the GameEnded above, so their refs must not linger as post-game subscribers — a dead
+        // ref would keep an otherwise-empty room from being evicted and bounce post-game chat to a stopped actor.
+        val subscribersByPlayer = subscribers.collect { case (ref, pid) if !BotId.isBot(pid) => pid -> ref }
         gameManager ! GameManager.GameCompleted(matchId, roomId, GameLifecycleStatus.Completed, subscribersByPlayer)
         // the game is over: cancel any pending turn clock so it cannot fire during terminating
         timers.cancel(TurnTimerKey)

--- a/game-service-actor/src/main/scala/com/andy327/actor/core/TurnBasedGameActor.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/core/TurnBasedGameActor.scala
@@ -9,7 +9,7 @@ import org.apache.pekko.actor.typed.{ActorRef, Behavior, Terminated}
 
 import com.andy327.actor.events.{EventPublisher, GameEvent}
 import com.andy327.actor.game.{GameProjection, GameView}
-import com.andy327.actor.lobby.GameLifecycleStatus
+import com.andy327.actor.lobby.{BotId, GameLifecycleStatus}
 import com.andy327.actor.persistence.PersistenceProtocol
 import com.andy327.model.core.{
   Draw,
@@ -312,7 +312,9 @@ class TurnBasedGameActor[G <: Game[M, G, P, GameStatus[P], GameError], M, P, S <
             (nextState.players.map(_ -> GameResult.Draw), GameEvent.Outcome.Draw)
         }
         results.foreach { case (pid, result) =>
-          persist ! PersistenceProtocol.RecordGameResult(pid, matchId, gameType, result, forfeit)
+          // bots hold no account and no history: a human's win over a bot records, but the bot's own row never does
+          if (!BotId.isBot(pid))
+            persist ! PersistenceProtocol.RecordGameResult(pid, matchId, gameType, result, forfeit)
         }
         publisher.publish(GameEvent.GameCompleted(matchId, gameType, outcome, nextState.moveCount))
         // hand the subscriber set back to the room so it survives this match's actor stopping and can keep fanning out

--- a/game-service-actor/src/main/scala/com/andy327/actor/lobby/BotId.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/lobby/BotId.scala
@@ -1,0 +1,38 @@
+package com.andy327.actor.lobby
+
+import java.util.UUID
+
+import com.andy327.model.core.PlayerId
+
+/** Mints and recognizes the reserved `PlayerId`s that bot seats occupy.
+  *
+  * A bot is a full lobby member — seated by the host, counted toward the roster, listed in `LobbyMetadata.players`,
+  * and dealt into the game like anyone else — but it holds no account and never connects, so its identity is derived
+  * rather than registered: every bot id shares `Marker` as its most significant bits and carries its ordinal in the
+  * least significant. Bot-ness is therefore decidable from the id alone, anywhere it travels — lobby metadata, game
+  * rosters, persisted snapshots — with no flag to thread through commands or storage.
+  */
+object BotId {
+
+  /** The most significant bits of every bot id. The version nibble this encodes is not 4, so a registered account's
+    * random (version 4) UUID can never collide with a bot id.
+    */
+  private val Marker: Long = 0xb07b07b07b07b07bL
+
+  /** True exactly when `id` names a bot minted by [[forOrdinal]]. */
+  def isBot(id: PlayerId): Boolean = id.getMostSignificantBits == Marker
+
+  /** The bot id with the given zero-based ordinal; deterministic, so the same ordinal always names the same bot. */
+  def forOrdinal(ordinal: Int): PlayerId = new UUID(Marker, ordinal.toLong)
+
+  /** The seated [[Player]] for `ordinal`, displayed as "Bot 1", "Bot 2", … */
+  def player(ordinal: Int): Player = Player(forOrdinal(ordinal), s"Bot ${ordinal + 1}")
+
+  /** The lowest-ordinal bot not already seated among `seated` — the next bot a lobby should add, so a room's bots are
+    * always named "Bot 1", "Bot 2", … without gaps, and removing then re-adding reuses the freed name.
+    */
+  def nextFor(seated: Set[PlayerId]): Player = {
+    val ordinal = Iterator.from(0).find(n => !seated.contains(forOrdinal(n))).get
+    player(ordinal)
+  }
+}

--- a/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyCodecs.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyCodecs.scala
@@ -7,8 +7,9 @@ import scala.util.Try
 import io.circe.generic.semiauto.deriveCodec
 import io.circe.parser.decode
 import io.circe.syntax._
-import io.circe.{Codec, Decoder, Encoder, KeyDecoder, KeyEncoder}
+import io.circe.{Codec, Decoder, Encoder, Json, KeyDecoder, KeyEncoder}
 
+import com.andy327.actor.bot.BotDifficulty
 import com.andy327.persistence.db.schema.GameTypeCodecs.gameTypeCodec
 
 /** Circe codecs for lobby domain types, used by [[RedisLobbyRepository]] to serialize and deserialize
@@ -45,7 +46,29 @@ object LobbyCodecs {
     }
   )
 
-  implicit val lobbyMetadataCodec: Codec[LobbyMetadata] = deriveCodec[LobbyMetadata]
+  implicit val botDifficultyCodec: Codec[BotDifficulty] = Codec.from(
+    Decoder.decodeString.emap(s => BotDifficulty.fromString(s).toRight(s"Unknown BotDifficulty: $s")),
+    Encoder.encodeString.contramap[BotDifficulty](_.label)
+  )
+
+  private val derivedLobbyMetadataCodec: Codec[LobbyMetadata] = deriveCodec[LobbyMetadata]
+
+  /** Decoding fills in an absent `bots` field rather than failing on it.
+    *
+    * Circe's derived decoders do not consult a case class's default values, so a room persisted before bot seats
+    * existed would otherwise be unreadable — costing the room its name, host, and rematch on the first restart after
+    * an upgrade. An older record simply has no bots, which is exactly what the empty map says.
+    */
+  implicit val lobbyMetadataCodec: Codec[LobbyMetadata] = Codec.from(
+    Decoder.instance { cursor =>
+      val filled = cursor.value.asObject
+        .filterNot(_.contains("bots"))
+        .map(obj => Json.fromJsonObject(obj.add("bots", Json.obj())).hcursor)
+        .getOrElse(cursor)
+      derivedLobbyMetadataCodec(filled)
+    },
+    derivedLobbyMetadataCodec
+  )
 
   /** Serializes a [[LobbyMetadata]] instance to a compact JSON string. */
   def serialize(metadata: LobbyMetadata): String = metadata.asJson.noSpaces

--- a/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyError.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyError.scala
@@ -53,4 +53,9 @@ object LobbyError {
   case class GameInProgress(roomId: RoomId) extends LobbyError {
     def message: String = s"Cannot leave lobby $roomId - game is in progress"
   }
+
+  /** The referenced player is not a bot seated in this lobby. Maps to HTTP 404. */
+  case class NoSuchBot(roomId: RoomId) extends LobbyError {
+    def message: String = s"No such bot in lobby $roomId"
+  }
 }

--- a/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyMetadata.scala
+++ b/game-service-actor/src/main/scala/com/andy327/actor/lobby/LobbyMetadata.scala
@@ -3,6 +3,7 @@ package com.andy327.actor.lobby
 import java.time.Instant
 import java.util.UUID
 
+import com.andy327.actor.bot.BotDifficulty
 import com.andy327.model.core.{GameType, MatchId, PlayerId, RoomId}
 
 object LobbyMetadata {
@@ -52,6 +53,10 @@ object LobbyMetadata {
   *                       idle post-game (Finished) rooms
   * @param name optional host-chosen display name for the lobby, shown in the lobby list so friends can recognize the
   *             room; when absent, clients fall back to a default "{host}'s {game}" label
+  * @param bots the difficulty each seated bot plays at, keyed by its player id. Only bot seats appear here, so the map
+  *             is empty for an all-human room. It is persisted with the room because a bot is seated in the lobby but
+  *             only spawned when the match starts — and again on restore after a restart — so the choice has to
+  *             outlive both steps
   */
 case class LobbyMetadata(
     roomId: RoomId,
@@ -63,5 +68,6 @@ case class LobbyMetadata(
     currentMatchId: Option[MatchId] = None,
     matchCount: Int = 0,
     lastActivityAt: Instant = Instant.EPOCH,
-    name: Option[String] = None
+    name: Option[String] = None,
+    bots: Map[PlayerId, BotDifficulty] = Map.empty
 )

--- a/game-service-actor/src/test/scala/com/andy327/actor/bot/BotActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/bot/BotActorSpec.scala
@@ -1,0 +1,193 @@
+package com.andy327.actor.bot
+
+import java.util.UUID
+
+import scala.concurrent.duration._
+import scala.util.Random
+
+import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
+import org.apache.pekko.actor.typed.ActorRef
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import com.andy327.actor.core.{GameActor, GameManager, PlayerActor, PlayerEvent}
+import com.andy327.actor.events.NoOpEventPublisher
+import com.andy327.actor.game.modules.TicTacToeModule
+import com.andy327.actor.game.{GameOperation, GameView, MovePayload}
+import com.andy327.actor.lobby.{BotId, GameLifecycleStatus}
+import com.andy327.actor.persistence.PersistenceProtocol
+import com.andy327.actor.tictactoe.TicTacToeActor
+import com.andy327.model.core.{GameError, MatchId, PlayerId, RoomId}
+import com.andy327.model.tictactoe.{TicTacToe, X}
+
+class BotActorSpec extends AnyWordSpecLike with Matchers {
+  private val testKit = ActorTestKit()
+  import testKit._
+
+  private val botId: PlayerId = BotId.forOrdinal(0)
+  private val human: PlayerId = UUID.randomUUID()
+  private val roomId: RoomId = UUID.randomUUID()
+
+  /** A bot wired to `gm`. Returns the session ref the game actor would push to — captured from the `register`
+    * callback. The think delay defaults to zero so a turn submits synchronously in tests.
+    */
+  private def newBot(
+      gm: ActorRef[GameManager.Command],
+      seed: Long = 0,
+      thinkDelay: FiniteDuration = Duration.Zero
+  ): ActorRef[PlayerActor.Command] = {
+    val sessionProbe = TestProbe[ActorRef[PlayerActor.Command]]()
+    spawn(BotActor(botId, roomId, RandomPolicy, gm, new Random(seed), thinkDelay)(sessionProbe.ref ! _))
+    sessionProbe.receiveMessage()
+  }
+
+  /** The bot's view of a TicTacToe game where the bot (X) is to move. */
+  private def botToMove: PlayerEvent =
+    PlayerEvent.GameStateUpdated(roomId, TicTacToeModule.project(TicTacToe.empty(botId, human), Some(botId)), 0)
+
+  "BotActor" should {
+    "submit a legal move when a push shows it is the bot's turn" in {
+      val gm = TestProbe[GameManager.Command]()
+      val session = newBot(gm.ref)
+
+      session ! PlayerActor.SendEvent(botToMove)
+
+      val op = gm.expectMessageType[GameManager.RunGameOperation]
+      op.roomId shouldBe roomId
+      op.op match {
+        case GameOperation.MakeMove(mover, _: MovePayload.TicTacToeMove) => mover shouldBe botId
+        case other                                                       => fail(s"unexpected op: $other")
+      }
+    }
+
+    "stay silent on a push where it is not the bot's turn" in {
+      val gm = TestProbe[GameManager.Command]()
+      val session = newBot(gm.ref)
+
+      // the same game projected for the human: X (the bot) is to move, so the human's view offers nothing
+      val humanView =
+        PlayerEvent.GameStateUpdated(roomId, TicTacToeModule.project(TicTacToe.empty(botId, human), Some(human)), 0)
+      session ! PlayerActor.SendEvent(humanView)
+
+      gm.expectNoMessage()
+    }
+
+    "submit exactly once per turn, ignoring duplicate pushes during the think delay" in {
+      val gm = TestProbe[GameManager.Command]()
+      // a real think delay opens the window a duplicate push would arrive in; the pending guard must collapse them
+      val session = newBot(gm.ref, thinkDelay = 300.millis)
+
+      session ! PlayerActor.SendEvent(botToMove)
+      session ! PlayerActor.SendEvent(botToMove) // redundant re-pushes of the same turn, mid-think
+      session ! PlayerActor.SendEvent(botToMove)
+
+      gm.expectMessageType[GameManager.RunGameOperation] // fires once the delay elapses
+      gm.expectNoMessage() // the two duplicates raised no further submission
+    }
+
+    "act again on the next turn after its move is applied" in {
+      val gm = TestProbe[GameManager.Command]()
+      val session = newBot(gm.ref)
+
+      session ! PlayerActor.SendEvent(botToMove)
+      gm.expectMessageType[GameManager.RunGameOperation]
+
+      // a later board where it is again the bot's turn (bot X to move after O replied)
+      val next = TicTacToe.empty(botId, human)
+        .play(X, com.andy327.model.tictactoe.Location(0, 0)).toOption.get
+        .play(com.andy327.model.tictactoe.O, com.andy327.model.tictactoe.Location(1, 1)).toOption.get
+      session ! PlayerActor.SendEvent(
+        PlayerEvent.GameStateUpdated(roomId, TicTacToeModule.project(next, Some(botId)), 0)
+      )
+
+      gm.expectMessageType[GameManager.RunGameOperation]
+    }
+
+    "ignore push events that are not game-state updates" in {
+      val gm = TestProbe[GameManager.Command]()
+      val session = newBot(gm.ref)
+
+      val chat = PlayerEvent.ChatMessage(roomId, human, "human", "hello bot", java.time.Instant.EPOCH)
+      session ! PlayerActor.SendEvent(chat)
+
+      gm.expectNoMessage() // chat is not the bot's concern; it neither acts nor crashes
+    }
+
+    "keep playing after a move is reported rejected, and ignore an accepted reply" in {
+      val gm = TestProbe[GameManager.Command]()
+      val session = newBot(gm.ref)
+
+      session ! PlayerActor.SendEvent(botToMove)
+      val op1 = gm.expectMessageType[GameManager.RunGameOperation]
+      op1.replyTo ! GameManager.MoveRejected("simulated rejection") // the bot logs and carries on
+
+      session ! PlayerActor.SendEvent(botToMove)
+      val op2 = gm.expectMessageType[GameManager.RunGameOperation] // still submits on the next turn
+      op2.replyTo ! GameManager.GameStatus(TicTacToeModule.project(TicTacToe.empty(botId, human), None)) // accepted
+
+      session ! PlayerActor.SendEvent(botToMove)
+      gm.expectMessageType[GameManager.RunGameOperation] // an accepted reply changes nothing
+    }
+
+    "stop when the game ends" in {
+      val gm = TestProbe[GameManager.Command]()
+      val sessionProbe = TestProbe[ActorRef[PlayerActor.Command]]()
+      val bot = spawn(
+        BotActor(botId, roomId, RandomPolicy, gm.ref, new Random(0), thinkDelay = Duration.Zero)(sessionProbe.ref ! _)
+      )
+      val session = sessionProbe.receiveMessage()
+
+      session ! PlayerActor.SendEvent(PlayerEvent.GameEnded(GameLifecycleStatus.Completed))
+      createTestProbe().expectTerminated(bot, 3.seconds)
+    }
+
+    "stop when its session is disconnected" in {
+      val gm = TestProbe[GameManager.Command]()
+      val sessionProbe = TestProbe[ActorRef[PlayerActor.Command]]()
+      val bot = spawn(
+        BotActor(botId, roomId, RandomPolicy, gm.ref, new Random(0), thinkDelay = Duration.Zero)(sessionProbe.ref ! _)
+      )
+      val session = sessionProbe.receiveMessage()
+
+      session ! PlayerActor.Disconnect
+      createTestProbe().expectTerminated(bot, 3.seconds)
+    }
+
+    "drive a real game to completion when two bots hold both seats" in {
+      // a genuine end-to-end loop: a live game actor pushes views, each bot decides and submits through a relay that
+      // routes the move back to the actor exactly as GameManager would, and random TicTacToe always terminates
+      val completion = TestProbe[GameManager.Command]()
+      val bot0 = BotId.forOrdinal(0)
+      val bot1 = BotId.forOrdinal(1)
+      val matchId: MatchId = UUID.randomUUID()
+
+      val (_, behavior) = TicTacToeActor.create(
+        matchId,
+        roomId,
+        Seq(bot0, bot1),
+        system.ignoreRef[PersistenceProtocol.Command],
+        completion.ref,
+        NoOpEventPublisher
+      )
+      val gameActor = spawn(behavior).unsafeUpcast[GameActor.GameCommand]
+
+      // stands in for GameManager's one move-routing responsibility: translate the submitted payload and forward it
+      val relay = spawn(Behaviors.receiveMessage[GameManager.Command] {
+        case GameManager.RunGameOperation(_, op, _) =>
+          TicTacToeModule.toGameCommand(op, system.ignoreRef[Either[GameError, GameView]]).foreach(gameActor ! _)
+          Behaviors.same
+        case _ => Behaviors.same
+      })
+
+      Seq(bot0, bot1).zipWithIndex.foreach { case (id, seed) =>
+        spawn(BotActor(id, roomId, RandomPolicy, relay, new Random(seed.toLong), thinkDelay = Duration.Zero) { session =>
+          gameActor ! TicTacToeActor.subscribeCommand(session, id)
+        })
+      }
+
+      // the actor reports the finished match to its GameManager once the bots have played it out
+      completion.expectMessageType[GameManager.GameCompleted](5.seconds)
+    }
+  }
+}

--- a/game-service-actor/src/test/scala/com/andy327/actor/bot/BotConfigSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/bot/BotConfigSpec.scala
@@ -1,0 +1,27 @@
+package com.andy327.actor.bot
+
+import scala.concurrent.duration._
+
+import com.typesafe.config.ConfigFactory
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class BotConfigSpec extends AnyWordSpec with Matchers {
+
+  "BotConfig.fromConfig" should {
+    "read a configured think delay" in {
+      val config = ConfigFactory.parseString("pekko-game-service.bot.think-delay = 250ms")
+      BotConfig.fromConfig(config).thinkDelay shouldBe 250.millis
+    }
+
+    "read a zero think delay" in {
+      val config = ConfigFactory.parseString("pekko-game-service.bot.think-delay = 0ms")
+      BotConfig.fromConfig(config).thinkDelay shouldBe Duration.Zero
+    }
+
+    "fall back to the default when the setting is absent" in {
+      BotConfig.fromConfig(ConfigFactory.empty()).thinkDelay shouldBe BotActor.DefaultThinkDelay
+    }
+  }
+}

--- a/game-service-actor/src/test/scala/com/andy327/actor/bot/BotDifficultySpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/bot/BotDifficultySpec.scala
@@ -1,0 +1,26 @@
+package com.andy327.actor.bot
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class BotDifficultySpec extends AnyWordSpec with Matchers {
+
+  "BotDifficulty" should {
+    "resolve every advertised level from its own label, case-insensitively" in {
+      BotDifficulty.all.foreach(level => BotDifficulty.fromString(level.label) shouldBe Some(level))
+      BotDifficulty.fromString("STANDARD") shouldBe Some(BotDifficulty.Standard)
+    }
+
+    "reject a label it does not know" in {
+      BotDifficulty.fromString("godlike") shouldBe None
+    }
+
+    "advertise its default among the levels a caller may ask for" in {
+      BotDifficulty.all should contain(BotDifficulty.Default)
+    }
+
+    "give every level a distinct label" in {
+      BotDifficulty.all.map(_.label).distinct should have size BotDifficulty.all.size.toLong
+    }
+  }
+}

--- a/game-service-actor/src/test/scala/com/andy327/actor/bot/RandomPolicySpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/bot/RandomPolicySpec.scala
@@ -1,0 +1,173 @@
+package com.andy327.actor.bot
+
+import java.util.UUID
+
+import scala.util.Random
+
+import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import com.andy327.actor.core.TurnBasedGameActor
+import com.andy327.actor.game.modules.{
+  BattleshipModule,
+  CheckersModule,
+  ConnectFourModule,
+  GameModule,
+  LiarsDiceModule,
+  MastermindModule,
+  PigModule,
+  TexasHoldEmModule,
+  TicTacToeModule
+}
+import com.andy327.actor.game.{GameOperation, GameView, MovePayload}
+import com.andy327.model.battleship.Battleship
+import com.andy327.model.checkers.{Black, Checkers, Piece, Red, Square}
+import com.andy327.model.core.{Game, GameError, GameType, PlayerId}
+import com.andy327.model.holdem.{Card, TexasHoldEm}
+import com.andy327.model.liarsdice.{Bid, LiarsDice, StandingBid}
+import com.andy327.model.mastermind.{Mastermind, Peg}
+import com.andy327.model.pig.Pig
+import com.andy327.model.tictactoe.TicTacToe
+
+class RandomPolicySpec extends AnyWordSpecLike with Matchers with OptionValues {
+  private val testKit = ActorTestKit()
+  import testKit._
+
+  private val alice: PlayerId = UUID.randomUUID()
+  private val bob: PlayerId = UUID.randomUUID()
+
+  private val seeds = 0 until 20
+
+  /** For every seed: decide from `viewer`'s projection of `game`, then push the payload through the game's module and
+    * the model's `play` — the same path a submitted move takes — asserting each decided move is accepted. The
+    * widening cast erases the game's move and player types, which is safe here for the same reason it is in
+    * `GameModuleBundle`: the module guarantees the command it built carries this game's own move type.
+    */
+  private def playsOnlyLegalMoves[G <: Game[_, _, _, _, _]](game: G, module: GameModule[G], viewer: PlayerId): Unit = {
+    val replyProbe = TestProbe[Either[GameError, GameView]]()
+    val playable = game.asInstanceOf[Game[Any, Any, Any, Any, Any]]
+    seeds.foreach { seed =>
+      val payload = RandomPolicy.decide(module.project(game, Some(viewer)), new Random(seed)).value
+      module.toGameCommand(GameOperation.MakeMove(viewer, payload), replyProbe.ref) match {
+        case Right(TurnBasedGameActor.MakeMove(_, move, _)) =>
+          withClue(s"seed $seed decided $payload: ") {
+            playable.play(playable.playerFor(viewer).value, move) shouldBe a[Right[_, _]]
+          }
+        case other => fail(s"seed $seed decided $payload, which did not convert: $other")
+      }
+    }
+  }
+
+  "RandomPolicy" should {
+    "play only legal TicTacToe moves" in
+      playsOnlyLegalMoves(TicTacToe.empty(alice, bob), TicTacToeModule, alice)
+
+    "play only legal ConnectFour moves" in
+      playsOnlyLegalMoves(com.andy327.model.connectfour.ConnectFour.empty(alice, bob), ConnectFourModule, alice)
+
+    "play only legal Battleship shots" in
+      playsOnlyLegalMoves(Battleship.random(alice, bob, new Random(0)), BattleshipModule, alice)
+
+    "play only legal Pig actions" in
+      playsOnlyLegalMoves(Pig.newGame(Seq(alice, bob)), PigModule, alice)
+
+    "play only legal Liar's Dice moves against a standing bid" in {
+      val game = LiarsDice
+        .newGame(Seq(alice, bob), List.fill(LiarsDice.MaxTotalDice)(3))
+        .copy(standing = Some(StandingBid(Bid(2, Some(4)), 1)))
+      playsOnlyLegalMoves(game, LiarsDiceModule, alice)
+    }
+
+    "play only legal Texas Hold 'Em actions" in
+      playsOnlyLegalMoves(TexasHoldEm.newGame(Seq(alice, bob), Card.deck), TexasHoldEmModule, alice)
+
+    "set a code and guess codes drawn from the Mastermind palette" in {
+      // the codemaker's single move, then the codebreaker's guesses, both range over the same random-code space
+      playsOnlyLegalMoves(Mastermind.newGame(Seq(alice, bob)), MastermindModule, alice)
+      val set = Mastermind(alice, bob, Some(Vector(Peg.Red, Peg.Blue, Peg.Green, Peg.Yellow)), Nil, None)
+      playsOnlyLegalMoves(set, MastermindModule, bob)
+    }
+
+    "take the only legal Checkers move when a capture is mandatory" in {
+      val blank = Vector.fill(Checkers.Size)(Option.empty[Piece])
+      val board = blank.indices.toVector.map {
+        case 4 => blank.updated(3, Some(Piece(Black, isKing = false)))
+        case 5 => blank.updated(2, Some(Piece(Red, isKing = false)))
+        case _ => blank
+      }
+      val game = Checkers(alice, bob, board, Red, None, moveCount = 0)
+
+      seeds.foreach { seed =>
+        RandomPolicy.decide(CheckersModule.project(game, Some(alice)), new Random(seed)).value shouldBe
+          MovePayload.CheckersMove(Square(5, 2), List(Square(3, 4))) // the jump is the entire legal move set
+      }
+    }
+
+    "decide nothing for a waiting opponent, a spectator, or a finished game" in {
+      val game = TicTacToe.empty(alice, bob) // X (alice) to act
+      RandomPolicy.decide(TicTacToeModule.project(game, Some(bob)), new Random(0)) shouldBe None
+      RandomPolicy.decide(TicTacToeModule.project(game, None), new Random(0)) shouldBe None
+
+      val won = game.copy(winner = Some(com.andy327.model.tictactoe.X))
+      RandomPolicy.decide(TicTacToeModule.project(won, Some(alice)), new Random(0)) shouldBe None
+    }
+
+    "decide nothing for the Mastermind role not on turn, a spectator, or a finished game" in {
+      val unset = Mastermind.newGame(Seq(alice, bob)) // the codemaker (alice) is on turn
+      RandomPolicy.decide(MastermindModule.project(unset, Some(bob)), new Random(0)) shouldBe None
+      RandomPolicy.decide(MastermindModule.project(unset, None), new Random(0)) shouldBe None
+
+      val finished = Mastermind(
+        alice,
+        bob,
+        Some(Vector(Peg.Red, Peg.Blue, Peg.Green, Peg.Yellow)),
+        Nil,
+        winner = Some(com.andy327.model.mastermind.Codemaker)
+      )
+      RandomPolicy.decide(MastermindModule.project(finished, Some(bob)), new Random(0)) shouldBe None
+    }
+
+    "keep a Hold 'Em sizing inside the open range" in {
+      val game = TexasHoldEm.newGame(Seq(alice, bob), Card.deck) // seat 0 owes the blind: raise range is open
+      val view = TexasHoldEmModule.project(game, Some(alice))
+      seeds.foreach { seed =>
+        RandomPolicy.decide(view, new Random(seed)).value match {
+          case MovePayload.HoldEmAction(action, Some(total)) =>
+            action shouldBe "raise"
+            total should ((be >= 20).and(be <= 1000)) // min-raise up to the all-in, from betBounds
+          case MovePayload.HoldEmAction(action, None) => action should (be("fold").or(be("call")))
+          case other                                  => fail(s"unexpected Hold 'Em payload: $other")
+        }
+      }
+    }
+
+    "replay identically under the same seed" in {
+      val view = TicTacToeModule.project(TicTacToe.empty(alice, bob), Some(alice))
+      RandomPolicy.decide(view, new Random(7)) shouldBe RandomPolicy.decide(view, new Random(7))
+    }
+
+    "vary its choice across seeds" in {
+      val view = TicTacToeModule.project(TicTacToe.empty(alice, bob), Some(alice))
+      seeds.map(seed => RandomPolicy.decide(view, new Random(seed)).value).distinct.size should be > 1
+    }
+  }
+
+  "BotPolicies" should {
+    "resolve every game type to the random baseline at Standard difficulty" in {
+      val allTypes = List(
+        GameType.TicTacToe,
+        GameType.ConnectFour,
+        GameType.Battleship,
+        GameType.Pig,
+        GameType.Mastermind,
+        GameType.LiarsDice,
+        GameType.TexasHoldEm,
+        GameType.Checkers
+      )
+      allTypes.foreach(gameType => BotPolicies.forGame(gameType, BotDifficulty.Standard) shouldBe RandomPolicy)
+      BotPolicies.forGame(GameType.Pig) shouldBe RandomPolicy // Standard is the default difficulty
+    }
+  }
+}

--- a/game-service-actor/src/test/scala/com/andy327/actor/bot/RandomPolicySpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/bot/RandomPolicySpec.scala
@@ -167,6 +167,10 @@ class RandomPolicySpec extends AnyWordSpecLike with Matchers with OptionValues {
         GameType.Checkers
       )
       allTypes.foreach(gameType => BotPolicies.forGame(gameType, BotDifficulty.Standard) shouldBe RandomPolicy)
+      // every advertised rung resolves for every game, so a caller can ask for any level without a lookup failure
+      allTypes.foreach(gameType =>
+        BotDifficulty.all.foreach(level => BotPolicies.forGame(gameType, level) should not be null)
+      )
       BotPolicies.forGame(GameType.Pig) shouldBe RandomPolicy // Standard is the default difficulty
     }
   }

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerBotSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/GameManagerBotSpec.scala
@@ -1,0 +1,104 @@
+package com.andy327.actor.core
+
+import java.util.UUID
+
+import scala.concurrent.duration._
+
+import com.typesafe.config.ConfigFactory
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+
+import org.apache.pekko.actor.testkit.typed.FishingOutcome
+import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
+import org.apache.pekko.actor.typed.ActorRef
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import com.andy327.actor.events.{EventPublisher, GameEvent}
+import com.andy327.actor.lobby.{BotId, LobbyMetadata, LobbyRepository}
+import com.andy327.actor.persistence.PersistenceProtocol
+import com.andy327.model.core.{GameType, MatchId, PlayerId, RoomId}
+import com.andy327.model.tictactoe.TicTacToe
+import com.andy327.persistence.db.GameRepository
+
+/** Covers the bot-spawning wiring: a bot seated in a started (or restored) game plays itself, with the think delay
+  * pinned to zero so a bot-versus-bot game resolves synchronously.
+  */
+class GameManagerBotSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterAll {
+  private val testKit = ActorTestKit(
+    ConfigFactory.parseString("pekko-game-service.bot.think-delay = 0ms").withFallback(ConfigFactory.load())
+  )
+  import testKit._
+
+  override def afterAll(): Unit = testKit.shutdownTestKit()
+
+  implicit val runtime: IORuntime = IORuntime.global
+
+  private val noOpLobbyRepo: LobbyRepository = new LobbyRepository {
+    override def saveLobby(metadata: LobbyMetadata): IO[Unit] = IO.unit
+    override def deleteLobby(roomId: RoomId): IO[Unit] = IO.unit
+    override def loadAllLobbies(): IO[List[LobbyMetadata]] = IO.pure(Nil)
+  }
+
+  private val bot0: PlayerId = BotId.forOrdinal(0)
+  private val bot1: PlayerId = BotId.forOrdinal(1)
+
+  /** Spawns a GameManager whose analytics events forward to `events`, awaited to the running state before returning. */
+  private def newManager(events: TestProbe[GameEvent], repo: GameRepository): ActorRef[GameManager.Command] = {
+    val readyProbe = TestProbe[GameManager.Ready.type]()
+    val publisher = new EventPublisher {
+      override def publish(event: GameEvent): Unit = events.ref ! event
+    }
+    val gm = spawn(
+      GameManager(
+        TestProbe[PersistenceProtocol.Command]().ref,
+        repo,
+        noOpLobbyRepo,
+        publisher = publisher,
+        onReady = Some(readyProbe.ref)
+      )
+    )
+    readyProbe.expectMessage(GameManager.Ready)
+    gm
+  }
+
+  /** Waits until a game-completed analytics event arrives, proving a game played itself to a terminal state. */
+  private def awaitCompletion(events: TestProbe[GameEvent]): Unit = {
+    events.fishForMessage(5.seconds) {
+      case _: GameEvent.GameCompleted => FishingOutcome.Complete
+      case _                          => FishingOutcome.Continue
+    }
+    ()
+  }
+
+  "GameManager bot wiring" should {
+    "let two bots seated in a started game play it to completion" in {
+      val events = TestProbe[GameEvent]()
+      val gm = newManager(events, new InMemRepo)
+      val responseProbe = TestProbe[GameManager.GameResponse]()
+
+      gm ! GameManager.SpawnGame(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        GameType.TicTacToe,
+        Seq(bot0, bot1),
+        responseProbe.ref
+      )
+      responseProbe.expectMessageType[GameManager.GameStarted]
+
+      awaitCompletion(events) // no human ever moves, yet the game reaches a terminal state
+    }
+
+    "re-create bots for an in-progress game restored from a snapshot" in {
+      val matchId: MatchId = UUID.randomUUID()
+      val restored = new InMemRepo(Map(matchId -> (GameType.TicTacToe, TicTacToe.empty(bot0, bot1))))
+      val events = TestProbe[GameEvent]()
+
+      newManager(events, restored) // restore spawns the game actor and re-creates its bots
+
+      awaitCompletion(events) // the re-created bots drive the restored game to completion with no external input
+    }
+  }
+}

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
@@ -14,6 +14,7 @@ import org.apache.pekko.actor.typed.scaladsl.Behaviors
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
+import com.andy327.actor.bot.BotDifficulty
 import com.andy327.actor.lobby.{BotId, GameLifecycleStatus, LobbyError, LobbyMetadata, LobbyRepository, Player}
 import com.andy327.model.core.{GameType, RoomId}
 
@@ -741,7 +742,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val f = newLobby()
       val roomId = createLobby(f)
 
-      f.lm ! LobbyManager.AddBot(roomId, alice.id, f.responseProbe.ref)
+      f.lm ! LobbyManager.AddBot(roomId, alice.id, BotDifficulty.Standard, f.responseProbe.ref)
       val joined = f.responseProbe.expectMessageType[GameManager.LobbyJoined]
       BotId.isBot(joined.joinedPlayer.id) shouldBe true
       joined.joinedPlayer.name shouldBe "Bot 1"
@@ -753,7 +754,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val f = newLobby()
       val roomId = createLobby(f)
 
-      f.lm ! LobbyManager.AddBot(roomId, alice.id, f.responseProbe.ref)
+      f.lm ! LobbyManager.AddBot(roomId, alice.id, BotDifficulty.Standard, f.responseProbe.ref)
       val bot = f.responseProbe.expectMessageType[GameManager.LobbyJoined].joinedPlayer
 
       f.lm ! LobbyManager.StartGame(roomId, alice.id, f.responseProbe.ref)
@@ -765,7 +766,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val f = newLobby()
       val roomId = createLobby(f)
 
-      f.lm ! LobbyManager.AddBot(roomId, alice.id, f.responseProbe.ref)
+      f.lm ! LobbyManager.AddBot(roomId, alice.id, BotDifficulty.Standard, f.responseProbe.ref)
       val bot = f.responseProbe.expectMessageType[GameManager.LobbyJoined].joinedPlayer
 
       f.lm ! LobbyManager.RemoveBot(roomId, alice.id, bot.id, f.responseProbe.ref)
@@ -777,7 +778,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       metadata.status shouldBe GameLifecycleStatus.WaitingForPlayers
 
       // the freed ordinal is reused, so the roster never shows a gap in bot names
-      f.lm ! LobbyManager.AddBot(roomId, alice.id, f.responseProbe.ref)
+      f.lm ! LobbyManager.AddBot(roomId, alice.id, BotDifficulty.Standard, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.LobbyJoined].joinedPlayer.name shouldBe "Bot 1"
     }
 
@@ -785,14 +786,14 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val f = newLobby()
       val (roomId, _) = createReadyLobby(f) // TicTacToe: alice + bob fills the room
 
-      f.lm ! LobbyManager.AddBot(roomId, bob.id, f.responseProbe.ref)
+      f.lm ! LobbyManager.AddBot(roomId, bob.id, BotDifficulty.Standard, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.LobbyErrorResponse].error shouldBe LobbyError.NotHostError(roomId)
 
-      f.lm ! LobbyManager.AddBot(roomId, alice.id, f.responseProbe.ref)
+      f.lm ! LobbyManager.AddBot(roomId, alice.id, BotDifficulty.Standard, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.LobbyErrorResponse].error shouldBe LobbyError.LobbyFull(roomId)
 
       val bogus = UUID.randomUUID()
-      f.lm ! LobbyManager.AddBot(bogus, alice.id, f.responseProbe.ref)
+      f.lm ! LobbyManager.AddBot(bogus, alice.id, BotDifficulty.Standard, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.LobbyErrorResponse].error shouldBe LobbyError.LobbyNotFound(bogus)
     }
 
@@ -800,7 +801,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val f = newLobby()
       val (roomId, _) = startGame(f)
 
-      f.lm ! LobbyManager.AddBot(roomId, alice.id, f.responseProbe.ref)
+      f.lm ! LobbyManager.AddBot(roomId, alice.id, BotDifficulty.Standard, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.LobbyErrorResponse].error shouldBe
         LobbyError.LobbyNotJoinable(roomId)
     }
@@ -819,7 +820,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
     "reject RemoveBot from a non-host, once the game has started, and on an unknown lobby" in {
       val f = newLobby()
       val roomId = createLobby(f)
-      f.lm ! LobbyManager.AddBot(roomId, alice.id, f.responseProbe.ref)
+      f.lm ! LobbyManager.AddBot(roomId, alice.id, BotDifficulty.Standard, f.responseProbe.ref)
       val bot = f.responseProbe.expectMessageType[GameManager.LobbyJoined].joinedPlayer
 
       f.lm ! LobbyManager.RemoveBot(roomId, bob.id, bot.id, f.responseProbe.ref)
@@ -841,7 +842,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val roomId = createLobby(f, GameType.Pig)
       f.lm ! LobbyManager.JoinLobby(roomId, bob, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.LobbyJoined]
-      f.lm ! LobbyManager.AddBot(roomId, alice.id, f.responseProbe.ref)
+      f.lm ! LobbyManager.AddBot(roomId, alice.id, BotDifficulty.Standard, f.responseProbe.ref)
       val bot = f.responseProbe.expectMessageType[GameManager.LobbyJoined].joinedPlayer
 
       f.lm ! LobbyManager.RemoveBot(roomId, alice.id, bot.id, f.responseProbe.ref)
@@ -852,11 +853,46 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
         GameLifecycleStatus.ReadyToStart
     }
 
+    "carry each bot's difficulty from its seat into the started game" in {
+      val f = newLobby()
+      val roomId = createLobby(f)
+
+      f.lm ! LobbyManager.AddBot(roomId, alice.id, BotDifficulty.Standard, f.responseProbe.ref)
+      val bot = f.responseProbe.expectMessageType[GameManager.LobbyJoined].joinedPlayer
+
+      f.lm ! LobbyManager.StartGame(roomId, alice.id, f.responseProbe.ref)
+      f.gmProbe.expectMessageType[GameManager.SpawnGame].bots shouldBe Map(bot.id -> BotDifficulty.Standard)
+    }
+
+    "record the difficulty on the lobby, and drop it when the bot's seat is freed" in {
+      val f = newLobby()
+      val roomId = createLobby(f)
+
+      f.lm ! LobbyManager.AddBot(roomId, alice.id, BotDifficulty.Standard, f.responseProbe.ref)
+      val bot = f.responseProbe.expectMessageType[GameManager.LobbyJoined].joinedPlayer
+
+      f.lm ! LobbyManager.GetLobbyInfo(roomId, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.bots shouldBe
+        Map(bot.id -> BotDifficulty.Standard)
+
+      f.lm ! LobbyManager.RemoveBot(roomId, alice.id, bot.id, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyLeft]
+
+      f.lm ! LobbyManager.GetLobbyInfo(roomId, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.bots shouldBe empty
+    }
+
+    "leave the bots map empty for an all-human roster" in {
+      val f = newLobby()
+      val (_, spawnMsg) = startGame(f)
+      spawnMsg.bots shouldBe empty
+    }
+
     "migrate the host role to a human, never a bot" in {
       val f = newLobby()
       val roomId = createLobby(f, GameType.Pig) // up to 8 seats, so bot + human + host all fit
 
-      f.lm ! LobbyManager.AddBot(roomId, alice.id, f.responseProbe.ref)
+      f.lm ! LobbyManager.AddBot(roomId, alice.id, BotDifficulty.Standard, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.LobbyJoined]
       f.lm ! LobbyManager.JoinLobby(roomId, bob, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.LobbyJoined]
@@ -872,7 +908,7 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val f = newLobby()
       val roomId = createLobby(f)
 
-      f.lm ! LobbyManager.AddBot(roomId, alice.id, f.responseProbe.ref)
+      f.lm ! LobbyManager.AddBot(roomId, alice.id, BotDifficulty.Standard, f.responseProbe.ref)
       f.responseProbe.expectMessageType[GameManager.LobbyJoined]
 
       f.lm ! LobbyManager.LeaveLobby(roomId, alice, f.responseProbe.ref)

--- a/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/core/LobbyManagerSpec.scala
@@ -14,7 +14,7 @@ import org.apache.pekko.actor.typed.scaladsl.Behaviors
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
-import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyError, LobbyMetadata, LobbyRepository, Player}
+import com.andy327.actor.lobby.{BotId, GameLifecycleStatus, LobbyError, LobbyMetadata, LobbyRepository, Player}
 import com.andy327.model.core.{GameType, RoomId}
 
 class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
@@ -726,6 +726,161 @@ class LobbyManagerSpec extends AnyWordSpecLike with Matchers {
       val error = responseProbe.expectMessageType[GameManager.LobbyErrorResponse]
       error.error shouldBe LobbyError.LobbyNotReady(roomId)
       gmProbe.expectNoMessage()
+    }
+  }
+
+  "LobbyManager bot seats" should {
+
+    /** Create a lobby hosted by alice and return its roomId. */
+    def createLobby(f: LobbyFixture, gameType: GameType = GameType.TicTacToe): RoomId = {
+      f.lm ! LobbyManager.CreateLobby(gameType, alice, None, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyCreated].roomId
+    }
+
+    "seat a bot for the host and count it toward readiness" in {
+      val f = newLobby()
+      val roomId = createLobby(f)
+
+      f.lm ! LobbyManager.AddBot(roomId, alice.id, f.responseProbe.ref)
+      val joined = f.responseProbe.expectMessageType[GameManager.LobbyJoined]
+      BotId.isBot(joined.joinedPlayer.id) shouldBe true
+      joined.joinedPlayer.name shouldBe "Bot 1"
+      joined.metadata.players should have size 2
+      joined.metadata.status shouldBe GameLifecycleStatus.ReadyToStart
+    }
+
+    "let a game start with a bot on the roster" in {
+      val f = newLobby()
+      val roomId = createLobby(f)
+
+      f.lm ! LobbyManager.AddBot(roomId, alice.id, f.responseProbe.ref)
+      val bot = f.responseProbe.expectMessageType[GameManager.LobbyJoined].joinedPlayer
+
+      f.lm ! LobbyManager.StartGame(roomId, alice.id, f.responseProbe.ref)
+      val spawnMsg = f.gmProbe.expectMessageType[GameManager.SpawnGame]
+      spawnMsg.players should contain(bot.id)
+    }
+
+    "remove a bot, recomputing readiness, and reuse its name on a later add" in {
+      val f = newLobby()
+      val roomId = createLobby(f)
+
+      f.lm ! LobbyManager.AddBot(roomId, alice.id, f.responseProbe.ref)
+      val bot = f.responseProbe.expectMessageType[GameManager.LobbyJoined].joinedPlayer
+
+      f.lm ! LobbyManager.RemoveBot(roomId, alice.id, bot.id, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyLeft].message should include("Bot 1")
+
+      f.lm ! LobbyManager.GetLobbyInfo(roomId, f.responseProbe.ref)
+      val metadata = f.responseProbe.expectMessageType[GameManager.LobbyInfo].metadata
+      metadata.players.keySet shouldBe Set(alice.id)
+      metadata.status shouldBe GameLifecycleStatus.WaitingForPlayers
+
+      // the freed ordinal is reused, so the roster never shows a gap in bot names
+      f.lm ! LobbyManager.AddBot(roomId, alice.id, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyJoined].joinedPlayer.name shouldBe "Bot 1"
+    }
+
+    "reject AddBot from a non-host, on a full lobby, and on an unknown lobby" in {
+      val f = newLobby()
+      val (roomId, _) = createReadyLobby(f) // TicTacToe: alice + bob fills the room
+
+      f.lm ! LobbyManager.AddBot(roomId, bob.id, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyErrorResponse].error shouldBe LobbyError.NotHostError(roomId)
+
+      f.lm ! LobbyManager.AddBot(roomId, alice.id, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyErrorResponse].error shouldBe LobbyError.LobbyFull(roomId)
+
+      val bogus = UUID.randomUUID()
+      f.lm ! LobbyManager.AddBot(bogus, alice.id, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyErrorResponse].error shouldBe LobbyError.LobbyNotFound(bogus)
+    }
+
+    "reject AddBot once the game has started" in {
+      val f = newLobby()
+      val (roomId, _) = startGame(f)
+
+      f.lm ! LobbyManager.AddBot(roomId, alice.id, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyErrorResponse].error shouldBe
+        LobbyError.LobbyNotJoinable(roomId)
+    }
+
+    "reject RemoveBot aimed at a human or an unseated id" in {
+      val f = newLobby()
+      val (roomId, _) = createReadyLobby(f)
+
+      f.lm ! LobbyManager.RemoveBot(roomId, alice.id, bob.id, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyErrorResponse].error shouldBe LobbyError.NoSuchBot(roomId)
+
+      f.lm ! LobbyManager.RemoveBot(roomId, alice.id, BotId.forOrdinal(3), f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyErrorResponse].error shouldBe LobbyError.NoSuchBot(roomId)
+    }
+
+    "reject RemoveBot from a non-host, once the game has started, and on an unknown lobby" in {
+      val f = newLobby()
+      val roomId = createLobby(f)
+      f.lm ! LobbyManager.AddBot(roomId, alice.id, f.responseProbe.ref)
+      val bot = f.responseProbe.expectMessageType[GameManager.LobbyJoined].joinedPlayer
+
+      f.lm ! LobbyManager.RemoveBot(roomId, bob.id, bot.id, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyErrorResponse].error shouldBe LobbyError.NotHostError(roomId)
+
+      f.lm ! LobbyManager.StartGame(roomId, alice.id, f.responseProbe.ref)
+      f.gmProbe.expectMessageType[GameManager.SpawnGame]
+      f.lm ! LobbyManager.RemoveBot(roomId, alice.id, bot.id, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyErrorResponse].error shouldBe
+        LobbyError.LobbyNotJoinable(roomId)
+
+      val bogus = UUID.randomUUID()
+      f.lm ! LobbyManager.RemoveBot(bogus, alice.id, bot.id, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyErrorResponse].error shouldBe LobbyError.LobbyNotFound(bogus)
+    }
+
+    "keep a lobby ready when removing a bot still leaves enough players" in {
+      val f = newLobby()
+      val roomId = createLobby(f, GameType.Pig)
+      f.lm ! LobbyManager.JoinLobby(roomId, bob, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyJoined]
+      f.lm ! LobbyManager.AddBot(roomId, alice.id, f.responseProbe.ref)
+      val bot = f.responseProbe.expectMessageType[GameManager.LobbyJoined].joinedPlayer
+
+      f.lm ! LobbyManager.RemoveBot(roomId, alice.id, bot.id, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyLeft]
+
+      f.lm ! LobbyManager.GetLobbyInfo(roomId, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.status shouldBe
+        GameLifecycleStatus.ReadyToStart
+    }
+
+    "migrate the host role to a human, never a bot" in {
+      val f = newLobby()
+      val roomId = createLobby(f, GameType.Pig) // up to 8 seats, so bot + human + host all fit
+
+      f.lm ! LobbyManager.AddBot(roomId, alice.id, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyJoined]
+      f.lm ! LobbyManager.JoinLobby(roomId, bob, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyJoined]
+
+      f.lm ! LobbyManager.LeaveLobby(roomId, alice, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyLeft].message should include("host transferred to bob")
+
+      f.lm ! LobbyManager.GetLobbyInfo(roomId, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.hostId shouldBe bob.id
+    }
+
+    "cancel the lobby when the departing host leaves only bots behind" in {
+      val f = newLobby()
+      val roomId = createLobby(f)
+
+      f.lm ! LobbyManager.AddBot(roomId, alice.id, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyJoined]
+
+      f.lm ! LobbyManager.LeaveLobby(roomId, alice, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyLeft].message should include("host left")
+
+      // the room is retired, not left running with an unattended bot
+      f.lm ! LobbyManager.GetLobbyInfo(roomId, f.responseProbe.ref)
+      f.responseProbe.expectMessageType[GameManager.LobbyInfo].metadata.status shouldBe GameLifecycleStatus.Cancelled
     }
   }
 }

--- a/game-service-actor/src/test/scala/com/andy327/actor/lobby/BotIdSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/lobby/BotIdSpec.scala
@@ -1,0 +1,37 @@
+package com.andy327.actor.lobby
+
+import java.util.UUID
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class BotIdSpec extends AnyWordSpec with Matchers {
+
+  "BotId" should {
+    "recognize every id it mints and no registered account's id" in {
+      BotId.isBot(BotId.forOrdinal(0)) shouldBe true
+      BotId.isBot(BotId.forOrdinal(41)) shouldBe true
+      // registered accounts carry random (version 4) UUIDs, whose version nibble a bot id never matches
+      BotId.isBot(UUID.randomUUID()) shouldBe false
+    }
+
+    "mint deterministic ids, so the same ordinal always names the same bot" in {
+      BotId.forOrdinal(2) shouldBe BotId.forOrdinal(2)
+      BotId.forOrdinal(2) should not be BotId.forOrdinal(3)
+    }
+
+    "display bots by one-based ordinal" in {
+      BotId.player(0).name shouldBe "Bot 1"
+      BotId.player(1).name shouldBe "Bot 2"
+      BotId.player(0).id shouldBe BotId.forOrdinal(0)
+    }
+
+    "hand out the lowest free ordinal, skipping seated bots but not humans" in {
+      BotId.nextFor(Set.empty).name shouldBe "Bot 1"
+      BotId.nextFor(Set(BotId.forOrdinal(0))).name shouldBe "Bot 2"
+      BotId.nextFor(Set(BotId.forOrdinal(0), BotId.forOrdinal(1))).name shouldBe "Bot 3"
+      // a freed ordinal is reused, and human ids in the set never block one
+      BotId.nextFor(Set(BotId.forOrdinal(1), UUID.randomUUID())).name shouldBe "Bot 1"
+    }
+  }
+}

--- a/game-service-actor/src/test/scala/com/andy327/actor/lobby/LobbyCodecsSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/lobby/LobbyCodecsSpec.scala
@@ -3,6 +3,7 @@ package com.andy327.actor.lobby
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import com.andy327.actor.bot.BotDifficulty
 import com.andy327.model.core.GameType
 
 class LobbyCodecsSpec extends AnyWordSpec with Matchers {
@@ -48,6 +49,30 @@ class LobbyCodecsSpec extends AnyWordSpec with Matchers {
     "default name to None when decoding legacy JSON that predates the field" in {
       val legacyJson = LobbyCodecs.serialize(baseLobby).replaceAll(""",?"name":null""", "")
       LobbyCodecs.deserialize(legacyJson) shouldBe Right(baseLobby.copy(name = None))
+    }
+
+    "round-trip a lobby carrying bot seats and their difficulties" in {
+      val bot = BotId.player(0)
+      val lobby = baseLobby.copy(
+        players = baseLobby.players + (bot.id -> bot),
+        bots = Map(bot.id -> BotDifficulty.Standard)
+      )
+      LobbyCodecs.deserialize(LobbyCodecs.serialize(lobby)) shouldBe Right(lobby)
+    }
+
+    "default bots to empty when decoding a record written before bot seats existed" in {
+      // circe's derived decoders ignore case-class defaults, so a room persisted by an older build would otherwise be
+      // unreadable — costing it its name, host, and rematch on the first restart after an upgrade
+      val legacyJson = LobbyCodecs.serialize(baseLobby).replaceAll(""",?"bots":\{\}""", "")
+      (legacyJson should not).include("bots")
+      LobbyCodecs.deserialize(legacyJson) shouldBe Right(baseLobby.copy(bots = Map.empty))
+    }
+
+    "return Left for a lobby JSON with an unknown difficulty" in {
+      val bot = BotId.player(0)
+      val lobby = baseLobby.copy(bots = Map(bot.id -> BotDifficulty.Standard))
+      val json = LobbyCodecs.serialize(lobby).replace("\"standard\"", "\"impossible\"")
+      LobbyCodecs.deserialize(json) shouldBe a[Left[_, _]]
     }
 
     "return Left for a lobby JSON containing an unknown status value" in {

--- a/game-service-actor/src/test/scala/com/andy327/actor/tictactoe/TicTacToeActorSpec.scala
+++ b/game-service-actor/src/test/scala/com/andy327/actor/tictactoe/TicTacToeActorSpec.scala
@@ -18,7 +18,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import com.andy327.actor.core.{GameManager, PlayerActor, PlayerEvent, TurnBasedGameActor}
 import com.andy327.actor.events.{EventPublisher, GameEvent, NoOpEventPublisher}
 import com.andy327.actor.game.{GameView, GridGameView}
-import com.andy327.actor.lobby.GameLifecycleStatus
+import com.andy327.actor.lobby.{BotId, GameLifecycleStatus}
 import com.andy327.actor.persistence.PersistenceProtocol
 import com.andy327.model.core.{Game, GameError, GameType, MatchId, PlayerId}
 import com.andy327.model.tictactoe.{Location, O, OutOfBounds, TicTacToe, X}
@@ -490,6 +490,26 @@ class TicTacToeActorSpec extends AnyWordSpecLike with Matchers {
         matchId,
         GameLifecycleStatus.Completed
       )
+    }
+
+    "record a result only for the human seats when a bot is in the game" in {
+      val matchId: MatchId = UUID.randomUUID()
+      val bot = BotId.forOrdinal(0)
+      val persistProbe = createTestProbe[PersistenceProtocol.Command]()
+      val (_, behavior) =
+        TicTacToeActor.create(matchId, matchId, Seq(alice, bot), persistProbe.ref, dummyGameManager, NoOpEventPublisher)
+      val actor = spawn(behavior)
+      val replyProbe = createTestProbe[Either[GameError, GameView]]()
+
+      // the bot (O) forfeits: alice's win records, but no row is ever written for the bot's loss
+      actor ! TurnBasedGameActor.PlayerLeft(bot, replyProbe.ref)
+      replyProbe.receiveMessage() shouldBe a[Right[_, _]]
+
+      persistProbe.expectMessageType[PersistenceProtocol.SaveSnapshot]
+      persistProbe.expectMessage(
+        PersistenceProtocol.RecordGameResult(alice, matchId, GameType.TicTacToe, GameResult.Win, forfeit = true)
+      )
+      persistProbe.expectNoMessage()
     }
 
     "forfeit the game to the opponent when a player leaves, appending no move but recording the result" in {

--- a/game-service-server/src/main/resources/web/board.js
+++ b/game-service-server/src/main/resources/web/board.js
@@ -15,6 +15,10 @@ export function renderBoard(state) {
   // a board push means we're now (or still) watching a live game, however we got here
   if (session.game) session.game.isLive = true;
   $("start-game").classList.add("hidden");
+  // the seats are locked once play begins, and a board push — not a LobbyUpdated — is what the start flow delivers,
+  // so the pre-game roster and its bot controls retire here
+  $("add-bot").classList.add("hidden");
+  $("lobby-roster").classList.add("hidden");
   $("post-game-bar").classList.add("hidden");
   $("rematch-btn").classList.add("hidden");
   setError("game-error", "");

--- a/game-service-server/src/main/resources/web/board.js
+++ b/game-service-server/src/main/resources/web/board.js
@@ -18,6 +18,7 @@ export function renderBoard(state) {
   // the seats are locked once play begins, and a board push — not a LobbyUpdated — is what the start flow delivers,
   // so the pre-game roster and its bot controls retire here
   $("add-bot").classList.add("hidden");
+  $("bot-difficulty").classList.add("hidden");
   $("lobby-roster").classList.add("hidden");
   $("post-game-bar").classList.add("hidden");
   $("rematch-btn").classList.add("hidden");

--- a/game-service-server/src/main/resources/web/index.html
+++ b/game-service-server/src/main/resources/web/index.html
@@ -101,6 +101,7 @@
     <div class="row">
       <button id="back-to-lobby">← Lobby</button>
       <button id="start-game" class="hidden">Start game</button>
+      <button id="add-bot" class="hidden">Add bot</button>
       <button id="join-as-player" class="hidden">Join this game</button>
       <button id="copy-link">Copy invite link</button>
       <button id="leave-game">Leave</button>

--- a/game-service-server/src/main/resources/web/index.html
+++ b/game-service-server/src/main/resources/web/index.html
@@ -103,6 +103,7 @@
     <div class="row">
       <button id="back-to-lobby">← Lobby</button>
       <button id="start-game" class="hidden">Start game</button>
+      <select id="bot-difficulty" class="hidden" title="Bot difficulty"></select>
       <button id="add-bot" class="hidden">Add bot</button>
       <button id="join-as-player" class="hidden">Join this game</button>
       <button id="copy-link">Copy invite link</button>

--- a/game-service-server/src/main/resources/web/index.html
+++ b/game-service-server/src/main/resources/web/index.html
@@ -89,6 +89,8 @@
   <section id="game" class="panel hidden">
     <h2 id="game-title"></h2>
     <p id="game-status" class="status"></p>
+    <!-- Who's seated, while the room is still pre-game. Bots carry a Remove button for the host. -->
+    <ul id="lobby-roster" class="hidden"></ul>
     <!-- Drop buttons for column-based games (Connect Four); empty (and hidden) for cell-click games. -->
     <div id="column-controls"></div>
     <div id="board"></div>

--- a/game-service-server/src/main/resources/web/lobby.js
+++ b/game-service-server/src/main/resources/web/lobby.js
@@ -116,6 +116,8 @@ function prepareGameView({ roomId, gameType, isHost, isSpectator = false, isLive
   $("start-game").classList.add("hidden");
   $("start-game").disabled = true;
   $("add-bot").classList.add("hidden"); // shown only for the host of a not-yet-full pre-game lobby (onLobbyUpdated)
+  $("bot-difficulty").classList.add("hidden"); // tracks the Add bot button's visibility
+  loadBotDifficulties(); // populate the selector (cached after the first room)
   $("lobby-roster").classList.add("hidden"); // populated from the first LobbyUpdated push
   $("lobby-roster").innerHTML = "";
   $("post-game-bar").classList.add("hidden");
@@ -239,6 +241,7 @@ export function onLobbyUpdated(metadata) {
   if (metadata.status === "InProgress") {
     $("start-game").classList.add("hidden"); // the game is live; Start no longer applies
     $("add-bot").classList.add("hidden"); // seats are locked once the match starts
+    $("bot-difficulty").classList.add("hidden");
     $("lobby-roster").classList.add("hidden"); // the board takes over; the roster is a pre-game view
     $("join-as-player").classList.add("hidden"); // too late to join — the match already started
     $("post-game-bar").classList.add("hidden"); // a rematch just began; the next GameStateUpdated takes over
@@ -247,6 +250,7 @@ export function onLobbyUpdated(metadata) {
   }
   if (metadata.status === "Finished") {
     $("add-bot").classList.add("hidden"); // a finished room's roster is fixed
+    $("bot-difficulty").classList.add("hidden");
     $("lobby-roster").classList.add("hidden"); // the final board stays in view instead
     $("join-as-player").classList.add("hidden"); // a finished room's roster is fixed; no new seats to join
     onMatchFinished(metadata);
@@ -262,8 +266,10 @@ export function onLobbyUpdated(metadata) {
 
   const max = GAMES[session.game.gameType].maxPlayers;
   $("join-as-player").classList.toggle("hidden", !isSpectator || count >= max);
-  // only the host manages bot seats, and only while a seat is still open
-  $("add-bot").classList.toggle("hidden", !youHost || count >= max);
+  // only the host manages bot seats, and only while a seat is still open; the difficulty selector rides along with it
+  const canAddBot = youHost && count < max;
+  $("add-bot").classList.toggle("hidden", !canAddBot);
+  $("bot-difficulty").classList.toggle("hidden", !canAddBot);
   renderRoster(metadata, youHost);
   if (youHost) {
     const ready = metadata.status === "ReadyToStart";
@@ -322,12 +328,34 @@ export async function startGame() {
   // On success the game-state push arrives over the WebSocket and renders the board.
 }
 
-// Host-only: seat an AI player. The resulting LobbyUpdated (fanned to every subscriber) refreshes the roster and
-// flips the room to ReadyToStart, which enables Start — so this only needs to fire the request.
+// Host-only: seat an AI player at the difficulty chosen in the selector. The resulting LobbyUpdated (fanned to every
+// subscriber) refreshes the roster and flips the room to ReadyToStart, which enables Start — so this only needs to
+// fire the request.
 export async function addBot() {
   setError("game-error", "");
-  const res = await api(`/lobby/${session.game.roomId}/bots`, { method: "POST", body: {} });
+  const difficulty = $("bot-difficulty").value;
+  const query = difficulty ? `?difficulty=${encodeURIComponent(difficulty)}` : "";
+  const res = await api(`/lobby/${session.game.roomId}/bots${query}`, { method: "POST", body: {} });
   if (!res.ok) flashError("game-error", res.data?.error || res.data || "Could not add a bot");
+}
+
+// Fill the difficulty selector from the server's list, so the levels shown are exactly those the server accepts and a
+// level added server-side appears here with no client change. Fetched once and cached; the selector stays populated
+// for the session. A failure leaves it empty, and addBot simply omits the query param (the server then defaults).
+let difficultiesLoaded = false;
+async function loadBotDifficulties() {
+  if (difficultiesLoaded) return;
+  const res = await api("/lobby/bot-difficulties");
+  if (!res.ok || !Array.isArray(res.data)) return;
+  const select = $("bot-difficulty");
+  select.innerHTML = "";
+  for (const level of res.data) {
+    const option = document.createElement("option");
+    option.value = level;
+    option.textContent = level.charAt(0).toUpperCase() + level.slice(1); // "standard" → "Standard"
+    select.appendChild(option);
+  }
+  difficultiesLoaded = true;
 }
 
 // Host-only: free a bot's seat, so the host can drop a surplus bot or make room for a human. Like addBot, the

--- a/game-service-server/src/main/resources/web/lobby.js
+++ b/game-service-server/src/main/resources/web/lobby.js
@@ -9,6 +9,12 @@ import { loadChatHistory } from "./chat.js";
 import { resetHoldemPreAction } from "./games/holdem.js";
 import { resetCopyLinkButton } from "./deeplinks.js";
 
+// Bot seats hold ids minted from a reserved namespace (see BotId on the server), so every bot id carries this prefix
+// and the client can spot one without the server tagging each player. Deliberately keyed on the id rather than the
+// display name: a guest is free to call themselves "Bot 1", but they cannot mint an id in this namespace.
+const BOT_ID_PREFIX = "b07b07b0-7b07-b07b-";
+const isBotId = (id) => id.startsWith(BOT_ID_PREFIX);
+
 export async function createGame(gameType) {
   setError("lobby-error", "");
   // Optional host-chosen lobby name; the server trims it and treats a blank value as unnamed.
@@ -110,6 +116,8 @@ function prepareGameView({ roomId, gameType, isHost, isSpectator = false, isLive
   $("start-game").classList.add("hidden");
   $("start-game").disabled = true;
   $("add-bot").classList.add("hidden"); // shown only for the host of a not-yet-full pre-game lobby (onLobbyUpdated)
+  $("lobby-roster").classList.add("hidden"); // populated from the first LobbyUpdated push
+  $("lobby-roster").innerHTML = "";
   $("post-game-bar").classList.add("hidden");
   $("rematch-btn").classList.add("hidden");
   resetCopyLinkButton();
@@ -231,6 +239,7 @@ export function onLobbyUpdated(metadata) {
   if (metadata.status === "InProgress") {
     $("start-game").classList.add("hidden"); // the game is live; Start no longer applies
     $("add-bot").classList.add("hidden"); // seats are locked once the match starts
+    $("lobby-roster").classList.add("hidden"); // the board takes over; the roster is a pre-game view
     $("join-as-player").classList.add("hidden"); // too late to join — the match already started
     $("post-game-bar").classList.add("hidden"); // a rematch just began; the next GameStateUpdated takes over
     $("rematch-btn").classList.add("hidden");
@@ -238,6 +247,7 @@ export function onLobbyUpdated(metadata) {
   }
   if (metadata.status === "Finished") {
     $("add-bot").classList.add("hidden"); // a finished room's roster is fixed
+    $("lobby-roster").classList.add("hidden"); // the final board stays in view instead
     $("join-as-player").classList.add("hidden"); // a finished room's roster is fixed; no new seats to join
     onMatchFinished(metadata);
     return;
@@ -254,6 +264,7 @@ export function onLobbyUpdated(metadata) {
   $("join-as-player").classList.toggle("hidden", !isSpectator || count >= max);
   // only the host manages bot seats, and only while a seat is still open
   $("add-bot").classList.toggle("hidden", !youHost || count >= max);
+  renderRoster(metadata, youHost);
   if (youHost) {
     const ready = metadata.status === "ReadyToStart";
     $("start-game").classList.remove("hidden");
@@ -317,6 +328,57 @@ export async function addBot() {
   setError("game-error", "");
   const res = await api(`/lobby/${session.game.roomId}/bots`, { method: "POST", body: {} });
   if (!res.ok) flashError("game-error", res.data?.error || res.data || "Could not add a bot");
+}
+
+// Host-only: free a bot's seat, so the host can drop a surplus bot or make room for a human. Like addBot, the
+// resulting LobbyUpdated re-renders the roster and recomputes whether Start is still available.
+async function removeBot(botId) {
+  setError("game-error", "");
+  const res = await api(`/lobby/${session.game.roomId}/bots/${botId}`, { method: "DELETE" });
+  if (!res.ok) flashError("game-error", res.data?.error || res.data || "Could not remove the bot");
+}
+
+// Draw the seated players for a pre-game room: who's here, which one is you, who hosts, and — for the host — a
+// Remove button on each bot. Rendered from metadata.players, the same source the (n/max) count comes from, so the
+// list and the count can never disagree.
+function renderRoster(metadata, youHost) {
+  const ul = $("lobby-roster");
+  ul.innerHTML = "";
+  // metadata.players is a map, so its order is arbitrary and can shuffle between pushes; sort for a stable list —
+  // the host leads, then everyone else by name (which orders bots by their ordinal)
+  const players = Object.values(metadata.players).sort((a, b) => {
+    if (a.id === metadata.hostId) return -1;
+    if (b.id === metadata.hostId) return 1;
+    return a.name.localeCompare(b.name);
+  });
+
+  for (const player of players) {
+    const li = document.createElement("li");
+    const isYou = Boolean(session.me) && player.id === session.me.id;
+    if (isYou) li.classList.add("you");
+
+    const tags = [];
+    if (player.id === metadata.hostId) tags.push("host");
+    if (isYou) tags.push("you");
+
+    const meta = document.createElement("span");
+    meta.className = "meta";
+    // textContent, not innerHTML: a player-chosen display name renders as literal text and can't inject markup
+    meta.textContent = tags.length > 0 ? `${player.name} (${tags.join(", ")})` : player.name;
+    li.appendChild(meta);
+
+    // only the host manages bot seats, and only before the match starts
+    if (youHost && isBotId(player.id)) {
+      const remove = document.createElement("button");
+      remove.textContent = "Remove";
+      remove.onclick = () => removeBot(player.id);
+      li.appendChild(remove);
+    }
+
+    ul.appendChild(li);
+  }
+
+  ul.classList.remove("hidden");
 }
 
 export function onGameEnded(result) {

--- a/game-service-server/src/main/resources/web/lobby.js
+++ b/game-service-server/src/main/resources/web/lobby.js
@@ -109,6 +109,7 @@ function prepareGameView({ roomId, gameType, isHost, isSpectator = false, isLive
   setError("game-error", "");
   $("start-game").classList.add("hidden");
   $("start-game").disabled = true;
+  $("add-bot").classList.add("hidden"); // shown only for the host of a not-yet-full pre-game lobby (onLobbyUpdated)
   $("post-game-bar").classList.add("hidden");
   $("rematch-btn").classList.add("hidden");
   resetCopyLinkButton();
@@ -229,12 +230,14 @@ export function onLobbyUpdated(metadata) {
 
   if (metadata.status === "InProgress") {
     $("start-game").classList.add("hidden"); // the game is live; Start no longer applies
+    $("add-bot").classList.add("hidden"); // seats are locked once the match starts
     $("join-as-player").classList.add("hidden"); // too late to join — the match already started
     $("post-game-bar").classList.add("hidden"); // a rematch just began; the next GameStateUpdated takes over
     $("rematch-btn").classList.add("hidden");
     return; // game state pushes take over from here
   }
   if (metadata.status === "Finished") {
+    $("add-bot").classList.add("hidden"); // a finished room's roster is fixed
     $("join-as-player").classList.add("hidden"); // a finished room's roster is fixed; no new seats to join
     onMatchFinished(metadata);
     return;
@@ -249,11 +252,17 @@ export function onLobbyUpdated(metadata) {
 
   const max = GAMES[session.game.gameType].maxPlayers;
   $("join-as-player").classList.toggle("hidden", !isSpectator || count >= max);
+  // only the host manages bot seats, and only while a seat is still open
+  $("add-bot").classList.toggle("hidden", !youHost || count >= max);
   if (youHost) {
     const ready = metadata.status === "ReadyToStart";
     $("start-game").classList.remove("hidden");
     $("start-game").disabled = !ready;
-    setStatus(ready ? "Opponent joined — press Start." : `You're hosting — waiting for an opponent… (${count}/${max})`);
+    setStatus(
+      ready
+        ? "Opponent seated — press Start, or add another."
+        : `You're hosting — add a bot or wait for a player… (${count}/${max})`
+    );
   } else if (isSpectator) {
     setStatus(`Hosted by ${hostName} — spectating (${count}/${max})`);
   } else {
@@ -300,6 +309,14 @@ export async function startGame() {
   const res = await api(`/lobby/${session.game.roomId}/start`, { method: "POST", body: {} });
   if (!res.ok) flashError("game-error", res.data?.error || res.data || "Could not start the game");
   // On success the game-state push arrives over the WebSocket and renders the board.
+}
+
+// Host-only: seat an AI player. The resulting LobbyUpdated (fanned to every subscriber) refreshes the roster and
+// flips the room to ReadyToStart, which enables Start — so this only needs to fire the request.
+export async function addBot() {
+  setError("game-error", "");
+  const res = await api(`/lobby/${session.game.roomId}/bots`, { method: "POST", body: {} });
+  if (!res.ok) flashError("game-error", res.data?.error || res.data || "Could not add a bot");
 }
 
 export function onGameEnded(result) {

--- a/game-service-server/src/main/resources/web/main.js
+++ b/game-service-server/src/main/resources/web/main.js
@@ -27,6 +27,7 @@ import {
   refreshMySessions,
   refreshLobbies,
   startGame,
+  addBot,
   joinAsPlayer,
   rematch,
   leaveGame
@@ -103,6 +104,7 @@ $("refresh-lobbies").addEventListener("click", () => {
 });
 $("lobby-filter").addEventListener("change", refreshLobbies);
 $("start-game").addEventListener("click", startGame);
+$("add-bot").addEventListener("click", addBot);
 $("join-as-player").addEventListener("click", joinAsPlayer);
 $("rematch-btn").addEventListener("click", rematch);
 $("back-to-lobby").addEventListener("click", enterLobby); // browse the lobby without leaving the current game

--- a/game-service-server/src/main/resources/web/style.css
+++ b/game-service-server/src/main/resources/web/style.css
@@ -110,10 +110,12 @@ button:disabled { opacity: 0.5; cursor: default; }
 }
 
 #lobby-list,
-#my-sessions { list-style: none; padding: 0; margin: 0.5rem 0 0; }
+#my-sessions,
+#lobby-roster { list-style: none; padding: 0; margin: 0.5rem 0 0; }
 
 #lobby-list li,
-#my-sessions li {
+#my-sessions li,
+#lobby-roster li {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -125,7 +127,11 @@ button:disabled { opacity: 0.5; cursor: default; }
 }
 
 #lobby-list .meta,
-#my-sessions .meta { color: var(--muted); font-size: 0.9rem; }
+#my-sessions .meta,
+#lobby-roster .meta { color: var(--muted); font-size: 0.9rem; }
+
+/* The seated player's own row stands out from the rest of the roster. */
+#lobby-roster li.you .meta { color: var(--text); }
 
 /* Groups a lobby row's action buttons (Join, Spectate) so they sit together at a consistent spot regardless of how
    many are present, rather than each being spread out individually by the row's space-between. */

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/LobbyRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/LobbyRoutes.scala
@@ -9,6 +9,7 @@ import org.apache.pekko.http.scaladsl.server.Directives._
 import org.apache.pekko.http.scaladsl.server.Route
 import org.apache.pekko.util.Timeout
 
+import com.andy327.actor.bot.BotDifficulty
 import com.andy327.actor.core.GameManager
 import com.andy327.actor.core.GameManager.{
   GameForfeited,
@@ -38,6 +39,7 @@ import com.andy327.server.http.routes.RouteDirectives._
   *
   * Route Summary:
   *   - POST /lobby/create/{gameType} - Create a new lobby for a specific game type
+  *   - GET /lobby/bot-difficulties - List the bot difficulty levels a host may choose
   *   - GET /lobby/list - List all available open lobbies
   *   - GET /lobby/{roomId} - Fetch metadata for a specific lobby
   *   - POST /lobby/{roomId}/join - Join an existing lobby
@@ -65,6 +67,17 @@ class LobbyRoutes(
 
   val routes: Route = pathPrefix("lobby") {
 
+    /** Lists the bot difficulty levels a host may choose from, weakest first, as their wire labels. The client
+      * populates its difficulty selector from this rather than hard-coding the levels, so a new level added on the
+      * server appears in the UI with no client change. No auth: it is static configuration.
+      *
+      * - 200: a JSON array of difficulty labels, e.g. `["standard"]`
+      */
+    path("bot-difficulties") {
+      get {
+        complete(BotDifficulty.all.map(_.label))
+      }
+    } ~
     /** Lists metadata for all joinable lobbies with optional filtering and pagination.
       *
       * - Query `gameType` (optional): filter by game type (e.g., `tictactoe`)
@@ -227,8 +240,9 @@ class LobbyRoutes(
           *
           * - Auth: Bearer token required
           * - Path: `roomId` — the UUID of the lobby to seat a bot in
+          * - Query `difficulty` (optional): how strong the bot plays, e.g. `standard`; defaults to the standard level
           * - 200: `LobbyJoined` with the seated bot and updated metadata
-          * - 400: invalid UUID format
+          * - 400: invalid UUID format, or unknown difficulty
           * - 401: missing or invalid token
           * - 403: requester is not the host
           * - 404: lobby not found
@@ -237,11 +251,20 @@ class LobbyRoutes(
           */
         path("bots") {
           post {
-            authenticator.authenticatePlayer { player =>
-              onSuccess(system.ask[GameResponse](replyTo => GameManager.AddBot(roomId, player.id, replyTo))) {
-                case joined: LobbyJoined       => complete(joined)
-                case LobbyErrorResponse(error) => complete(statusFor(error) -> ErrorResponse(error.message))
-                case other => complete(StatusCodes.InternalServerError -> ErrorResponse(s"Unexpected response: $other"))
+            parameter("difficulty".?) { difficultyParam =>
+              authenticator.authenticatePlayer { player =>
+                LobbyRoutes.parseDifficulty(difficultyParam) match {
+                  case Left(err)         => complete(StatusCodes.BadRequest -> ErrorResponse(err))
+                  case Right(difficulty) =>
+                    onSuccess(
+                      system.ask[GameResponse](replyTo => GameManager.AddBot(roomId, player.id, difficulty, replyTo))
+                    ) {
+                      case joined: LobbyJoined       => complete(joined)
+                      case LobbyErrorResponse(error) => complete(statusFor(error) -> ErrorResponse(error.message))
+                      case other                     =>
+                        complete(StatusCodes.InternalServerError -> ErrorResponse(s"Unexpected response: $other"))
+                    }
+                }
               }
             }
           }
@@ -358,5 +381,17 @@ object LobbyRoutes {
     name.map(_.trim).filter(_.nonEmpty) match {
       case Some(n) if n.length > MaxNameLength => Left(s"Lobby name must be at most $MaxNameLength characters")
       case cleaned                             => Right(cleaned)
+    }
+
+  /** Resolves an optional `difficulty` query value to the level a new bot should play at, defaulting when it is absent
+    * or blank. Returns an error message naming the accepted levels when the value is not one of them.
+    */
+  def parseDifficulty(value: Option[String]): Either[String, BotDifficulty] =
+    value.map(_.trim).filter(_.nonEmpty) match {
+      case None      => Right(BotDifficulty.Default)
+      case Some(raw) =>
+        BotDifficulty
+          .fromString(raw)
+          .toRight(s"Unknown difficulty: $raw (expected one of ${BotDifficulty.all.map(_.label).mkString(", ")})")
     }
 }

--- a/game-service-server/src/main/scala/com/andy327/server/http/routes/LobbyRoutes.scala
+++ b/game-service-server/src/main/scala/com/andy327/server/http/routes/LobbyRoutes.scala
@@ -42,6 +42,8 @@ import com.andy327.server.http.routes.RouteDirectives._
   *   - GET /lobby/{roomId} - Fetch metadata for a specific lobby
   *   - POST /lobby/{roomId}/join - Join an existing lobby
   *   - POST /lobby/{roomId}/leave - Leave a lobby (or forfeit an in-progress game)
+  *   - POST /lobby/{roomId}/bots - Seat a bot in a pre-game lobby (host only)
+  *   - DELETE /lobby/{roomId}/bots/{botId} - Remove a bot seat (host only)
   *   - POST /lobby/{roomId}/start - Start a game from a lobby (host only)
   *   - DELETE /lobby/{roomId} - Cancel a pre-game lobby (host only)
   *   - POST /lobby/{roomId}/subscribe - Start spectating a lobby (push events over the player's WebSocket)
@@ -57,6 +59,7 @@ class LobbyRoutes(
   private def statusFor(error: LobbyError): StatusCode = error match {
     case _: LobbyError.LobbyNotFound => StatusCodes.NotFound
     case _: LobbyError.NotHostError  => StatusCodes.Forbidden
+    case _: LobbyError.NoSuchBot     => StatusCodes.NotFound
     case _                           => StatusCodes.Conflict
   }
 
@@ -214,6 +217,52 @@ class LobbyRoutes(
                 case left @ LobbyLeft(_, _)    => complete(left)
                 case GameForfeited(_, state)   => complete(state)
                 case MoveRejected(msg)         => complete(StatusCodes.Conflict -> ErrorResponse(msg))
+                case LobbyErrorResponse(error) => complete(statusFor(error) -> ErrorResponse(error.message))
+                case other => complete(StatusCodes.InternalServerError -> ErrorResponse(s"Unexpected response: $other"))
+              }
+            }
+          }
+        } ~
+        /** Seats a bot in the lobby. Only the host may add bots; the bot counts toward the roster like any player.
+          *
+          * - Auth: Bearer token required
+          * - Path: `roomId` — the UUID of the lobby to seat a bot in
+          * - 200: `LobbyJoined` with the seated bot and updated metadata
+          * - 400: invalid UUID format
+          * - 401: missing or invalid token
+          * - 403: requester is not the host
+          * - 404: lobby not found
+          * - 409: lobby full, or the game has already started
+          * - 500: unexpected error
+          */
+        path("bots") {
+          post {
+            authenticator.authenticatePlayer { player =>
+              onSuccess(system.ask[GameResponse](replyTo => GameManager.AddBot(roomId, player.id, replyTo))) {
+                case joined: LobbyJoined       => complete(joined)
+                case LobbyErrorResponse(error) => complete(statusFor(error) -> ErrorResponse(error.message))
+                case other => complete(StatusCodes.InternalServerError -> ErrorResponse(s"Unexpected response: $other"))
+              }
+            }
+          }
+        } ~
+        /** Removes a bot seat from the lobby. Only the host may remove bots.
+          *
+          * - Auth: Bearer token required
+          * - Path: `roomId` — the UUID of the lobby; `botId` — the bot's UUID (from the lobby metadata)
+          * - 200: `LobbyLeft` confirming the removal
+          * - 400: invalid UUID format
+          * - 401: missing or invalid token
+          * - 403: requester is not the host
+          * - 404: lobby not found, or `botId` is not a bot seated in it
+          * - 409: the game has already started
+          * - 500: unexpected error
+          */
+        path("bots" / JavaUUID) { botId =>
+          delete {
+            authenticator.authenticatePlayer { player =>
+              onSuccess(system.ask[GameResponse](replyTo => GameManager.RemoveBot(roomId, player.id, botId, replyTo))) {
+                case left @ LobbyLeft(_, _)    => complete(left)
                 case LobbyErrorResponse(error) => complete(statusFor(error) -> ErrorResponse(error.message))
                 case other => complete(StatusCodes.InternalServerError -> ErrorResponse(s"Unexpected response: $other"))
               }

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/LobbyRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/LobbyRoutesSpec.scala
@@ -21,6 +21,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.wordspec.AnyWordSpec
 
+import com.andy327.actor.bot.BotDifficulty
 import com.andy327.actor.core.{GameManager, InMemRepo, PlayerActor}
 import com.andy327.actor.lobby.{GameLifecycleStatus, LobbyMetadata, LobbyRepository, Player}
 import com.andy327.actor.persistence.PersistenceProtocol
@@ -151,6 +152,35 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
 
       Post(s"/lobby/$roomId/start").withHeaders(aliceHeader) ~> routes ~> check {
         status shouldBe StatusCodes.OK
+      }
+    }
+
+    "list the bot difficulty levels for the selector" in
+      Get("/lobby/bot-difficulties") ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+        responseAs[String] should include("standard") // the client populates its selector from this list
+      }
+
+    "seat a bot at an explicitly requested difficulty" in {
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
+      }
+
+      Post(s"/lobby/$roomId/bots?difficulty=standard").withHeaders(aliceHeader) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+        val bot = responseAs[GameManager.LobbyJoined].joinedPlayer
+        responseAs[GameManager.LobbyJoined].metadata.bots.get(bot.id) shouldBe Some(BotDifficulty.Standard)
+      }
+    }
+
+    "reject an unknown bot difficulty" in {
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
+      }
+
+      Post(s"/lobby/$roomId/bots?difficulty=godlike").withHeaders(aliceHeader) ~> routes ~> check {
+        status shouldBe StatusCodes.BadRequest
+        responseAs[String] should include("Unknown difficulty")
       }
     }
 

--- a/game-service-server/src/test/scala/com/andy327/server/http/routes/LobbyRoutesSpec.scala
+++ b/game-service-server/src/test/scala/com/andy327/server/http/routes/LobbyRoutesSpec.scala
@@ -136,6 +136,55 @@ class LobbyRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest 
       }
     }
 
+    "seat a bot for the host and start against it" in {
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
+      }
+
+      Post(s"/lobby/$roomId/bots").withHeaders(aliceHeader) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+        val GameManager.LobbyJoined(_, metadata, bot) = responseAs[GameManager.LobbyJoined]
+        bot.name shouldBe "Bot 1"
+        metadata.players should have size 2
+        metadata.status shouldBe GameLifecycleStatus.ReadyToStart
+      }
+
+      Post(s"/lobby/$roomId/start").withHeaders(aliceHeader) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+      }
+    }
+
+    "remove a bot seat for the host" in {
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
+      }
+      val botId = Post(s"/lobby/$roomId/bots").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyJoined].joinedPlayer.id
+      }
+
+      Delete(s"/lobby/$roomId/bots/$botId").withHeaders(aliceHeader) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+        responseAs[GameManager.LobbyLeft].message should include("Bot 1")
+      }
+    }
+
+    "reject bot changes from a non-host and a removal aimed at a human" in {
+      val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
+        responseAs[GameManager.LobbyCreated].roomId
+      }
+      Post(s"/lobby/$roomId/join").withHeaders(bobHeader) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+      }
+
+      Post(s"/lobby/$roomId/bots").withHeaders(bobHeader) ~> routes ~> check {
+        status shouldBe StatusCodes.Forbidden
+      }
+
+      Delete(s"/lobby/$roomId/bots/$bobId").withHeaders(aliceHeader) ~> routes ~> check {
+        status shouldBe StatusCodes.NotFound // bob is a human seat, not a bot
+      }
+    }
+
     "leave a lobby" in {
       val roomId = Post("/lobby/create/tictactoe").withHeaders(aliceHeader) ~> routes ~> check {
         responseAs[GameManager.LobbyCreated].roomId


### PR DESCRIPTION
### Summary

Closes #14. Adds AI opponents so a player can start any game type solo. A host seats bots in a pre-game lobby; when the match starts they play their turns on their own, submitting moves through the same path a human does. Bots are impossible to cheat by construction — a bot decides only from the per-viewer `GameView` it is pushed, so it never sees another seat's hidden state — which is what the earlier typed-view refactor (#77) was groundwork for.

### Bot identity and seating

- **`BotId`** — bots hold ids minted from a reserved namespace, so bot-ness is decidable from the id alone wherever it travels (lobby metadata, game rosters, snapshots) with no flag to thread through. A reserved id can never collide with a registered account's random UUID.
- **Host-managed seats** — `POST /lobby/{roomId}/bots` seats a bot; `DELETE /lobby/{roomId}/bots/{botId}` frees one; both host-only, pre-game only. A bot counts toward the roster and is dealt in like any player. Host powers never migrate to a bot, and a room left with only bots is retired rather than kept alive.
- **History** — a human's win over a bot records to `player_games`; the bot's own result never does.

### Playing the game

- **`AiPolicy`** — a pure `(view, rng) => Option[MovePayload]`, one per game, with a seeded RNG so play is reproducible. A `RandomPolicy` baseline covers all eight games; `None` means "not my turn", since a view lists only its own viewer's legal moves.
- **`BotActor`** — a headless session that implements the player-session protocol, subscribes to the game actor, and on each pushed view thinks for a short beat and submits its move. Turn-based play means one push per turn, so at most one move is ever in flight.
- **Spawning** — bots are created when a game with bot seats starts and re-created when such a game is restored after a restart, so a bot game survives a restart with no external input.

### Difficulty

- A universal `BotDifficulty` ladder (one rung, `Standard`, today) chosen per seat, stored on the lobby, carried into the spawned game, and recovered on restore. Passed explicitly rather than encoded in the id, so it can change without changing identity and stays game-agnostic. `GET /lobby/bot-difficulties` lets the client populate its selector from the server, so a new rung needs no client change.

### Web client

- Host controls in the pre-game room: an **Add bot** button, a difficulty selector, and a roster listing every seat with a per-bot **Remove** button.

### Config

- `pekko-game-service.bot.think-delay` tunes the pause before a bot moves (default 700ms); zero removes it, which also makes bot-vs-bot games a driver for load testing (#15).

### Testing

- Policy legality proven end to end (each decided move accepted by the model, across seeds); `BotActor` driven through its full turn cycle plus a real two-bot game played to completion; GameManager wiring verified on both start and restore; lobby seating, removal, host migration, difficulty persistence, and the `LobbyMetadata` codec's backward compatibility (an absent `bots` field must still decode) all covered. Full `sbt ci` green across all modules at 99.31% statement coverage; scalafmt, scalafix, and scaladoc clean. The add-bot, remove, difficulty-selector, and bot-plays-a-turn flows were also verified live in the bundled web client.